### PR TITLE
Silksnake integration: extract StateBuffer interface from db::Buffer

### DIFF
--- a/silkworm/chain/config.hpp
+++ b/silkworm/chain/config.hpp
@@ -130,6 +130,18 @@ constexpr ChainConfig kRopstenConfig{
     7'117'117,  // muir_glacier_block
 };
 
+constexpr ChainConfig kGoerliConfig{
+    5,  // chain_id
+
+    0,          // homestead_block
+    0,          // tangerine_whistle_block
+    0,          // spurious_dragon_block
+    0,          // byzantium_block
+    0,          // constantinople_block
+    0,          // petersburg_block
+    1'561'651,  // istanbul_block
+};
+
 // https://ecips.ethereumclassic.org/ECIPs/ecip-1066
 constexpr ChainConfig kClassicMainnetConfig{
     61,  // chain_id
@@ -149,6 +161,8 @@ inline const ChainConfig* lookup_chain_config(uint64_t chain_id) noexcept {
             return &kMainnetConfig;
         case kRopstenConfig.chain_id:
             return &kRopstenConfig;
+        case kGoerliConfig.chain_id:
+            return &kGoerliConfig;
         case kClassicMainnetConfig.chain_id:
             return &kClassicMainnetConfig;
         default:

--- a/silkworm/db/buffer.cpp
+++ b/silkworm/db/buffer.cpp
@@ -228,7 +228,7 @@ void Buffer::insert_receipts(uint64_t block_number, const std::vector<Receipt>& 
     }
 }
 
-void Buffer::insert_header(BlockHeader block_header) {
+void Buffer::insert_header(BlockHeader& block_header) {
     Bytes rlp{};
     rlp::encode(rlp, block_header);
     ethash::hash256 hash{keccak256(rlp)};

--- a/silkworm/db/buffer.cpp
+++ b/silkworm/db/buffer.cpp
@@ -228,12 +228,12 @@ void Buffer::insert_receipts(uint64_t block_number, const std::vector<Receipt>& 
     }
 }
 
-void Buffer::insert_header(BlockHeader& block_header) {
+void Buffer::insert_header(const BlockHeader& block_header) {
     Bytes rlp{};
     rlp::encode(rlp, block_header);
     ethash::hash256 hash{keccak256(rlp)};
     Bytes key{block_key(block_header.number, hash.bytes)};
-    headers_[key] = std::move(block_header);
+    headers_[key] = block_header;
 }
 
 std::optional<BlockHeader> Buffer::read_header(uint64_t block_number, const evmc::bytes32& block_hash) const noexcept {

--- a/silkworm/db/buffer.hpp
+++ b/silkworm/db/buffer.hpp
@@ -56,7 +56,7 @@ class Buffer : public StateBuffer {
     std::optional<BlockHeader> read_header(uint64_t block_number, const evmc::bytes32& block_hash) const noexcept override;
     ///@}
 
-    void insert_header(BlockHeader& block_header) override;
+    void insert_header(const BlockHeader& block_header) override;
 
     void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) override;
 

--- a/silkworm/db/buffer.hpp
+++ b/silkworm/db/buffer.hpp
@@ -25,6 +25,7 @@
 #include <optional>
 #include <silkworm/db/chaindb.hpp>
 #include <silkworm/db/change.hpp>
+#include <silkworm/db/state_buffer.hpp>
 #include <silkworm/types/account.hpp>
 #include <silkworm/types/block.hpp>
 #include <silkworm/types/receipt.hpp>
@@ -32,7 +33,7 @@
 
 namespace silkworm::db {
 
-class Buffer {
+class Buffer : public StateBuffer {
    public:
     Buffer(const Buffer&) = delete;
     Buffer& operator=(const Buffer&) = delete;
@@ -42,22 +43,22 @@ class Buffer {
 
     /** @name Readers */
     ///@{
-    std::optional<Account> read_account(const evmc::address& address) const noexcept;
+    std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 
-    Bytes read_code(const evmc::bytes32& code_hash) const noexcept;
+    Bytes read_code(const evmc::bytes32& code_hash) const noexcept override;
 
     evmc::bytes32 read_storage(const evmc::address& address, uint64_t incarnation,
-                               const evmc::bytes32& key) const noexcept;
+                               const evmc::bytes32& key) const noexcept override;
 
     /** Previous non-zero incarnation of an account; 0 if none exists. */
-    uint64_t previous_incarnation(const evmc::address& address) const noexcept;
+    uint64_t previous_incarnation(const evmc::address& address) const noexcept override;
 
-    std::optional<BlockHeader> read_header(uint64_t block_number, const evmc::bytes32& block_hash) const noexcept;
+    std::optional<BlockHeader> read_header(uint64_t block_number, const evmc::bytes32& block_hash) const noexcept override;
     ///@}
 
-    void insert_header(BlockHeader block_header);
+    void insert_header(BlockHeader& block_header) override;
 
-    void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts);
+    void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) override;
 
     /** @name State changes
      *  Change sets are backward changes of the state, i.e. account/storage values <em>at the beginning of a block</em>.
@@ -66,20 +67,20 @@ class Buffer {
     /** Mark the beggining of a new block.
      * Must be called prior to calling update_account/update_account_code/update_storage.
      */
-    void begin_block(uint64_t block_number);
+    void begin_block(uint64_t block_number) override;
 
-    void update_account(const evmc::address& address, std::optional<Account> initial, std::optional<Account> current);
+    void update_account(const evmc::address& address, std::optional<Account> initial, std::optional<Account> current) override;
 
     void update_account_code(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& code_hash,
-                             ByteView code);
+                             ByteView code) override;
 
     void update_storage(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& key,
-                        const evmc::bytes32& initial, const evmc::bytes32& current);
+                        const evmc::bytes32& initial, const evmc::bytes32& current) override;
 
     /** Mark the end of a block.
      * Must be called after all invocations of update_account/update_account_code/update_storage.
      */
-    void end_block();
+    void end_block() override;
 
     /** Account (backward) changes for the current block.*/
     const AccountChanges& account_changes() const { return current_account_changes_; }

--- a/silkworm/db/state_buffer.hpp
+++ b/silkworm/db/state_buffer.hpp
@@ -42,7 +42,7 @@ class StateBuffer {
     virtual std::optional<BlockHeader> read_header(uint64_t block_number, const evmc::bytes32& block_hash) const noexcept = 0;
     ///@}
 
-    virtual void insert_header(BlockHeader& block_header) = 0;
+    virtual void insert_header(const BlockHeader& block_header) = 0;
 
     virtual void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) = 0;
 

--- a/silkworm/db/state_buffer.hpp
+++ b/silkworm/db/state_buffer.hpp
@@ -1,0 +1,72 @@
+/*
+   Copyright 2020 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKWORM_DB_STATE_BUFFER_H_
+#define SILKWORM_DB_STATE_BUFFER_H_
+
+#include <evmc/evmc.hpp>
+#include <optional>
+#include <silkworm/types/account.hpp>
+
+namespace silkworm::db {
+
+class StateBuffer {
+   public:
+    virtual ~StateBuffer() = default;
+
+    /** @name Readers */
+    ///@{
+    virtual std::optional<Account> read_account(const evmc::address& address) const noexcept = 0;
+
+    virtual Bytes read_code(const evmc::bytes32& code_hash) const noexcept = 0;
+
+    virtual evmc::bytes32 read_storage(const evmc::address& address, uint64_t incarnation,
+                               const evmc::bytes32& key) const noexcept = 0;
+
+    /** Previous non-zero incarnation of an account; 0 if none exists. */
+    virtual uint64_t previous_incarnation(const evmc::address& address) const noexcept = 0;
+
+    virtual std::optional<BlockHeader> read_header(uint64_t block_number, const evmc::bytes32& block_hash) const noexcept = 0;
+    ///@}
+
+    virtual void insert_header(BlockHeader& block_header) = 0;
+
+    virtual void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) = 0;
+
+    /** @name State changes
+     *  Change sets are backward changes of the state, i.e. account/storage values <em>at the beginning of a block</em>.
+     */
+    ///@{
+    /** Mark the beggining of a new block.
+     * Must be called prior to calling update_account/update_account_code/update_storage.
+     */
+    virtual void begin_block(uint64_t block_number) = 0;
+
+    virtual void update_account(const evmc::address& address, std::optional<Account> initial, std::optional<Account> current) = 0;
+
+    virtual void update_account_code(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& code_hash,
+                             ByteView code) = 0;
+
+    virtual void update_storage(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& key,
+                        const evmc::bytes32& initial, const evmc::bytes32& current) = 0;
+
+    virtual void end_block() = 0;
+    ///@}
+};
+
+}  // namespace silkworm::db
+
+#endif  // SILKWORM_DB_STATE_BUFFER_H_

