### PR TITLE
make LOG macros work in subspaces

### DIFF
--- a/db/silkworm/common/log.cpp
+++ b/db/silkworm/common/log.cpp
@@ -19,36 +19,32 @@
 
 namespace silkworm {
 
-namespace detail {
+teestream log_streams_{std::cerr, null_stream()};
 
-    teestream log_streams_{std::cerr, null_stream()};
+LogLevels log_verbosity_{LogInfo};
 
-    LogLevels log_verbosity_{LogInfo};
+constexpr char const kLogTags_[7][6] = {
+    "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",		  };
 
-    constexpr char const kLogTags_[7][6] = {
-        "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",		  };
+// Log to one or two output streams - typically the console and optional log file.
+void log_set_streams_(std::ostream& o1, std::ostream& o2) {
+    log_streams_.set_streams(o1.rdbuf(), o2.rdbuf());
+}
 
-    // Log to one or two output streams - typically the console and optional log file.
-    void log_set_streams_(std::ostream& o1, std::ostream& o2) {
-        log_streams_.set_streams(o1.rdbuf(), o2.rdbuf());
-    }
+std::mutex log_::log_mtx_;
 
-    std::mutex log_::log_mtx_;
+std::ostream& log_::header_(LogLevels level) {
+    return
+        log_streams_
+            << kLogTags_[level]
+            << "["
+            << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone())
+            << "]";
+}
 
-    std::ostream& log_::header_(LogLevels level) {
-        return
-            log_streams_
-                << kLogTags_[level]
-                << "["
-                << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone())
-                << "] ";
-    }
-
-    void log_expand_and_compile_test_() {
-        SILKWORM_LOG(LogInfo) << "log_expand_and_compile_test_" << std::endl;
-    }
-
-}  // namespace detail
+void log_expand_and_compile_test_() {
+    SILKWORM_LOG(LogInfo) << "log_expand_and_compile_test_" << std::endl;
+}
 
 std::ostream& null_stream() {
 	static struct null_buf : public std::streambuf {

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -25,41 +25,43 @@ namespace silkworm {
 // stream labeled logging output - e.g.
 //	  SILKWORM_LOG(LogInfo) << "All your " << num_bases << " base are belong to us\n";
 //
-#define SILKWORM_LOG(level_) if ((level_) < detail::log_verbosity_) {} else detail::log_(level_)
+#define SILKWORM_LOG(level_) \
+    if ((level_) < silkworm::log_verbosity_) {} else log_(level_) << " "
 
 // change the logging verbosity level - default level is LogInfo
 //
-#define SILKWORM_LOG_VERBOSITY(level_) (detail::log_verbosity_ = (level_))
+#define SILKWORM_LOG_VERBOSITY(level_) \
+    (silkworm::log_verbosity_ = (level_))
 
 // available verbosity levels
 enum LogLevels { LogTrace, LogDebug, LogInfo, LogWarn, LogError, LogCritical, LogNone };
 
 // change the logging output streams - default is (cerr, null_stream())
 //
-#define SILKWORM_LOG_STREAMS(stream1_, stream2_) detail::log_set_streams_((stream1_), (stream2_));
+#define SILKWORM_LOG_STREAMS(stream1_, stream2_) \
+    silkworm::log_set_streams_((stream1_), (stream2_));
 
 // silence
 std::ostream& null_stream();
 
 //
-// Below are for access via macros ONLY :(
+// Below are for access via macros ONLY.
+// Placing them in detail namespace prevents use of macros in nested namespaces of silkworm :(
 //
-namespace detail {
-    extern LogLevels log_verbosity_;
-    void log_set_streams_(std::ostream & o1, std::ostream & o2);
-    class log_ {
-      public:
-       log_(LogLevels level_) : level_(level_) { log_mtx_.lock(); }
-        ~log_() { log_mtx_.unlock(); }
-        std::ostream& header_(LogLevels);
-        template <class T> std::ostream& operator<< (const T & message) {
-            return header_(level_) << message;
-        }
-      private:
-        LogLevels level_;
-        static std::mutex log_mtx_;
-    };
-}  // namespace namespace detail
+extern LogLevels log_verbosity_;
+void log_set_streams_(std::ostream & o1, std::ostream & o2);
+class log_ {
+  public:
+    log_(LogLevels level_) : level_(level_) { log_mtx_.lock(); }
+    ~log_() { log_mtx_.unlock(); }
+    std::ostream& header_(LogLevels);
+    template <class T> std::ostream& operator<< (const T & message) {
+        return header_(level_) << message;
+    }
+  private:
+    LogLevels level_;
+    static std::mutex log_mtx_;
+};
 
 }  // namespace silkworm
 


### PR DESCRIPTION
Placing log_ class in detail namespace badly confuses compiler when expanding macros in nested namespaces.  No amount of explicit qualification seems  to help.
