### PR TITLE
EVM::execute Precondition: txn.from must be recovered

### DIFF
--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -48,15 +48,15 @@ CallResult EVM::execute(const Transaction& txn, uint64_t gas) noexcept {
     bool contract_creation{!txn.to.has_value()};
 
     evmc_message message{
-        contract_creation ? EVMC_CREATE : EVMC_CALL,    // kind
-        0,                                              // flags
-        0,                                              // depth
-        static_cast<int64_t>(gas),                      // gas
-        contract_creation ? evmc::address{} : *txn.to,  // destination
-        *txn.from,                                      // sender
-        &txn.data[0],                                   // input_data
-        txn.data.size(),                                // input_size
-        intx::be::store<evmc::uint256be>(txn.value),    // value
+        contract_creation ? EVMC_CREATE : EVMC_CALL,         // kind
+        0,                                                   // flags
+        0,                                                   // depth
+        static_cast<int64_t>(gas),                           // gas
+        contract_creation ? evmc::address{} : *txn.to,       // destination
+        txn.from.has_value() ? *txn.from : evmc::address{},  // sender
+        &txn.data[0],                                        // input_data
+        txn.data.size(),                                     // input_size
+        intx::be::store<evmc::uint256be>(txn.value),         // value
     };
 
     evmc::result res{contract_creation ? create(message) : call(message)};

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -39,6 +39,7 @@ struct CallResult {
 
 class EVM {
   public:
+    // Not copyable nor movable
     EVM(const EVM&) = delete;
     EVM& operator=(const EVM&) = delete;
 
@@ -53,6 +54,7 @@ class EVM {
     IntraBlockState& state() noexcept { return state_; }
     const IntraBlockState& state() const noexcept { return state_; }
 
+    // Precondition: txn.from must be recovered
     CallResult execute(const Transaction& txn, uint64_t gas) noexcept;
 
     evmc_revision revision() const noexcept;

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -340,6 +340,7 @@ TEST_CASE("EIP-3541: Reject new contracts starting with the 0xEF byte") {
     EVM evm{block, state, config};
 
     Transaction txn;
+    txn.from = 0x1000000000000000000000000000000000000000_address;
     const uint64_t gas{50'000};
 
     // https://eips.ethereum.org/EIPS/eip-3541#test-cases

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -60,6 +60,7 @@ Receipt ExecutionProcessor::execute_transaction(const Transaction& txn) noexcept
     IntraBlockState& state{evm_.state()};
     evm_.state().clear_journal_and_substate();
 
+    assert(txn.from.has_value());
     state.access_account(*txn.from);
 
     const intx::uint256 base_fee_per_gas{evm_.block().header.base_fee_per_gas.value_or(0)};


### PR DESCRIPTION
Evm test fail if txn.from is empty