--- a/silkworm/execution/evm_test.cpp
+++ b/silkworm/execution/evm_test.cpp
@@ -17,6 +17,7 @@
 #include "evm.hpp"
 
 #include <catch2/catch.hpp>
+#include <silkworm/db/buffer.hpp>
 
 #include "address.hpp"
 #include "protocol_param.hpp"

--- a/silkworm/state/intra_block_state.hpp
+++ b/silkworm/state/intra_block_state.hpp
@@ -53,7 +53,7 @@ class IntraBlockState {
 
     explicit IntraBlockState(db::StateBuffer& db) noexcept : db_{db} {}
 
-    db::StateBuffer& db() const { return db_; }
+    db::StateBuffer& db() { return db_; }
 
     bool exists(const evmc::address& address) const noexcept;
 

--- a/silkworm/state/intra_block_state.hpp
+++ b/silkworm/state/intra_block_state.hpp
@@ -23,7 +23,7 @@
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 #include <memory>
-#include <silkworm/db/buffer.hpp>
+#include <silkworm/db/state_buffer.hpp>
 #include <silkworm/state/delta.hpp>
 #include <silkworm/state/object.hpp>
 #include <silkworm/types/log.hpp>
@@ -51,9 +51,9 @@ class IntraBlockState {
     IntraBlockState(const IntraBlockState&) = delete;
     IntraBlockState& operator=(const IntraBlockState&) = delete;
 
-    explicit IntraBlockState(db::Buffer& db) noexcept : db_{db} {}
+    explicit IntraBlockState(db::StateBuffer& db) noexcept : db_{db} {}
 
-    db::Buffer& db() { return db_; }
+    db::StateBuffer& db() const { return db_; }
 
     bool exists(const evmc::address& address) const noexcept;
 
@@ -121,7 +121,7 @@ class IntraBlockState {
 
     void touch(const evmc::address& address) noexcept;
 
-    db::Buffer& db_;
+    db::StateBuffer& db_;
 
     mutable absl::flat_hash_map<evmc::address, state::Object> objects_;
     mutable absl::flat_hash_map<evmc::address, state::Storage> storage_;


### PR DESCRIPTION
This PR introduces the changes needed to call `ExecutionProcessor::execute_transaction` from [Silksnake](https://github.com/torquem-ch/silksnake).

Basically this means being able to replace `db::Buffer` in `IntraBlockState` constructor with a pure virtual base class, which then Silksnake implements in a `RemoteBuffer` class accessing the data through KV gRPC.

Moreover there's a couple of minor changes:
- add pass-by-ref in `db::Buffer::insert_header` method
- add Goerli chain configuration