### PR TITLE
Logging, simplified

### DIFF
--- a/cmd/blockhashes.cpp
+++ b/cmd/blockhashes.cpp
@@ -36,7 +36,6 @@ int main(int argc, char* argv[]) {
         ->check(CLI::ExistingDirectory);
     CLI11_PARSE(app, argc, argv);
 
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
 
     // Check data.mdb exists in provided directory
     boost::filesystem::path db_file{boost::filesystem::path(db_path) / boost::filesystem::path("data.mdb")};

--- a/cmd/check_blockhashes.cpp
+++ b/cmd/check_blockhashes.cpp
@@ -35,7 +35,6 @@ int main(int argc, char* argv[]) {
         ->check(CLI::ExistingDirectory);
     CLI11_PARSE(app, argc, argv);
 
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
 
     // Check data.mdb exists in provided directory
     boost::filesystem::path db_file{boost::filesystem::path(db_path) / boost::filesystem::path("data.mdb")};

--- a/cmd/check_senders.cpp
+++ b/cmd/check_senders.cpp
@@ -774,9 +774,8 @@ int main(int argc, char* argv[]) {
     auto& app_verify = *app.add_subcommand("verify", "Verifies senders' addresses for given block");
 
     CLI11_PARSE(app, argc, argv);
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
     if (options.debug) {
-        Logger::default_logger().verbosity = LogLevels::LogTrace;
+        SILKWORM_LOG_VERBOSITY(LogLevels::LogTrace);
     }
 
     auto lmdb_mapSize{parse_size(mapSizeStr)};

--- a/cmd/check_tx_lookup.cpp
+++ b/cmd/check_tx_lookup.cpp
@@ -58,7 +58,6 @@ int main(int argc, char* argv[]) {
         ->check(CLI::Range(1u, UINT32_MAX));
     CLI11_PARSE(app, argc, argv);
 
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
 
     // Check data.mdb exists in provided directory
     boost::filesystem::path db_file{boost::filesystem::path(db_path) / boost::filesystem::path("data.mdb")};

--- a/cmd/execute.cpp
+++ b/cmd/execute.cpp
@@ -46,7 +46,6 @@ int main(int argc, char* argv[]) {
 
     CLI11_PARSE(app, argc, argv);
 
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
 
     // Check data.mdb exists in provided directory
     boost::filesystem::path db_file{boost::filesystem::path(db_path) / boost::filesystem::path("data.mdb")};

--- a/cmd/tx_lookup.cpp
+++ b/cmd/tx_lookup.cpp
@@ -47,7 +47,6 @@ int main(int argc, char* argv[]) {
     app.add_flag("--full", full, "Start making lookups from block 0");
     CLI11_PARSE(app, argc, argv);
 
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
 
     // Check data.mdb exists in provided directory
     boost::filesystem::path db_file{boost::filesystem::path(db_path) / boost::filesystem::path("data.mdb")};

--- a/db/silkworm/common/log.cpp
+++ b/db/silkworm/common/log.cpp
@@ -15,7 +15,6 @@
 */
 
 #include <silkworm/common/log.hpp>
-
 #include <absl/time/clock.h>
 
 namespace silkworm {
@@ -27,26 +26,16 @@ namespace {
         "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",		  };
 }
 
-std::ostream& log_(LogLevels level) {
-	return
-		streams
-			<< kLogTags[level]
-			<< "["
-			<< absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone())
-			<< "] ";
+void log_verbosity_(LogLevels level) {
+    verbosity = level;
 }
-
 LogLevels log_verbosity_() {
     return verbosity;
 }
 
-void log_verbosity_(LogLevels level) {
-    verbosity = level;
-}
-
 // Log to one or two output streams - typically the console and optional log file.
-void log_set_streams_(std::ostream & o1, std::ostream & o2) {
-    streams.set_streams((o1), (o2));
+void log_set_streams_(std::ostream& o1, std::ostream& o2) {
+    streams.set_streams(o1.rdbuf(), o2.rdbuf());
 }
 
 std::ostream& null_stream() {
@@ -58,5 +47,21 @@ std::ostream& null_stream() {
 	} null_strm;
 	return null_strm;
 }
+
+std::mutex log_::log_mtx_;
+
+std::ostream& log_header_(LogLevels level) {
+	return
+		streams
+			<< kLogTags[level]
+			<< "["
+			<< absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone())
+			<< "] ";
+}
+
+void log_expand_and_compile_test_() {
+    SILKWORM_LOG(LogNone) << "log_expand_and_compile_test_" << std::endl;
+}
+
 
 }  // namespace silkworm

--- a/db/silkworm/common/log.cpp
+++ b/db/silkworm/common/log.cpp
@@ -20,11 +20,12 @@
 
 namespace silkworm {
 
-// Log to one or two output streams - typically the console and optional log file.
-static teestream streams{std::cerr, null_stream()};
-static LogLevels verbosity{LogInfo};
-static constexpr char const kLogTags[7][6] = {
-	"TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",		  };
+namespace {
+    teestream streams{std::cerr, null_stream()};
+    LogLevels verbosity{LogInfo};
+    constexpr char const kLogTags[7][6] = {
+        "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",		  };
+}
 
 std::ostream& log_(LogLevels level) {
 	return
@@ -35,11 +36,18 @@ std::ostream& log_(LogLevels level) {
 			<< "] ";
 }
 
-LogLevels log_verbosity_() { return verbosity; }
+LogLevels log_verbosity_() {
+    return verbosity;
+}
 
-void log_verbosity_(LogLevels level) { verbosity = level; }
+void log_verbosity_(LogLevels level) {
+    verbosity = level;
+}
 
-void log_set_streams_(std::ostream & o1, std::ostream & o2) { streams.set_streams((o1), (o2)); }
+// Log to one or two output streams - typically the console and optional log file.
+void log_set_streams_(std::ostream & o1, std::ostream & o2) {
+    streams.set_streams((o1), (o2));
+}
 
 std::ostream& null_stream() {
 	static struct null_buf : public std::streambuf {

--- a/db/silkworm/common/log.cpp
+++ b/db/silkworm/common/log.cpp
@@ -16,9 +16,11 @@
 
 #include <silkworm/common/log.hpp>
 
+#include <absl/time/clock.h>
+
 namespace silkworm {
 
-std::ostream& Logger::null_stream() {
+std::ostream& Logger::null_stream_() {
     static struct NullBuffer : public std::streambuf {
         int overflow(int c) override { return c; }
     } null_buffer;
@@ -28,9 +30,18 @@ std::ostream& Logger::null_stream() {
     return null_stream;
 }
 
-Logger& Logger::default_logger() noexcept {
+Logger& Logger::default_logger_() noexcept {
     static Logger logger;
     return logger;
 }
+
+std::string Logger::formatTime(std::string) noexcept {
+    static absl::TimeZone local{absl::LocalTimeZone()};
+    static absl::TimeZone utc{absl::UTCTimeZone()};
+    return absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), (localTime_ ? local : utc));
+}
+
+
+
 
 }  // namespace silkworm

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -18,6 +18,7 @@
 #define SILKWORM_COMMON_LOG_H_
 
 #include <silkworm/common/tee.hpp>
+#include <mutex>
 
 namespace silkworm {
 

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -13,11 +13,27 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+/*
+
+Usage:
+
+// log to default logger - cerr
+SILKWORM_LOG(LogInfo) << "default logger" << endl;
+
+// create local logger and log to it
+silkworm::Logger logger(LogInfo, cerr, file_ostream);
+
+SILKWORM_LOG_TO(logger, LogCritical) << "local logger" << endl;
+
+Also, to reset the logging level of default or local logger:
+
+SILKWORM_LOG_VERBOSITY(level);
+SILKWORM_LOG_VERBOSITY_OF(logger, level);
+
+*/
 
 #ifndef SILKWORM_COMMON_LOG_H_
 #define SILKWORM_COMMON_LOG_H_
-
-#include <absl/time/clock.h>
 
 #include <silkworm/common/tee.hpp>
 
@@ -28,36 +44,43 @@ enum LogLevels { LogTrace, LogDebug, LogInfo, LogWarn, LogError, LogCritical, Lo
 // Log to one or two output streams - typically the console and optional log file.
 class Logger {
   public:
-    explicit Logger(std::ostream& o1 = std::cerr, std::ostream& o2 = Logger::null_stream()) : stream_(o1, o2) {}
+    explicit Logger(std::ostream& o1 = std::cerr, std::ostream& o2 = Logger::null_stream_()) : stream_(o1, o2) {}
 
-    LogLevels verbosity{LogInfo};
-
-    void set_local_timezone(bool local) noexcept { timezone_ = local ? absl::LocalTimeZone() : absl::UTCTimeZone(); }
-
-    std::ostream& log(LogLevels level) {
-        return stream_ << kLogTags[level] << "[" << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), timezone_)
+    // public only for access by macros :(
+    std::ostream& log_(LogLevels level) {
+        return stream_ << kLogTags[level]
+                       << "["
+                       << formatTime("%m-%d|%H:%M:%E3S")
                        << "] ";
     }
-
-    static Logger& default_logger() noexcept;
-    static std::ostream& null_stream();
+    LogLevels verbosity_{LogInfo};
+    bool localTime_{true};  // for compatibility with TG logging, false means UTC
+    static Logger& default_logger_() noexcept;
 
   private:
     teestream stream_;
-    absl::TimeZone timezone_{absl::UTCTimeZone()};
+    std::string formatTime(std::string format) noexcept;
+    static std::ostream& null_stream_();
     static constexpr char const kLogTags[7][6] = {
-        "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE",
+        "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",
     };
 };
 
-#define SILKWORM_LOG_TO(logger_, level_)  \
-    if ((level_) < (logger_).verbosity) { \
-    } else                                \
-        (logger_).log((level_))
-
 // Example usage:
 // SILKWORM_LOG(LogInfo) << "All your " << num_bases << " base are belong to us\n";
-#define SILKWORM_LOG(level_) SILKWORM_LOG_TO(Logger::default_logger(), (level_))
+//
+
+#define SILKWORM_LOG_TO(logger_, level_)  \
+    if ((level_) < (logger_).verbosity_) {} \
+    else (logger_).log_(level_)
+
+#define SILKWORM_LOG(level_) SILKWORM_LOG_TO(Logger::default_logger_(), (level_))
+
+#define SILKWORM_LOG_LOCALTIME_OF(logger_, yes_) ((logger_).localTime_ = (yes_))
+#define SILKWORM_LOG_LOCALTIME(yes_) SILKWORM_LOG_LOCALTIME_OF(Logger::default_logger_(), (yes_))
+
+#define SILKWORM_LOG_VERBOSITY_OF(logger_, level_) ((logger_).verbosity_ = (level_))
+#define SILKWORM_LOG_VERBOSITY(level_) SILKWORM_LOG_VERBOSITY_OF(Logger::default_logger_(), (level_))
 
 }  // namespace silkworm
 

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -43,10 +43,21 @@ std::ostream& null_stream();
 //
 // Below are for access via macros ONLY :(
 //
-std::ostream& log_(LogLevels level);
 LogLevels log_verbosity_();
 void log_verbosity_(LogLevels);
 void log_set_streams_(std::ostream & o1, std::ostream & o2);
+std::ostream& log_header_(LogLevels);
+class log_ {
+  public:
+   log_(LogLevels level_) : level_(level_) { log_mtx_.lock(); }
+    ~log_() { log_mtx_.unlock(); }
+    template <class T> std::ostream& operator<< (const T & message) {
+        return log_header_(level_) << message;
+    }
+  private:
+    LogLevels level_;
+    static std::mutex log_mtx_;
+};
 
 }  // namespace silkworm
 

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -5,31 +5,13 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	   http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-*/
-/*
-
-Usage:
-
-// log to default logger - cerr
-SILKWORM_LOG(LogInfo) << "default logger" << endl;
-
-// create local logger and log to it
-silkworm::Logger logger(LogInfo, cerr, file_ostream);
-
-SILKWORM_LOG_TO(logger, LogCritical) << "local logger" << endl;
-
-Also, to reset the logging level of default or local logger:
-
-SILKWORM_LOG_VERBOSITY(level);
-SILKWORM_LOG_VERBOSITY_OF(logger, level);
-
 */
 
 #ifndef SILKWORM_COMMON_LOG_H_
@@ -39,49 +21,33 @@ SILKWORM_LOG_VERBOSITY_OF(logger, level);
 
 namespace silkworm {
 
+// stream logging output - e.g.
+//	  SILKWORM_LOG(LogInfo) << "All your " << num_bases << " base are belong to us\n";
+//
+#define SILKWORM_LOG(level_) if ((level_) < log_verbosity_()) {} else log_(level_)
+
+// change the logging verbosity - default level is LogInfo
+//
+#define SILKWORM_LOG_VERBOSITY(level_) log_verbosity_(level_)
+
+// available verbosity levels
 enum LogLevels { LogTrace, LogDebug, LogInfo, LogWarn, LogError, LogCritical, LogNone };
 
-// Log to one or two output streams - typically the console and optional log file.
-class Logger {
-  public:
-    explicit Logger(std::ostream& o1 = std::cerr, std::ostream& o2 = Logger::null_stream_()) : stream_(o1, o2) {}
-
-    // public only for access by macros :(
-    std::ostream& log_(LogLevels level) {
-        return stream_ << kLogTags[level]
-                       << "["
-                       << formatTime("%m-%d|%H:%M:%E3S")
-                       << "] ";
-    }
-    LogLevels verbosity_{LogInfo};
-    bool localTime_{true};  // for compatibility with TG logging, false means UTC
-    static Logger& default_logger_() noexcept;
-
-  private:
-    teestream stream_;
-    std::string formatTime(std::string format) noexcept;
-    static std::ostream& null_stream_();
-    static constexpr char const kLogTags[7][6] = {
-        "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",
-    };
-};
-
-// Example usage:
-// SILKWORM_LOG(LogInfo) << "All your " << num_bases << " base are belong to us\n";
+// change the logging output streams - default is (cerr, null_stream())
 //
+#define SILKWORM_LOG_STREAMS(stream1_, stream2_) log_set_streams_((stream1_), (stream2_));
 
-#define SILKWORM_LOG_TO(logger_, level_)  \
-    if ((level_) < (logger_).verbosity_) {} \
-    else (logger_).log_(level_)
+// silence
+std::ostream& null_stream();
 
-#define SILKWORM_LOG(level_) SILKWORM_LOG_TO(Logger::default_logger_(), (level_))
-
-#define SILKWORM_LOG_LOCALTIME_OF(logger_, yes_) ((logger_).localTime_ = (yes_))
-#define SILKWORM_LOG_LOCALTIME(yes_) SILKWORM_LOG_LOCALTIME_OF(Logger::default_logger_(), (yes_))
-
-#define SILKWORM_LOG_VERBOSITY_OF(logger_, level_) ((logger_).verbosity_ = (level_))
-#define SILKWORM_LOG_VERBOSITY(level_) SILKWORM_LOG_VERBOSITY_OF(Logger::default_logger_(), (level_))
+//
+// Below are for access via macros ONLY :(
+//
+std::ostream& log_(LogLevels level);
+LogLevels log_verbosity_();
+void log_verbosity_(LogLevels);
+void log_set_streams_(std::ostream & o1, std::ostream & o2);
 
 }  // namespace silkworm
 
-#endif  // SILKWORM_COMMON_LOG_H_
+#endif	// SILKWORM_COMMON_LOG_H_

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -21,12 +21,12 @@
 
 namespace silkworm {
 
-// stream logging output - e.g.
+// stream labeled logging output - e.g.
 //	  SILKWORM_LOG(LogInfo) << "All your " << num_bases << " base are belong to us\n";
 //
 #define SILKWORM_LOG(level_) if ((level_) < log_verbosity_()) {} else log_(level_)
 
-// change the logging verbosity - default level is LogInfo
+// change the logging verbosity level - default level is LogInfo
 //
 #define SILKWORM_LOG_VERBOSITY(level_) log_verbosity_(level_)
 

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/db/silkworm/common/log_test.cpp
+++ b/db/silkworm/common/log_test.cpp
@@ -46,7 +46,7 @@ namespace {
 
 TEST_CASE("Logging") {
     // test true branch of macro
-    logger.verbosity = LogTrace;
+    SILKWORM_LOG_VERBOSITY_OF(logger, LogTrace);
     SILKWORM_LOG_TO(logger, LogCritical) << "LogCritical" << std::endl;
     CHECK(test_log("CRIT ", kInfix, "LogCritical"));
     SILKWORM_LOG_TO(logger, LogError) << "LogError" << std::endl;
@@ -61,7 +61,7 @@ TEST_CASE("Logging") {
     CHECK(test_log("TRACE", kInfix, "LogTrace"));
 
     // test false branch of macro
-    logger.verbosity = LogDebug;
+    SILKWORM_LOG_VERBOSITY_OF(logger, LogDebug);
     SILKWORM_LOG_TO(logger, LogTrace) << "LogTrace" << std::endl;
     CHECK(test_log("", "", ""));
 }

--- a/db/silkworm/common/log_test.cpp
+++ b/db/silkworm/common/log_test.cpp
@@ -5,7 +5,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	   http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,45 +25,46 @@
 namespace silkworm {
 
 namespace {
-    std::ostringstream stream1, stream2;
-    Logger logger(stream1, stream2);
-    const std::string kInfix(R"(\[\d\d-\d\d|\d\d:\d\d:\d\d\.\d{3}\] )");
+	std::ostringstream stream1, stream2;
+	const std::string kInfix(R"(\[\d\d-\d\d|\d\d:\d\d:\d\d\.\d{3}\] )");
 
-    bool test_log(std::string prefix, std::string infix, std::string suffix) {
-        std::string string1(stream1.str());
-        std::string string2(stream2.str());
-        stream1.clear();
-        stream1.str("");
-        stream2.clear();
-        stream2.str("");
-        if (string1 != string2) return false;
+	bool test_log(std::string prefix, std::string infix, std::string suffix) {
+		std::string string1(stream1.str());
+		std::string string2(stream2.str());
+		stream1.clear();
+		stream1.str("");
+		stream2.clear();
+		stream2.str("");
+		if (string1 != string2) return false;
 
-        const std::string pattern = prefix + infix + suffix;
-        const std::regex rx(pattern);
-        return std::regex_search(string1, rx);
-    }
+		const std::string pattern = prefix + infix + suffix;
+		const std::regex rx(pattern);
+		return std::regex_search(string1, rx);
+	}
 }  // namespace
 
 TEST_CASE("Logging") {
-    // test true branch of macro
-    SILKWORM_LOG_VERBOSITY_OF(logger, LogTrace);
-    SILKWORM_LOG_TO(logger, LogCritical) << "LogCritical" << std::endl;
-    CHECK(test_log("CRIT ", kInfix, "LogCritical"));
-    SILKWORM_LOG_TO(logger, LogError) << "LogError" << std::endl;
-    CHECK(test_log("ERROR", kInfix, "LogError"));
-    SILKWORM_LOG_TO(logger, LogWarn) << "LogWarn" << std::endl;
-    CHECK(test_log("WARN ", kInfix, "LogWarn"));
-    SILKWORM_LOG_TO(logger, LogInfo) << "LogInfo" << std::endl;
-    CHECK(test_log("INFO ", kInfix, "LogInfo"));
-    SILKWORM_LOG_TO(logger, LogDebug) << "LogDebug" << std::endl;
-    CHECK(test_log("DEBUG", kInfix, "LogDebug"));
-    SILKWORM_LOG_TO(logger, LogTrace) << "LogTrace" << std::endl;
-    CHECK(test_log("TRACE", kInfix, "LogTrace"));
+	SILKWORM_LOG_STREAMS(stream1, stream2);
 
-    // test false branch of macro
-    SILKWORM_LOG_VERBOSITY_OF(logger, LogDebug);
-    SILKWORM_LOG_TO(logger, LogTrace) << "LogTrace" << std::endl;
-    CHECK(test_log("", "", ""));
+	// test true branch of macro
+	SILKWORM_LOG_VERBOSITY(LogTrace);
+	SILKWORM_LOG(LogCritical) << "LogCritical" << std::endl;
+	CHECK(test_log("CRIT ", kInfix, "LogCritical"));
+	SILKWORM_LOG(LogError) << "LogError" << std::endl;
+	CHECK(test_log("ERROR", kInfix, "LogError"));
+	SILKWORM_LOG(LogWarn) << "LogWarn" << std::endl;
+	CHECK(test_log("WARN ", kInfix, "LogWarn"));
+	SILKWORM_LOG(LogInfo) << "LogInfo" << std::endl;
+	CHECK(test_log("INFO ", kInfix, "LogInfo"));
+	SILKWORM_LOG(LogDebug) << "LogDebug" << std::endl;
+	CHECK(test_log("DEBUG", kInfix, "LogDebug"));
+	SILKWORM_LOG(LogTrace) << "LogTrace" << std::endl;
+	CHECK(test_log("TRACE", kInfix, "LogTrace"));
+
+	// test false branch of macro
+	SILKWORM_LOG_VERBOSITY(LogDebug);
+	SILKWORM_LOG(LogTrace) << "LogTrace" << std::endl;
+	CHECK(test_log("", "", ""));
 }
 
 }  // namespace silkworm

--- a/db/silkworm/common/tee.hpp
+++ b/db/silkworm/common/tee.hpp
@@ -29,8 +29,16 @@ namespace silkworm {
 class teebuf: public std::streambuf {
 public:
     // Construct a streambuf which tees output to the supplied streambufs.
-    teebuf(std::streambuf* sb1, std::streambuf* sb2)
-      : sb1(sb1), sb2(sb2) {}
+    teebuf(std::streambuf* b1, std::streambuf* b2)
+      : sb1(b1), sb2(b2) {}
+
+    void set_streams(std::streambuf* b1, std::streambuf* b2) {
+        sb1 = b1;
+        sb2 = b2;
+    }
+
+    std::streambuf * sb1;
+    std::streambuf * sb2;
 
 private:
     // This tee buffer has no buffer. So every character "overflows"
@@ -51,8 +59,6 @@ private:
         int const r2 = sb2->pubsync();
         return ((r1 == 0 && r2 == 0) ? 0 : -1);
     }
-    std::streambuf * sb1;
-    std::streambuf * sb2;
 };
 
 class teestream : public std::ostream {
@@ -60,6 +66,11 @@ public:
     // Construct an ostream which tees output to the supplied ostreams.
    teestream(std::ostream & o1, std::ostream & o2)
       : std::ostream(&tbuf), tbuf(o1.rdbuf(), o2.rdbuf()) {}
+
+    void set_streams(std::ostream & o1, std::ostream & o2) {
+        tbuf.sb1 = o1.rdbuf();
+        tbuf.sb2 = o2.rdbuf();
+    }
 
 private:
     teebuf tbuf;

--- a/db/silkworm/common/tee.hpp
+++ b/db/silkworm/common/tee.hpp
@@ -37,9 +37,6 @@ public:
         sb2 = b2;
     }
 
-    std::streambuf * sb1;
-    std::streambuf * sb2;
-
 private:
     // This tee buffer has no buffer. So every character "overflows"
     // and can be put directly into the teed buffers.
@@ -59,6 +56,8 @@ private:
         int const r2 = sb2->pubsync();
         return ((r1 == 0 && r2 == 0) ? 0 : -1);
     }
+    std::streambuf * sb1;
+    std::streambuf * sb2;
 };
 
 class teestream : public std::ostream {
@@ -67,9 +66,8 @@ public:
    teestream(std::ostream & o1, std::ostream & o2)
       : std::ostream(&tbuf), tbuf(o1.rdbuf(), o2.rdbuf()) {}
 
-    void set_streams(std::ostream & o1, std::ostream & o2) {
-        tbuf.sb1 = o1.rdbuf();
-        tbuf.sb2 = o2.rdbuf();
+    void set_streams(std::streambuf* sb1, std::streambuf* sb2) {
+        tbuf.set_streams(sb1, sb2);
     }
 
 private:

--- a/db/silkworm/common/tee.hpp
+++ b/db/silkworm/common/tee.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/tg_api/silkworm_tg_api.cpp
+++ b/tg_api/silkworm_tg_api.cpp
@@ -31,7 +31,6 @@ SILKWORM_EXPORT SilkwormStatusCode silkworm_execute_blocks(MDB_txn* mdb_txn, uin
     assert(mdb_txn);
 
     using namespace silkworm;
-    Logger::default_logger().set_local_timezone(true);  // for compatibility with TG logging
 
     const ChainConfig* config{lookup_chain_config(chain_id)};
     if (!config) {


### PR DESCRIPTION
Simplified by removing unused - and likely unneeded - functionality.  So just one logger, and easier to reset streams logged to.

Also wrapped logging in a mutex so that the logs of multiple threads interleave cleanly.