### PR TITLE
Reorder includes for clarity

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,19 @@ ColumnLimit: 120
 IndentWidth: 4
 AccessModifierOffset: -2
 NamespaceIndentation: Inner
+IncludeCategories:
+  # Silkworm headers
+  - Regex:           '<silkworm.*'
+    Priority:        4
+  
+  # C standard library
+  - Regex:           '<[[:alnum:]]+\.h>'
+    Priority:        1
+
+  # C++ standard library
+  - Regex:           '<[[:alnum:]_]+>'
+    Priority:        2
+
+  # Third-party libraries
+  - Regex:           '<.*'
+    Priority:        3

--- a/cmd/blockhashes.cpp
+++ b/cmd/blockhashes.cpp
@@ -14,10 +14,12 @@
    limitations under the License.
 */
 
+#include <iostream>
+
 #include <CLI/CLI.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
-#include <iostream>
+
 #include <silkworm/common/log.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>

--- a/cmd/check_blockhashes.cpp
+++ b/cmd/check_blockhashes.cpp
@@ -17,6 +17,7 @@
 #include <CLI/CLI.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
+
 #include <silkworm/common/log.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/db/tables.hpp>

--- a/cmd/check_changes.cpp
+++ b/cmd/check_changes.cpp
@@ -14,12 +14,13 @@
    limitations under the License.
 */
 
-#include <absl/container/flat_hash_set.h>
-#include <absl/time/time.h>
+#include <iostream>
 
 #include <CLI/CLI.hpp>
+#include <absl/container/flat_hash_set.h>
+#include <absl/time/time.h>
 #include <boost/filesystem.hpp>
-#include <iostream>
+
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/buffer.hpp>
 #include <silkworm/execution/execution.hpp>

--- a/cmd/check_senders.cpp
+++ b/cmd/check_senders.cpp
@@ -14,16 +14,20 @@
    limitations under the License.
 */
 
-#include <CLI/CLI.hpp>
 #include <atomic>
+#include <csignal>
+#include <queue>
+#include <string>
+#include <thread>
+
+#include <CLI/CLI.hpp>
 #include <boost/endian.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/signals2.hpp>
-#include <csignal>
 #include <ethash/keccak.hpp>
-#include <queue>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/worker.hpp>
@@ -33,8 +37,6 @@
 #include <silkworm/db/util.hpp>
 #include <silkworm/etl/collector.hpp>
 #include <silkworm/types/block.hpp>
-#include <string>
-#include <thread>
 
 namespace fs = boost::filesystem;
 using namespace silkworm;

--- a/cmd/check_tx_lookup.cpp
+++ b/cmd/check_tx_lookup.cpp
@@ -14,11 +14,13 @@
    limitations under the License.
 */
 
+#include <csignal>
+#include <iostream>
+
 #include <CLI/CLI.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
-#include <csignal>
-#include <iostream>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/util.hpp>

--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -14,15 +14,19 @@
    limitations under the License.
 */
 
-#include <evmc/loader.h>
-
-#include <CLI/CLI.hpp>
-#include <boost/filesystem.hpp>
 #include <exception>
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <CLI/CLI.hpp>
+#include <boost/filesystem.hpp>
+#include <evmc/loader.h>
 #include <nlohmann/json.hpp>
+
 #include <silkworm/chain/blockchain.hpp>
 #include <silkworm/chain/difficulty.hpp>
 #include <silkworm/chain/validity.hpp>
@@ -31,9 +35,6 @@
 #include <silkworm/state/intra_block_state.hpp>
 #include <silkworm/state/memory_buffer.hpp>
 #include <silkworm/types/block.hpp>
-#include <string>
-#include <string_view>
-#include <vector>
 
 // See https://ethereum-tests.readthedocs.io
 

--- a/cmd/dbtool.cpp
+++ b/cmd/dbtool.cpp
@@ -14,20 +14,22 @@
    limitations under the License.
 */
 
+#include <csignal>
+#include <iostream>
+#include <regex>
+#include <string>
+
 #include <CLI/CLI.hpp>
 #include <boost/bind.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <csignal>
-#include <iostream>
-#include <regex>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/db/chaindb.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/util.hpp>
 #include <silkworm/types/block.hpp>
-#include <string>
 
 namespace fs = boost::filesystem;
 using namespace silkworm;

--- a/cmd/execute.cpp
+++ b/cmd/execute.cpp
@@ -17,7 +17,7 @@
 #include <CLI/CLI.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
-#include <limits>
+
 #include <silkworm/common/log.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>

--- a/cmd/extract_headers.cpp
+++ b/cmd/extract_headers.cpp
@@ -13,18 +13,21 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
 #include <CLI/CLI.hpp>
 #include <boost/beast/core/detail/base64.hpp>
 #include <boost/endian/conversion.hpp>
-#include <chrono>
-#include <iostream>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/util.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/util.hpp>
 #include <silkworm/types/transaction.hpp>
-#include <string>
 
 using namespace silkworm;
 

--- a/cmd/history_index.cpp
+++ b/cmd/history_index.cpp
@@ -14,19 +14,21 @@
    limitations under the License.
 */
 
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
 #include <CLI/CLI.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
-#include <iomanip>
-#include <iostream>
+
 #include <silkworm/common/log.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/bitmap.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/etl/collector.hpp>
-#include <string>
-#include <unordered_map>
 
 using namespace silkworm;
 

--- a/cmd/scan_txs.cpp
+++ b/cmd/scan_txs.cpp
@@ -14,12 +14,11 @@
    limitations under the License.
 */
 
-#include <absl/container/flat_hash_set.h>
-#include <absl/time/time.h>
+#include <iostream>
 
 #include <CLI/CLI.hpp>
 #include <boost/filesystem.hpp>
-#include <iostream>
+
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/buffer.hpp>
 #include <silkworm/execution/execution.hpp>

--- a/cmd/tx_lookup.cpp
+++ b/cmd/tx_lookup.cpp
@@ -14,10 +14,12 @@
    limitations under the License.
 */
 
+#include <iostream>
+
 #include <CLI/CLI.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem.hpp>
-#include <iostream>
+
 #include <silkworm/common/log.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>

--- a/core/silkworm/chain/blockchain.cpp
+++ b/core/silkworm/chain/blockchain.cpp
@@ -17,6 +17,7 @@
 #include "blockchain.hpp"
 
 #include <cassert>
