### PR TITLE
Return data in CallResult from EVM execution

### DIFF
--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -56,7 +56,7 @@ CallResult EVM::execute(const Transaction& txn, uint64_t gas) noexcept {
 
     evmc::result res{contract_creation ? create(message) : call(message)};
 
-    return {res.status_code, static_cast<uint64_t>(res.gas_left)};
+    return {res.status_code, static_cast<uint64_t>(res.gas_left), {res.output_data, res.output_size}};
 }
 
 evmc::result EVM::create(const evmc_message& message) noexcept {

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -22,6 +22,7 @@
 
 #include <intx/intx.hpp>
 
+#include <silkworm/common/util.hpp>
 #include <silkworm/chain/config.hpp>
 #include <silkworm/execution/analysis_cache.hpp>
 #include <silkworm/execution/state_pool.hpp>
@@ -33,6 +34,7 @@ namespace silkworm {
 struct CallResult {
     evmc_status_code status{EVMC_SUCCESS};
     uint64_t gas_left{0};
+    Bytes data;
 };
 
 class EVM {


### PR DESCRIPTION
This change is needed by Silkrpc that is using Silkworm EVM to implement `eth_call`