### PR TITLE
Revert "Git submodule automation on build (#155)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,15 @@
 version: 2.1
 
 commands:
+  checkout_with_submodules:
+    steps:
+      - checkout
+      - run:
+          name: "Update submodules"
+          command: |
+            git submodule sync
+            git submodule update --init --recursive
+
   build:
     steps:
       - run:
@@ -70,7 +79,7 @@ jobs:
             sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 50
             gcc --version
             g++ --version
-      - checkout
+      - checkout_with_submodules
       - build
       - test
 
@@ -81,7 +90,7 @@ jobs:
     docker:
       - image: ethereum/cpp-build-env:14-clang-10
     steps:
-      - checkout
+      - checkout_with_submodules
       - build
       - run:
           name: "Core unit tests"
@@ -123,7 +132,7 @@ jobs:
     machine:
       image: ubuntu-2004:202010-01
     steps:
-      - checkout
+      - checkout_with_submodules
       - run:
           name: "Install WASI SDK"
           working_directory: ~/tmp1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,25 +16,11 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-find_package(Git)
-if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.gitmodules")
-  # Update submodules
-  option(GIT_SUBMODULE "Check submodules during build" ON)
-  if(GIT_SUBMODULE)
-    message(STATUS "Submodule update")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
-    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-       message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-    endif()
-  endif()
-else()
-  message(FATAL_ERROR "Git tool is required.")
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/evmone/evmc/.git)
+  message(FATAL_ERROR "Git submodules not initialized, execute:\n  git submodule update --init --recursive")
 endif()
 
 get_directory_property(SILKWORM_HAS_PARENT PARENT_DIRECTORY)
-
 if(NOT SILKWORM_HAS_PARENT)
   include(evmone/cmake/cable/bootstrap.cmake)
   include(CableBuildType)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ as outlined in its [release commentary](https://ledgerwatch.github.io/turbo_geth
 git clone --recurse-submodules https://github.com/torquem-ch/silkworm.git
 ```
 
+To update the submodules later on run
+```
+git submodule update --init --recursive
+```
+
 ## Linux & macOS
 Building silkworm requires:
 * C++17 compiler (GCC or Clang)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,8 @@ cache:
 
 before_build:
   - cd "%APPVEYOR_BUILD_FOLDER%"
+  - git submodule sync
+  - git submodule update --init --recursive
   - SET INCLUDE=C:\Tools\vcpkg\installed\x64-windows\include;%INCLUDE%
   - SET PATH=C:\Tools\vcpkg\installed\x64-windows\bin;%PATH%
   - cmake -H. -Bbuild -Wno-dev


### PR DESCRIPTION
This reverts commit b46f5c3c0796674ff28ce43cccd18fc1e046da7a.

This feature useful when somebody else updates submodules and you then pick up their changes automatically, but on the other hand it's super annoying or confusing when you change a submodule locally prior to commit and then your change is silently reverted by build.

See also https://stackoverflow.com/questions/4611512/is-there-a-way-to-make-git-pull-automatically-update-submodules