+
 #include <silkworm/execution/execution.hpp>
 
 namespace silkworm {

--- a/core/silkworm/chain/blockchain.hpp
+++ b/core/silkworm/chain/blockchain.hpp
@@ -17,10 +17,11 @@
 #ifndef SILKWORM_CHAIN_BLOCKCHAIN_HPP_
 #define SILKWORM_CHAIN_BLOCKCHAIN_HPP_
 
-#include <silkworm/chain/validity.hpp>
-#include <silkworm/state/buffer.hpp>
 #include <unordered_map>
 #include <vector>
+
+#include <silkworm/chain/validity.hpp>
+#include <silkworm/state/buffer.hpp>
 
 namespace silkworm {
 

--- a/core/silkworm/chain/difficulty.hpp
+++ b/core/silkworm/chain/difficulty.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_CHAIN_DIFFICULTY_H_
-#define SILKWORM_CHAIN_DIFFICULTY_H_
+#ifndef SILKWORM_CHAIN_DIFFICULTY_HPP_
+#define SILKWORM_CHAIN_DIFFICULTY_HPP_
 
 #include <intx/intx.hpp>
+
 #include <silkworm/chain/config.hpp>
 
 namespace silkworm {
@@ -49,4 +50,4 @@ intx::uint256 canonical_difficulty(uint64_t block_number, uint64_t block_timesta
 
 }  // namespace silkworm
 
-#endif  // SILKWORM_CHAIN_DIFFICULTY_H_
+#endif  // SILKWORM_CHAIN_DIFFICULTY_HPP_

--- a/core/silkworm/chain/intrinsic_gas.hpp
+++ b/core/silkworm/chain/intrinsic_gas.hpp
@@ -18,6 +18,7 @@
 #define SILKWORM_CHAIN_INTRINSIC_GAS_HPP_
 
 #include <intx/int128.hpp>
+
 #include <silkworm/types/transaction.hpp>
 
 namespace silkworm {

--- a/core/silkworm/common/util.hpp
+++ b/core/silkworm/common/util.hpp
@@ -17,14 +17,16 @@
 #ifndef SILKWORM_COMMON_UTIL_HPP_
 #define SILKWORM_COMMON_UTIL_HPP_
 
+#include <cstring>
+#include <optional>
+
+#include <ethash/keccak.hpp>
+
+#include <silkworm/common/base.hpp>
+
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
-
-#include <cstring>
-#include <ethash/keccak.hpp>
-#include <optional>
-#include <silkworm/common/base.hpp>
 
 namespace silkworm {
 

--- a/core/silkworm/crypto/ecdsa.hpp
+++ b/core/silkworm/crypto/ecdsa.hpp
@@ -19,8 +19,10 @@
 
 // See Yellow Paper, Appendix F "Signing Transactions"
 
-#include <intx/intx.hpp>
 #include <optional>
+
+#include <intx/intx.hpp>
+
 #include <silkworm/common/base.hpp>
 
 namespace silkworm::ecdsa {

--- a/core/silkworm/crypto/rmd160.hpp
+++ b/core/silkworm/crypto/rmd160.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #define SILKWORM_CRYPTO_RMD160_HPP_
 
 #include <gsl/span>
+
 #include <silkworm/common/base.hpp>
 
 namespace silkworm::crypto {

--- a/core/silkworm/crypto/snark.cpp
+++ b/core/silkworm/crypto/snark.cpp
@@ -19,8 +19,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libff/common/profiling.hpp>
+
 #include <silkworm/common/endian.hpp>
 
 namespace silkworm::snark {

--- a/core/silkworm/crypto/snark.hpp
+++ b/core/silkworm/crypto/snark.hpp
@@ -17,13 +17,14 @@
 #ifndef SILKWORM_CRYPTO_SNARK_HPP_
 #define SILKWORM_CRYPTO_SNARK_HPP_
 
+#include <optional>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
 #pragma GCC diagnostic pop
 
-#include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
-#include <optional>
 #include <silkworm/common/base.hpp>
 
 // Utility functions for zkSNARK related precompiled contracts.

--- a/core/silkworm/execution/address.cpp
+++ b/core/silkworm/execution/address.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "address.hpp"
 
 #include <ethash/keccak.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/rlp/encode.hpp>
 

--- a/core/silkworm/execution/analysis_cache.cpp
+++ b/core/silkworm/execution/analysis_cache.cpp
@@ -16,9 +16,10 @@
 
 #include "analysis_cache.hpp"
 
-#include <evmone/analysis.hpp>
 #include <memory>
 #include <utility>
+
+#include <evmone/analysis.hpp>
 
 namespace silkworm {
 

--- a/core/silkworm/execution/analysis_cache.hpp
+++ b/core/silkworm/execution/analysis_cache.hpp
@@ -17,8 +17,10 @@
 #ifndef SILKWORM_EXECUTION_ANALYSIS_CACHE_HPP_
 #define SILKWORM_EXECUTION_ANALYSIS_CACHE_HPP_
 
-#include <lrucache.hpp>
 #include <memory>
+
+#include <lrucache.hpp>
+
 #include <silkworm/common/base.hpp>
 
 namespace evmone {

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -19,10 +19,12 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <iterator>
+
 #include <ethash/keccak.hpp>
 #include <evmone/analysis.hpp>
 #include <evmone/baseline.hpp>
-#include <iterator>
+
 #include <silkworm/chain/protocol_param.hpp>
 
 #include "address.hpp"

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -17,14 +17,16 @@
 #ifndef SILKWORM_EXECUTION_EVM_HPP_
 #define SILKWORM_EXECUTION_EVM_HPP_
 
+#include <stack>
+#include <vector>
+
 #include <intx/intx.hpp>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/execution/analysis_cache.hpp>
 #include <silkworm/execution/state_pool.hpp>
 #include <silkworm/state/intra_block_state.hpp>
 #include <silkworm/types/block.hpp>
-#include <stack>
-#include <vector>
 
 namespace silkworm {
 

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -17,6 +17,7 @@
 #include "evm.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/state/memory_buffer.hpp>
 

--- a/core/silkworm/execution/execution.hpp
+++ b/core/silkworm/execution/execution.hpp
@@ -17,6 +17,8 @@
 #ifndef SILKWORM_EXECUTION_EXECUTION_HPP_
 #define SILKWORM_EXECUTION_EXECUTION_HPP_
 
+#include <stdexcept>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/chain/validity.hpp>
 #include <silkworm/execution/analysis_cache.hpp>
@@ -24,7 +26,6 @@
 #include <silkworm/state/buffer.hpp>
 #include <silkworm/types/block.hpp>
 #include <silkworm/types/receipt.hpp>
-#include <stdexcept>
 
 namespace silkworm {
 

--- a/core/silkworm/execution/execution_test.cpp
+++ b/core/silkworm/execution/execution_test.cpp
@@ -16,9 +16,11 @@
 
 #include "execution.hpp"
 
-#include <catch2/catch.hpp>
 #include <cstring>
+
+#include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/execution/address.hpp>

--- a/core/silkworm/execution/precompiled.cpp
+++ b/core/silkworm/execution/precompiled.cpp
@@ -17,25 +17,27 @@
 #include "precompiled.hpp"
 
 #include <gmp.h>
-#include <silkworm/crypto/blake2.h>
-#include <silkworm/crypto/sha-256.h>
 
 #include <algorithm>
 #include <cstring>
-#include <ethash/keccak.hpp>
 #include <iterator>
 #include <limits>
-#include <silkworm/chain/protocol_param.hpp>
-#include <silkworm/common/endian.hpp>
-#include <silkworm/common/util.hpp>
-#include <silkworm/crypto/ecdsa.hpp>
-#include <silkworm/crypto/rmd160.hpp>
-#include <silkworm/crypto/snark.hpp>
+
+#include <ethash/keccak.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp>
 #pragma GCC diagnostic pop
+
+#include <silkworm/chain/protocol_param.hpp>
+#include <silkworm/common/endian.hpp>
+#include <silkworm/common/util.hpp>
+#include <silkworm/crypto/blake2.h>
+#include <silkworm/crypto/ecdsa.hpp>
+#include <silkworm/crypto/rmd160.hpp>
+#include <silkworm/crypto/sha-256.h>
+#include <silkworm/crypto/snark.hpp>
 
 namespace silkworm::precompiled {
 

--- a/core/silkworm/execution/precompiled.hpp
+++ b/core/silkworm/execution/precompiled.hpp
@@ -14,12 +14,13 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_EXECUTION_PRECOMPILED_H_
-#define SILKWORM_EXECUTION_PRECOMPILED_H_
+#ifndef SILKWORM_EXECUTION_PRECOMPILED_HPP_
+#define SILKWORM_EXECUTION_PRECOMPILED_HPP_
+
+#include <optional>
 
 #include <evmc/evmc.h>
 
-#include <optional>
 #include <silkworm/common/base.hpp>
 
 // See Yellow Paper, Appendix E "Precompiled Contracts"
@@ -80,4 +81,4 @@ static_assert(std::size(kContracts) == kNumOfIstanbulContracts);
 
 }  // namespace silkworm::precompiled
 
-#endif  // SILKWORM_EXECUTION_PRECOMPILED_H_
+#endif  // SILKWORM_EXECUTION_PRECOMPILED_HPP_

--- a/core/silkworm/execution/precompiled_test.cpp
+++ b/core/silkworm/execution/precompiled_test.cpp
@@ -17,6 +17,7 @@
 #include "precompiled.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm::precompiled {

--- a/core/silkworm/execution/processor.hpp
+++ b/core/silkworm/execution/processor.hpp
@@ -19,13 +19,14 @@
 
 #include <stdint.h>
 
+#include <utility>
+#include <vector>
+
 #include <silkworm/chain/validity.hpp>
 #include <silkworm/execution/evm.hpp>
 #include <silkworm/types/block.hpp>
 #include <silkworm/types/receipt.hpp>
 #include <silkworm/types/transaction.hpp>
-#include <utility>
-#include <vector>
 
 namespace silkworm {
 

--- a/core/silkworm/execution/processor_test.cpp
+++ b/core/silkworm/execution/processor_test.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch.hpp>
 #include <evmc/evmc.hpp>
+
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/state/memory_buffer.hpp>
 

--- a/core/silkworm/execution/state_pool.cpp
+++ b/core/silkworm/execution/state_pool.cpp
@@ -16,12 +16,12 @@
 
 #include "state_pool.hpp"
 
+#include <utility>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <evmone/analysis.hpp>
 #pragma GCC diagnostic pop
-
-#include <utility>
 
 namespace silkworm {
 

--- a/core/silkworm/rlp/decode.cpp
+++ b/core/silkworm/rlp/decode.cpp
@@ -17,9 +17,10 @@
 #include "decode.hpp"
 
 #include <cassert>
+#include <tuple>
+
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/util.hpp>
-#include <tuple>
 
 namespace silkworm::rlp {
 

--- a/core/silkworm/rlp/decode.hpp
+++ b/core/silkworm/rlp/decode.hpp
@@ -22,12 +22,14 @@
 
 #include <array>
 #include <cstring>
-#include <gsl/span>
-#include <intx/intx.hpp>
-#include <silkworm/common/base.hpp>
-#include <silkworm/rlp/encode.hpp>
 #include <utility>
 #include <vector>
+
+#include <gsl/span>
+#include <intx/intx.hpp>
+
+#include <silkworm/common/base.hpp>
+#include <silkworm/rlp/encode.hpp>
 
 namespace silkworm::rlp {
 
@@ -99,7 +101,6 @@ DecodingResult decode(ByteView& from, std::array<uint8_t, N>& to) noexcept {
 
 template <class T>
 DecodingResult decode_vector(ByteView& from, std::vector<T>& to) noexcept {
-
     auto [h, err]{decode_header(from)};
     if (err != DecodingResult::kOk) {
         return err;

--- a/core/silkworm/rlp/decode_test.cpp
+++ b/core/silkworm/rlp/decode_test.cpp
@@ -17,6 +17,7 @@
 #include "decode.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm::rlp {

--- a/core/silkworm/rlp/encode.hpp
+++ b/core/silkworm/rlp/encode.hpp
@@ -21,11 +21,13 @@
 #define SILKWORM_RLP_ENCODE_HPP_
 
 #include <array>
+#include <optional>
+#include <vector>
+
 #include <gsl/span>
 #include <intx/intx.hpp>
-#include <optional>
+
 #include <silkworm/common/base.hpp>
-#include <vector>
 
 namespace silkworm {
 

--- a/core/silkworm/rlp/encode_test.cpp
+++ b/core/silkworm/rlp/encode_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "encode.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm {

--- a/core/silkworm/state/buffer.hpp
+++ b/core/silkworm/state/buffer.hpp
@@ -18,6 +18,7 @@
 #define SILKWORM_STATE_BUFFER_HPP_
 
 #include <optional>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/types/account.hpp>
 #include <silkworm/types/block.hpp>

--- a/core/silkworm/state/intra_block_state.cpp
+++ b/core/silkworm/state/intra_block_state.cpp
@@ -17,7 +17,9 @@
 #include "intra_block_state.hpp"
 
 #include <cstring>
+
 #include <ethash/keccak.hpp>
+
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/util.hpp>
 

--- a/core/silkworm/state/intra_block_state.hpp
+++ b/core/silkworm/state/intra_block_state.hpp
@@ -17,16 +17,17 @@
 #ifndef SILKWORM_STATE_INTRA_BLOCK_STATE_HPP_
 #define SILKWORM_STATE_INTRA_BLOCK_STATE_HPP_
 
-#include <robin_hood.h>
+#include <memory>
+#include <vector>
 
 #include <intx/intx.hpp>
-#include <memory>
+#include <robin_hood.h>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/state/buffer.hpp>
 #include <silkworm/state/delta.hpp>
 #include <silkworm/state/object.hpp>
 #include <silkworm/types/log.hpp>
-#include <vector>
 
 namespace silkworm {
 

--- a/core/silkworm/state/memory_buffer.cpp
+++ b/core/silkworm/state/memory_buffer.cpp
@@ -16,8 +16,10 @@
 
 #include "memory_buffer.hpp"
 
-#include <ethash/keccak.hpp>
 #include <map>
+
+#include <ethash/keccak.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/rlp/encode.hpp>
 #include <silkworm/trie/hash_builder.hpp>

--- a/core/silkworm/state/memory_buffer.hpp
+++ b/core/silkworm/state/memory_buffer.hpp
@@ -14,12 +14,13 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_STATE_MEMORY_BUFFER_H_
-#define SILKWORM_STATE_MEMORY_BUFFER_H_
+#ifndef SILKWORM_STATE_MEMORY_BUFFER_HPP_
+#define SILKWORM_STATE_MEMORY_BUFFER_HPP_
 
-#include <silkworm/state/buffer.hpp>
 #include <unordered_map>
 #include <vector>
+
+#include <silkworm/state/buffer.hpp>
 
 namespace silkworm {
 
@@ -115,4 +116,4 @@ class MemoryBuffer : public StateBuffer {
 
 }  // namespace silkworm
 
-#endif  // SILKWORM_STATE_MEMORY_BUFFER_H_
+#endif  // SILKWORM_STATE_MEMORY_BUFFER_HPP_

--- a/core/silkworm/state/object.hpp
+++ b/core/silkworm/state/object.hpp
@@ -17,9 +17,10 @@
 #ifndef SILKWORM_STATE_OBJECT_HPP_
 #define SILKWORM_STATE_OBJECT_HPP_
 
+#include <optional>
+
 #include <robin_hood.h>
 
-#include <optional>
 #include <silkworm/common/base.hpp>
 #include <silkworm/types/account.hpp>
 

--- a/core/silkworm/trie/hash_builder.cpp
+++ b/core/silkworm/trie/hash_builder.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+
 #include <ethash/keccak.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/rlp/encode.hpp>
 

--- a/core/silkworm/trie/hash_builder.hpp
+++ b/core/silkworm/trie/hash_builder.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_TRIE_HASH_BUILDER_H_
-#define SILKWORM_TRIE_HASH_BUILDER_H_
+#ifndef SILKWORM_TRIE_HASH_BUILDER_HPP_
+#define SILKWORM_TRIE_HASH_BUILDER_HPP_
+
+#include <vector>
 
 #include <silkworm/common/base.hpp>
-#include <vector>
 
 namespace silkworm::trie {
 
@@ -26,7 +27,7 @@ namespace silkworm::trie {
 // See Appendix D "Modified Merkle Patricia Trie" of the Yellow Paper
 // and https://eth.wiki/fundamentals/patricia-tree
 class HashBuilder {
-   public:
+  public:
     HashBuilder(const HashBuilder&) = delete;
     HashBuilder& operator=(const HashBuilder&) = delete;
 
@@ -42,7 +43,7 @@ class HashBuilder {
     // May only be called after all entries have been added.
     evmc::bytes32 root_hash();
 
-   private:
+  private:
     void gen_struct_step(ByteView curr, ByteView succ, ByteView value);
 
     void branch_ref(uint16_t mask);
@@ -53,6 +54,7 @@ class HashBuilder {
     std::vector<uint16_t> groups_;
     std::vector<Bytes> stack_;  // node references: hashes or embedded RLPs
 };
+
 }  // namespace silkworm::trie
 
-#endif  // SILKWORM_TRIE_HASH_BUILDER_H_
+#endif  // SILKWORM_TRIE_HASH_BUILDER_HPP_

--- a/core/silkworm/trie/hash_builder_test.cpp
+++ b/core/silkworm/trie/hash_builder_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 #include "hash_builder.hpp"
 
 #include <algorithm>
+#include <iterator>
+
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
-#include <iterator>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm::trie {

--- a/core/silkworm/trie/vector_root_test.cpp
+++ b/core/silkworm/trie/vector_root_test.cpp
@@ -17,6 +17,7 @@
 #include "vector_root.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/types/receipt.hpp>
 #include <silkworm/types/transaction.hpp>

--- a/core/silkworm/types/account.hpp
+++ b/core/silkworm/types/account.hpp
@@ -14,10 +14,11 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_TYPES_ACCOUNT_H_
-#define SILKWORM_TYPES_ACCOUNT_H_
+#ifndef SILKWORM_TYPES_ACCOUNT_HPP_
+#define SILKWORM_TYPES_ACCOUNT_HPP_
 
 #include <intx/intx.hpp>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/rlp/decode.hpp>
 
@@ -45,4 +46,4 @@ bool operator==(const Account& a, const Account& b);
 
 }  // namespace silkworm
 
-#endif  // SILKWORM_TYPES_ACCOUNT_H_
+#endif  // SILKWORM_TYPES_ACCOUNT_HPP_

--- a/core/silkworm/types/account_test.cpp
+++ b/core/silkworm/types/account_test.cpp
@@ -17,6 +17,7 @@
 #include "account.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm {

--- a/core/silkworm/types/block.cpp
+++ b/core/silkworm/types/block.cpp
@@ -17,6 +17,7 @@
 #include "block.hpp"
 
 #include <cstring>
+
 #include <silkworm/rlp/encode.hpp>
 
 namespace silkworm {

--- a/core/silkworm/types/block.hpp
+++ b/core/silkworm/types/block.hpp
@@ -20,13 +20,15 @@
 #include <stdint.h>
 
 #include <array>
+#include <vector>
+
 #include <intx/intx.hpp>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/util.hpp>
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/types/bloom.hpp>
 #include <silkworm/types/transaction.hpp>
-#include <vector>
 
 namespace silkworm {
 

--- a/core/silkworm/types/bloom.cpp
+++ b/core/silkworm/types/bloom.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "bloom.hpp"
 
 #include <ethash/keccak.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm {

--- a/core/silkworm/types/bloom.hpp
+++ b/core/silkworm/types/bloom.hpp
@@ -14,15 +14,16 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_TYPES_BLOOM_H_
-#define SILKWORM_TYPES_BLOOM_H_
+#ifndef SILKWORM_TYPES_BLOOM_HPP_
+#define SILKWORM_TYPES_BLOOM_HPP_
 
 #include <stddef.h>
 #include <stdint.h>
 
 #include <array>
-#include <silkworm/types/log.hpp>
 #include <vector>
+
+#include <silkworm/types/log.hpp>
 
 namespace silkworm {
 
@@ -42,4 +43,4 @@ inline void join(Bloom& sum, const Bloom& addend) {
 
 }  // namespace silkworm
 
-#endif  // SILKWORM_TYPES_BLOOM_H_
+#endif  // SILKWORM_TYPES_BLOOM_HPP_

--- a/core/silkworm/types/bloom_test.cpp
+++ b/core/silkworm/types/bloom_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "bloom.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm {

--- a/core/silkworm/types/log.hpp
+++ b/core/silkworm/types/log.hpp
@@ -17,8 +17,9 @@
 #ifndef SILKWORM_TYPES_LOG_HPP_
 #define SILKWORM_TYPES_LOG_HPP_
 
-#include <silkworm/common/base.hpp>
 #include <vector>
+
+#include <silkworm/common/base.hpp>
 
 namespace silkworm {
 

--- a/core/silkworm/types/receipt.hpp
+++ b/core/silkworm/types/receipt.hpp
@@ -14,10 +14,11 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_TYPES_RECEIPT_H_
-#define SILKWORM_TYPES_RECEIPT_H_
+#ifndef SILKWORM_TYPES_RECEIPT_HPP_
+#define SILKWORM_TYPES_RECEIPT_HPP_
 
 #include <optional>
+
 #include <silkworm/types/bloom.hpp>
 #include <silkworm/types/log.hpp>
 
@@ -33,4 +34,4 @@ struct Receipt {
 
 }  // namespace silkworm
 
-#endif  // SILKWORM_TYPES_RECEIPT_H_
+#endif  // SILKWORM_TYPES_RECEIPT_HPP_

--- a/core/silkworm/types/transaction.cpp
+++ b/core/silkworm/types/transaction.cpp
@@ -18,7 +18,9 @@
 
 #include <cassert>
 #include <cstring>
+
 #include <ethash/keccak.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/crypto/ecdsa.hpp>
 #include <silkworm/rlp/encode.hpp>

--- a/core/silkworm/types/transaction.hpp
+++ b/core/silkworm/types/transaction.hpp
@@ -17,11 +17,13 @@
 #ifndef SILKWORM_TYPES_TRANSACTION_HPP_
 #define SILKWORM_TYPES_TRANSACTION_HPP_
 
-#include <intx/intx.hpp>
 #include <optional>
+#include <vector>
+
+#include <intx/intx.hpp>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/rlp/decode.hpp>
-#include <vector>
 
 namespace silkworm {
 

--- a/core/silkworm/types/transaction_test.cpp
+++ b/core/silkworm/types/transaction_test.cpp
@@ -17,6 +17,7 @@
 #include "transaction.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm {

--- a/db/silkworm/common/log.cpp
+++ b/db/silkworm/common/log.cpp
@@ -1,11 +1,11 @@
 /*
-   Copyright 2020 - 2021 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-	   http://www.apache.org/licenses/LICENSE-2.0
+           http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,8 +14,9 @@
    limitations under the License.
 */
 
-#include <silkworm/common/log.hpp>
 #include <absl/time/clock.h>
+
+#include <silkworm/common/log.hpp>
 
 namespace silkworm {
 
@@ -24,36 +25,29 @@ teestream log_streams_{std::cerr, null_stream()};
 LogLevels log_verbosity_{LogInfo};
 
 constexpr char const kLogTags_[7][6] = {
-    "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",		  };
+    "TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "CRIT ", "NONE ",
+};
 
 // Log to one or two output streams - typically the console and optional log file.
-void log_set_streams_(std::ostream& o1, std::ostream& o2) {
-    log_streams_.set_streams(o1.rdbuf(), o2.rdbuf());
-}
+void log_set_streams_(std::ostream& o1, std::ostream& o2) { log_streams_.set_streams(o1.rdbuf(), o2.rdbuf()); }
 
 std::mutex log_::log_mtx_;
 
 std::ostream& log_::header_(LogLevels level) {
-    return
-        log_streams_
-            << kLogTags_[level]
-            << "["
-            << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone())
-            << "]";
+    return log_streams_ << kLogTags_[level] << "["
+                        << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone()) << "]";
 }
 
-void log_expand_and_compile_test_() {
-    SILKWORM_LOG(LogInfo) << "log_expand_and_compile_test_" << std::endl;
-}
+void log_expand_and_compile_test_() { SILKWORM_LOG(LogInfo) << "log_expand_and_compile_test_" << std::endl; }
 
 std::ostream& null_stream() {
-	static struct null_buf : public std::streambuf {
-		int overflow(int c) override { return c; }
-	} null_buf;
-	static struct null_strm : public std::ostream {
-		null_strm() : std::ostream(&null_buf) {}
-	} null_strm;
-	return null_strm;
+    static struct null_buf : public std::streambuf {
+        int overflow(int c) override { return c; }
+    } null_buf;
+    static struct null_strm : public std::ostream {
+        null_strm() : std::ostream(&null_buf) {}
+    } null_strm;
+    return null_strm;
 }
 
 }  // namespace silkworm

--- a/db/silkworm/common/log.hpp
+++ b/db/silkworm/common/log.hpp
@@ -1,11 +1,11 @@
 /*
-   Copyright 2020 - 2021 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-	   http://www.apache.org/licenses/LICENSE-2.0
+           http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,29 +17,30 @@
 #ifndef SILKWORM_COMMON_LOG_HPP_
 #define SILKWORM_COMMON_LOG_HPP_
 
-#include <silkworm/common/tee.hpp>
 #include <mutex>
+
+#include <silkworm/common/tee.hpp>
 
 namespace silkworm {
 
 // stream labeled logging output - e.g.
 //	  SILKWORM_LOG(LogInfo) << "All your " << num_bases << " base are belong to us\n";
 //
-#define SILKWORM_LOG(level_) \
-    if ((level_) < silkworm::log_verbosity_) {} else log_(level_) << " "
+#define SILKWORM_LOG(level_)                   \
+    if ((level_) < silkworm::log_verbosity_) { \
+    } else                                     \
+        log_(level_) << " "
 
 // change the logging verbosity level - default level is LogInfo
 //
-#define SILKWORM_LOG_VERBOSITY(level_) \
-    (silkworm::log_verbosity_ = (level_))
+#define SILKWORM_LOG_VERBOSITY(level_) (silkworm::log_verbosity_ = (level_))
 
 // available verbosity levels
 enum LogLevels { LogTrace, LogDebug, LogInfo, LogWarn, LogError, LogCritical, LogNone };
 
 // change the logging output streams - default is (cerr, null_stream())
 //
-#define SILKWORM_LOG_STREAMS(stream1_, stream2_) \
-    silkworm::log_set_streams_((stream1_), (stream2_));
+#define SILKWORM_LOG_STREAMS(stream1_, stream2_) silkworm::log_set_streams_((stream1_), (stream2_));
 
 // silence
 std::ostream& null_stream();
@@ -49,15 +50,17 @@ std::ostream& null_stream();
 // Placing them in detail namespace prevents use of macros in nested namespaces of silkworm :(
 //
 extern LogLevels log_verbosity_;
-void log_set_streams_(std::ostream & o1, std::ostream & o2);
+void log_set_streams_(std::ostream& o1, std::ostream& o2);
 class log_ {
   public:
     log_(LogLevels level_) : level_(level_) { log_mtx_.lock(); }
     ~log_() { log_mtx_.unlock(); }
     std::ostream& header_(LogLevels);
-    template <class T> std::ostream& operator<< (const T & message) {
+    template <class T>
+    std::ostream& operator<<(const T& message) {
         return header_(level_) << message;
     }
+
   private:
     LogLevels level_;
     static std::mutex log_mtx_;
@@ -65,4 +68,4 @@ class log_ {
 
 }  // namespace silkworm
 
-#endif	// !SILKWORM_COMMON_LOG_HPP_
+#endif  // !SILKWORM_COMMON_LOG_HPP_

--- a/db/silkworm/common/log_test.cpp
+++ b/db/silkworm/common/log_test.cpp
@@ -5,7 +5,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-	   http://www.apache.org/licenses/LICENSE-2.0
+           http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,55 +16,56 @@
 
 #include "log.hpp"
 
-#include <catch2/catch.hpp>
 #include <iostream>
 #include <regex>
 #include <sstream>
 #include <string>
 
+#include <catch2/catch.hpp>
+
 namespace silkworm {
 
 namespace {
-	std::ostringstream stream1, stream2;
-	const std::string kInfix(R"(\[\d\d-\d\d|\d\d:\d\d:\d\d\.\d{3}\] )");
+    std::ostringstream stream1, stream2;
+    const std::string kInfix(R"(\[\d\d-\d\d|\d\d:\d\d:\d\d\.\d{3}\] )");
 
-	bool test_log(std::string prefix, std::string infix, std::string suffix) {
-		std::string string1(stream1.str());
-		std::string string2(stream2.str());
-		stream1.clear();
-		stream1.str("");
-		stream2.clear();
-		stream2.str("");
-		if (string1 != string2) return false;
+    bool test_log(std::string prefix, std::string infix, std::string suffix) {
+        std::string string1(stream1.str());
+        std::string string2(stream2.str());
+        stream1.clear();
+        stream1.str("");
+        stream2.clear();
+        stream2.str("");
+        if (string1 != string2) return false;
 
-		const std::string pattern = prefix + infix + suffix;
-		const std::regex rx(pattern);
-		return std::regex_search(string1, rx);
-	}
+        const std::string pattern = prefix + infix + suffix;
+        const std::regex rx(pattern);
+        return std::regex_search(string1, rx);
+    }
 }  // namespace
 
 TEST_CASE("Logging") {
-	SILKWORM_LOG_STREAMS(stream1, stream2);
+    SILKWORM_LOG_STREAMS(stream1, stream2);
 
-	// test true branch of macro
-	SILKWORM_LOG_VERBOSITY(LogTrace);
-	SILKWORM_LOG(LogCritical) << "LogCritical" << std::endl;
-	CHECK(test_log("CRIT ", kInfix, "LogCritical"));
-	SILKWORM_LOG(LogError) << "LogError" << std::endl;
-	CHECK(test_log("ERROR", kInfix, "LogError"));
-	SILKWORM_LOG(LogWarn) << "LogWarn" << std::endl;
-	CHECK(test_log("WARN ", kInfix, "LogWarn"));
-	SILKWORM_LOG(LogInfo) << "LogInfo" << std::endl;
-	CHECK(test_log("INFO ", kInfix, "LogInfo"));
-	SILKWORM_LOG(LogDebug) << "LogDebug" << std::endl;
-	CHECK(test_log("DEBUG", kInfix, "LogDebug"));
-	SILKWORM_LOG(LogTrace) << "LogTrace" << std::endl;
-	CHECK(test_log("TRACE", kInfix, "LogTrace"));
+    // test true branch of macro
+    SILKWORM_LOG_VERBOSITY(LogTrace);
+    SILKWORM_LOG(LogCritical) << "LogCritical" << std::endl;
+    CHECK(test_log("CRIT ", kInfix, "LogCritical"));
+    SILKWORM_LOG(LogError) << "LogError" << std::endl;
+    CHECK(test_log("ERROR", kInfix, "LogError"));
+    SILKWORM_LOG(LogWarn) << "LogWarn" << std::endl;
+    CHECK(test_log("WARN ", kInfix, "LogWarn"));
+    SILKWORM_LOG(LogInfo) << "LogInfo" << std::endl;
+    CHECK(test_log("INFO ", kInfix, "LogInfo"));
+    SILKWORM_LOG(LogDebug) << "LogDebug" << std::endl;
+    CHECK(test_log("DEBUG", kInfix, "LogDebug"));
+    SILKWORM_LOG(LogTrace) << "LogTrace" << std::endl;
+    CHECK(test_log("TRACE", kInfix, "LogTrace"));
 
-	// test false branch of macro
-	SILKWORM_LOG_VERBOSITY(LogDebug);
-	SILKWORM_LOG(LogTrace) << "LogTrace" << std::endl;
-	CHECK(test_log("", "", ""));
+    // test false branch of macro
+    SILKWORM_LOG_VERBOSITY(LogDebug);
+    SILKWORM_LOG(LogTrace) << "LogTrace" << std::endl;
+    CHECK(test_log("", "", ""));
 }
 
 }  // namespace silkworm

--- a/db/silkworm/db/access_layer.cpp
+++ b/db/silkworm/db/access_layer.cpp
@@ -16,9 +16,10 @@
 
 #include "access_layer.hpp"
 
-#include <nlohmann/json.hpp>
-#include <boost/endian/conversion.hpp>
 #include <cassert>
+
+#include <boost/endian/conversion.hpp>
+#include <nlohmann/json.hpp>
 
 #include "bitmap.hpp"
 #include "tables.hpp"

--- a/db/silkworm/db/access_layer.hpp
+++ b/db/silkworm/db/access_layer.hpp
@@ -21,12 +21,13 @@
 // See TG core/rawdb/accessors_chain.go
 
 #include <optional>
+#include <vector>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/db/chaindb.hpp>
 #include <silkworm/db/util.hpp>
 #include <silkworm/types/account.hpp>
 #include <silkworm/types/block.hpp>
-#include <vector>
 
 namespace silkworm::db {
 

--- a/db/silkworm/db/access_layer_test.cpp
+++ b/db/silkworm/db/access_layer_test.cpp
@@ -18,6 +18,7 @@
 
 #include <boost/endian/conversion.hpp>
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/temp_dir.hpp>
 
 #include "tables.hpp"

--- a/db/silkworm/db/bitmap.hpp
+++ b/db/silkworm/db/bitmap.hpp
@@ -18,12 +18,13 @@
 #define SILKWORM_DB_BITMAP_HPP_
 
 #include <optional>
-#include <silkworm/common/base.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <roaring64map.hh>
 #pragma GCC diagnostic pop
+
+#include <silkworm/common/base.hpp>
 
 namespace silkworm::db::bitmap {
 

--- a/db/silkworm/db/bitmap_test.cpp
+++ b/db/silkworm/db/bitmap_test.cpp
@@ -14,21 +14,26 @@
    limitations under the License.
 */
 
-#include "access_layer.hpp"
+#include "bitmap.hpp"
+
+#include <vector>
 
 #include <catch2/catch.hpp>
 
-#include "bitmap.hpp"
-#include <vector>
+#include "access_layer.hpp"
 
 namespace silkworm::db::bitmap {
-    TEST_CASE("cut_left") {
-        roaring::Roaring64Map bitmap(roaring::api::roaring_bitmap_from_range(0, 100000, 1));
-        roaring::Roaring64Map expected(roaring::api::roaring_bitmap_from_range(0, 100000, 1));
-        roaring::Roaring64Map actual;
-        std::vector<roaring::Roaring64Map> bitmap_chunks;
-        while(bitmap.cardinality() != 0) bitmap_chunks.push_back(cut_left(bitmap, kBitmapChunkLimit));
-        for(const auto &chunk: bitmap_chunks) actual |= chunk;
-        CHECK(actual == expected);
+TEST_CASE("cut_left") {
+    roaring::Roaring64Map bitmap(roaring::api::roaring_bitmap_from_range(0, 100000, 1));
+    roaring::Roaring64Map expected(roaring::api::roaring_bitmap_from_range(0, 100000, 1));
+    roaring::Roaring64Map actual;
+    std::vector<roaring::Roaring64Map> bitmap_chunks;
+    while (bitmap.cardinality() != 0) {
+        bitmap_chunks.push_back(cut_left(bitmap, kBitmapChunkLimit));
     }
-}  // namespace bitmap
+    for (const auto &chunk : bitmap_chunks) {
+        actual |= chunk;
+    }
+    CHECK(actual == expected);
+}
+}  // namespace silkworm::db::bitmap

--- a/db/silkworm/db/buffer.cpp
+++ b/db/silkworm/db/buffer.cpp
@@ -16,10 +16,11 @@
 
 #include "buffer.hpp"
 
-#include <absl/container/btree_set.h>
-
 #include <algorithm>
+
+#include <absl/container/btree_set.h>
 #include <boost/endian/conversion.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/types/log_cbor.hpp>
 #include <silkworm/types/receipt_cbor.hpp>

--- a/db/silkworm/db/buffer.hpp
+++ b/db/silkworm/db/buffer.hpp
@@ -17,18 +17,19 @@
 #ifndef SILKWORM_DB_BUFFER_HPP_
 #define SILKWORM_DB_BUFFER_HPP_
 
+#include <optional>
+#include <vector>
+
 #include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 
-#include <optional>
 #include <silkworm/db/chaindb.hpp>
 #include <silkworm/db/util.hpp>
 #include <silkworm/state/buffer.hpp>
 #include <silkworm/types/account.hpp>
 #include <silkworm/types/block.hpp>
 #include <silkworm/types/receipt.hpp>
-#include <vector>
 
 namespace silkworm::db {
 

--- a/db/silkworm/db/chaindb.hpp
+++ b/db/silkworm/db/chaindb.hpp
@@ -22,18 +22,19 @@
  * See http://www.lmdb.tech/doc/index.html
  */
 
-#include <lmdb/lmdb.h>
-
 #include <exception>
 #include <map>
 #include <mutex>
 #include <optional>
-#include <silkworm/common/base.hpp>
-#include <silkworm/common/util.hpp>
-#include <silkworm/db/util.hpp>
 #include <string>
 #include <thread>
 #include <vector>
+
+#include <lmdb/lmdb.h>
+
+#include <silkworm/common/base.hpp>
+#include <silkworm/common/util.hpp>
+#include <silkworm/db/util.hpp>
 
 static_assert(sizeof(size_t) == 8, "32 bit environment limits LMDB size");
 

--- a/db/silkworm/db/util.cpp
+++ b/db/silkworm/db/util.cpp
@@ -16,11 +16,13 @@
 
 #include "util.hpp"
 
-#include <boost/endian/conversion.hpp>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+
+#include <boost/endian/conversion.hpp>
 #include <intx/int128.hpp>
+
 #include <silkworm/common/util.hpp>
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/rlp/encode.hpp>

--- a/db/silkworm/db/util.hpp
+++ b/db/silkworm/db/util.hpp
@@ -14,20 +14,21 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_DB_UTIL_H_
-#define SILKWORM_DB_UTIL_H_
+#ifndef SILKWORM_DB_UTIL_HPP_
+#define SILKWORM_DB_UTIL_HPP_
 
 /*
 Part of the compatibility layer with the Turbo-Geth DB format;
 see its package dbutils.
 */
 
+#include <string>
+
 #include <absl/container/btree_map.h>
 #include <lmdb/lmdb.h>
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/types/block.hpp>
-#include <string>
 
 namespace silkworm::db {
 
@@ -106,4 +107,4 @@ namespace detail {
 }  // namespace detail
 }  // namespace silkworm::db
 
-#endif  // SILKWORM_DB_UTIL_H_
+#endif  // SILKWORM_DB_UTIL_HPP_

--- a/db/silkworm/etl/buffer.hpp
+++ b/db/silkworm/etl/buffer.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
    limitations under the License.
 */
 
-#pragma once
-#ifndef SILKWORM_ETL_BUFFER_H_
-#define SILKWORM_ETL_BUFFER_H_
+#ifndef SILKWORM_ETL_BUFFER_HPP_
+#define SILKWORM_ETL_BUFFER_HPP_
 
 #include <algorithm>
+#include <vector>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/etl/util.hpp>
-#include <vector>
 
 namespace silkworm::etl {
 
@@ -42,5 +42,7 @@ class Buffer {
     size_t optimal_size_;
     size_t size_ = 0;
 };
+
 }  // namespace silkworm::etl
-#endif  // !SILKWORM_ETL_BUFFER_H_
+
+#endif  // !SILKWORM_ETL_BUFFER_HPP_

--- a/db/silkworm/etl/collector.cpp
+++ b/db/silkworm/etl/collector.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -13,17 +13,18 @@
 
 #include "collector.hpp"
 
-#include <boost/filesystem.hpp>
-#include <silkworm/common/log.hpp>
-#include <queue>
 #include <iomanip>
+#include <queue>
+
+#include <boost/filesystem.hpp>
+
+#include <silkworm/common/log.hpp>
 
 namespace silkworm::etl {
 
 namespace fs = boost::filesystem;
 
 Collector::~Collector() {
-
     file_providers_.clear();  // Will ensure all files (if any) have been orderly closed and deleted before we remove
                               // the working dir
     fs::path path(work_path_);
@@ -46,9 +47,7 @@ void Collector::flush_buffer() {
     }
 }
 
-size_t Collector::size() const {
-    return size_;
-}
+size_t Collector::size() const { return size_; }
 
 void Collector::collect(Entry& entry) {
     buffer_.put(entry);
@@ -58,9 +57,9 @@ void Collector::collect(Entry& entry) {
     }
 }
 
-void Collector::load(silkworm::lmdb::Table* table, LoadFunc load_func, unsigned int db_flags, uint32_t log_every_percent) {
-
-    const auto overall_size{size()}; // Amount of work
+void Collector::load(silkworm::lmdb::Table* table, LoadFunc load_func, unsigned int db_flags,
+                     uint32_t log_every_percent) {
+    const auto overall_size{size()};  // Amount of work
 
     if (!overall_size) {
         SILKWORM_LOG(LogInfo) << "ETL Load called without data to process" << std::endl;
@@ -77,7 +76,7 @@ void Collector::load(silkworm::lmdb::Table* table, LoadFunc load_func, unsigned 
         if (load_func) {
             for (const auto& etl_entry : buffer_.get_entries()) {
                 load_func(etl_entry, table, db_flags);
-                
+
                 if (!--dummy_counter) {
                     actual_progress += progress_step;
                     dummy_counter = progress_increment_count;
@@ -136,7 +135,7 @@ void Collector::load(silkworm::lmdb::Table* table, LoadFunc load_func, unsigned 
             actual_progress += progress_step;
             dummy_counter = progress_increment_count;
             SILKWORM_LOG(LogInfo) << "ETL Load Progress "
-                << " << " << actual_progress << "%" << std::endl;
+                                  << " << " << actual_progress << "%" << std::endl;
         }
 
         // From the provider which has served the current key
@@ -155,7 +154,7 @@ void Collector::load(silkworm::lmdb::Table* table, LoadFunc load_func, unsigned 
             file_provider.reset();
         }
     }
-    size_ = 0; // We have consumed all items
+    size_ = 0;  // We have consumed all items
 }
 
 std::string Collector::set_work_path(const char* provided_work_path) {

--- a/db/silkworm/etl/collector_test.cpp
+++ b/db/silkworm/etl/collector_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -13,10 +13,12 @@
 
 #include "collector.hpp"
 
+#include <set>
+
 #include <boost/endian/conversion.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <catch2/catch.hpp>
-#include <set>
+
 #include <silkworm/common/temp_dir.hpp>
 #include <silkworm/db/tables.hpp>
 
@@ -75,7 +77,7 @@ void run_collector_test(LoadFunc load_func) {
 TEST_CASE("collect_and_default_load") { run_collector_test(nullptr); }
 
 TEST_CASE("collect_and_load") {
-    run_collector_test([](Entry entry, lmdb::Table * table, unsigned int) {
+    run_collector_test([](Entry entry, lmdb::Table* table, unsigned int) {
         entry.key.at(0) = 1;
         table->put(entry.key, entry.value);
     });

--- a/db/silkworm/etl/file_provider.cpp
+++ b/db/silkworm/etl/file_provider.cpp
@@ -17,6 +17,7 @@
 #include "file_provider.hpp"
 
 #include <boost/filesystem/operations.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm::etl {

--- a/db/silkworm/etl/file_provider.hpp
+++ b/db/silkworm/etl/file_provider.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
    limitations under the License.
 */
 
-#pragma once
-#ifndef ETL_SILKWORM_FILE_PROVIDER_H_
-#define ETL_SILKWORM_FILE_PROVIDER_H_
+#ifndef ETL_SILKWORM_FILE_PROVIDER_HPP_
+#define ETL_SILKWORM_FILE_PROVIDER_HPP_
 
 #include <fstream>
 #include <memory>
 #include <optional>
+
 #include <silkworm/etl/buffer.hpp>
 #include <silkworm/etl/util.hpp>
 
@@ -47,5 +47,7 @@ class FileProvider {
     std::string file_name_;  // Actual name of file
     size_t file_size_{0};    // Actual size of written data
 };
+
 }  // namespace silkworm::etl
-#endif  // !ETL_SILKWORM_FILE_PROVIDER_H_
+
+#endif  // !ETL_SILKWORM_FILE_PROVIDER_HPP_

--- a/db/silkworm/types/receipt_cbor_test.cpp
+++ b/db/silkworm/types/receipt_cbor_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "receipt_cbor.hpp"
 
 #include <catch2/catch.hpp>
+
 #include <silkworm/common/util.hpp>
 
 namespace silkworm {

--- a/tg_api/silkworm_tg_api.cpp
+++ b/tg_api/silkworm_tg_api.cpp
@@ -17,7 +17,9 @@
 #include "silkworm_tg_api.h"
 
 #include <cassert>
+
 #include <gsl/gsl_util>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/db/access_layer.hpp>

--- a/tg_api/silkworm_tg_api.h
+++ b/tg_api/silkworm_tg_api.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,9 +19,10 @@
 
 // C API exported by Silkworm to be used in Turbo-Geth.
 
-#include <lmdb/lmdb.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#include <lmdb/lmdb.h>
 
 #if defined _MSC_VER
 #define SILKWORM_EXPORT __declspec(dllexport)

--- a/wasm/silkworm_wasm_api.cpp
+++ b/wasm/silkworm_wasm_api.cpp
@@ -17,6 +17,7 @@
 #include "silkworm_wasm_api.hpp"
 
 #include <cstdlib>
+
 #include <silkworm/chain/difficulty.hpp>
 #include <silkworm/chain/intrinsic_gas.hpp>
 #include <silkworm/common/util.hpp>

--- a/wasm/silkworm_wasm_api.hpp
+++ b/wasm/silkworm_wasm_api.hpp
@@ -21,11 +21,12 @@
 // Currently it's unstable and is likely to change.
 // Used for https://torquem.ch/eth_tests.html
 
-#include <evmc/evmc.h>
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <evmc/evmc.h>
 #include <intx/intx.hpp>
+
 #include <silkworm/chain/blockchain.hpp>
 #include <silkworm/common/base.hpp>
 #include <silkworm/state/memory_buffer.hpp>


### PR DESCRIPTION
Clang-format header includes in the following order:

1. Main header (`foo.hpp` in `foo.cpp`)
2. C system headers
3. C++ standard library headers
4. Third-party libraries
5. Silkworm headers

This agrees with [Google style guide](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes) and hopefully is a bit cleaner than before.