### PR TITLE
Small change in check_senders logic

### DIFF
--- a/cmd/check_senders.cpp
+++ b/cmd/check_senders.cpp
@@ -458,7 +458,7 @@ class RecoveryFarm final {
                 << "Senders Unwinding : Unexpected database error :  " << ex.what() << std::endl;
             return Status::DatabaseError;
         }
-        return Status::Succeded;
+        return should_stop() ? Status::WorkerAborted : Status::Succeded;
     }
 
   private:

--- a/cmd/check_senders.cpp
+++ b/cmd/check_senders.cpp
@@ -257,7 +257,6 @@ class RecoveryFarm final {
                     if (ret_status != Status::Succeded) {
                         return ret_status;
                     }
-                    db::stages::set_stage_progress(db_transaction_, db::stages::kSendersKey, new_height);
                 } else {
                     height_from = senders_stage_height + 1;
                 }
@@ -449,6 +448,15 @@ class RecoveryFarm final {
                     << "Senders Unwinding : Unexpected database error :  " << ex.what() << std::endl;
                 return Status::DatabaseError;
             }
+        }
+
+        // Eventually update new stage height
+        try {
+            db::stages::set_stage_progress(db_transaction_, db::stages::kSendersKey, new_height);
+        } catch (const lmdb::exception& ex) {
+            SILKWORM_LOG(LogLevels::LogError)
+                << "Senders Unwinding : Unexpected database error :  " << ex.what() << std::endl;
+            return Status::DatabaseError;
         }
         return Status::Succeded;
     }


### PR DESCRIPTION
* Move the stage regression persistance at the end of unwind method (so unwind can be called as standalone method)
* Don't commit if user has CTRL+C