### PR TITLE
cmd/consensus: Allow passing EVMC options to VM

### DIFF
--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -586,7 +586,7 @@ int main(int argc, char* argv[]) {
 
     if (!evm_path.empty()) {
         evmc_loader_error_code err;
-        evm = evmc_load_and_create(evm_path.c_str(), &err);
+        evm = evmc_load_and_configure(evm_path.c_str(), &err);
         if (err) {
             std::cerr << "Failed to load EVM: " << evmc_last_error_msg() << std::endl;
             return -1;


### PR DESCRIPTION
Use evmc_load_and_configure() instead of evmc_load_and_create().
This allows passing additional EVMC options to VM along with the path,
e.g. --evm=./libevmone.so,O=0.

Documentation: https://evmc.ethereum.org/group__loader.html#gabd3a005d5ac0ca5230e71df1b1940f9c