### PR TITLE
Optimization: use ExecutionStatePool in consensus tests

### DIFF
--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -216,6 +216,7 @@ static void check_rlp_err(rlp::DecodingResult err) {
     }
 }
 
+ExecutionStatePool state_pool;
 evmc_vm* evm{nullptr};
 
 // https://ethereum-tests.readthedocs.io/en/latest/test_types/blockchain_tests.html#pre-prestate-section
@@ -380,6 +381,7 @@ Status blockchain_test(const nlohmann::json& json_test, std::optional<ChainConfi
     init_pre_state(json_test["pre"], state);
 
     Blockchain blockchain{state, config, genesis_block};
+    blockchain.state_pool = &state_pool;
     blockchain.exo_evm = evm;
 
     for (const auto& json_block : json_test["blocks"]) {

--- a/core/silkworm/chain/blockchain.cpp
+++ b/core/silkworm/chain/blockchain.cpp
@@ -90,7 +90,7 @@ ValidationResult Blockchain::insert_block(Block& block, bool check_state_root) {
 
 ValidationResult Blockchain::execute_block(const Block& block, bool check_state_root) {
     std::pair<std::vector<Receipt>, ValidationResult> res{
-        silkworm::execute_block(block, state_, config_, /*analysis_cache=*/nullptr, /*state_pool=*/nullptr, exo_evm)};
+        silkworm::execute_block(block, state_, config_, /*analysis_cache=*/nullptr, state_pool, exo_evm)};
     if (res.second != ValidationResult::kOk) {
         return res.second;
     }

--- a/core/silkworm/chain/blockchain.hpp
+++ b/core/silkworm/chain/blockchain.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <silkworm/chain/validity.hpp>
+#include <silkworm/execution/state_pool.hpp>
 #include <silkworm/state/buffer.hpp>
 
 namespace silkworm {
@@ -33,6 +34,8 @@ class Blockchain {
     Blockchain& operator=(const Blockchain&) = delete;
 
     ValidationResult insert_block(Block& block, bool check_state_root);
+
+    ExecutionStatePool* state_pool{nullptr};
 
     evmc_vm* exo_evm{nullptr};
 


### PR DESCRIPTION
With this optimization `cmd/consensus` takes 30 instead of 35 sec on my MacBook.