### PR TITLE
Switch linux-gcc-9 to Release and no_output_timeout in linux-clang-coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
 jobs:
   linux-gcc-9:
     environment:
-      BUILD_TYPE: Debug
+      BUILD_TYPE: Release
       CLANG_COVERAGE: OFF
     machine:
       image: ubuntu-2004:202010-01
@@ -98,6 +98,7 @@ jobs:
       - run:
           name: "Ethereum consensus tests"
           working_directory: ~/build
+          no_output_timeout: 15m
           command: |
             cmd/consensus
             mv default.profraw consensus.profraw


### PR DESCRIPTION
This is to alleviate slow consensus tests in CI