### PR TITLE
EIP-2929 evmone implementation update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 xcode
+.idea
 .vscode
 .vs

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -346,7 +346,7 @@ bool EvmHost::account_exists(const evmc::address& address) const noexcept {
 
 evmc_access_status EvmHost::access_account(const evmc::address& address) noexcept {
     if (evm_.is_precompiled(address)) {
-        return EVMC_WARM_ACCESS;
+        return EVMC_ACCESS_WARM;
     }
     return evm_.state().access_account(address);
 }

--- a/core/silkworm/state/intra_block_state.cpp
+++ b/core/silkworm/state/intra_block_state.cpp
@@ -225,7 +225,7 @@ evmc_access_status IntraBlockState::access_account(const evmc::address& address)
     if (cold_read) {
         journal_.emplace_back(new state::AccountAccessDelta{address});
     }
-    return cold_read ? EVMC_COLD_ACCESS : EVMC_WARM_ACCESS;
+    return cold_read ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
 }
 
 evmc_access_status IntraBlockState::access_storage(const evmc::address& address, const evmc::bytes32& key) noexcept {
@@ -233,7 +233,7 @@ evmc_access_status IntraBlockState::access_storage(const evmc::address& address,
     if (cold_read) {
         journal_.emplace_back(new state::StorageAccessDelta{address, key});
     }
-    return cold_read ? EVMC_COLD_ACCESS : EVMC_WARM_ACCESS;
+    return cold_read ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
 }
 
 evmc::bytes32 IntraBlockState::get_current_storage(const evmc::address& address,


### PR DESCRIPTION
This updates evmone to upstream version implementing EIP-2929. So far this is needed for evmone consensus testing (cyclic dependency).