### PR TITLE
Fix access to already deallocated memory in cmd/hashstate

### DIFF
--- a/cmd/check_hashstate.cpp
+++ b/cmd/check_hashstate.cpp
@@ -51,9 +51,9 @@ void check(lmdb::Transaction* txn, Operation operation) {
     auto [source_config, target_config] = get_tables_for_checking(operation);
     auto source_table{txn->open(source_config)};
     auto target_table{txn->open(target_config)};
-    MDB_val mdb_key{db::to_mdb_val(Bytes(8, '\0'))};
+    MDB_val mdb_key;
     MDB_val mdb_data;
-    int rc{source_table->seek(&mdb_key, &mdb_data)};
+    int rc{source_table->get_first(&mdb_key, &mdb_data)};
     while (!rc) { /* Loop as long as we have no errors*/
         Bytes mdb_key_as_bytes{db::from_mdb_val(mdb_key)};
         Bytes expected_value{db::from_mdb_val(mdb_data)};

--- a/cmd/check_hashstate.cpp
+++ b/cmd/check_hashstate.cpp
@@ -24,6 +24,7 @@
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/db/tables.hpp>
+#include <silkworm/db/util.hpp>
 #include <silkworm/etl/collector.hpp>
 
 using namespace silkworm;
@@ -54,8 +55,8 @@ void check(lmdb::Transaction* txn, Operation operation) {
     MDB_val mdb_data;
     int rc{source_table->seek(&mdb_key, &mdb_data)};
     while (!rc) { /* Loop as long as we have no errors*/
-        Bytes mdb_key_as_bytes{static_cast<uint8_t*>(mdb_key.mv_data), mdb_key.mv_size};
-        Bytes expected_value{static_cast<uint8_t*>(mdb_data.mv_data), mdb_data.mv_size};
+        Bytes mdb_key_as_bytes{db::from_mdb_val(mdb_key)};
+        Bytes expected_value{db::from_mdb_val(mdb_data)};
 
         if (operation == HashAccount) {
             // Account

--- a/cmd/check_senders.cpp
+++ b/cmd/check_senders.cpp
@@ -404,7 +404,7 @@ class RecoveryFarm final {
                     // Get the last processed block and update stage height
                     MDB_val mdb_key{}, mdb_val{};
                     lmdb::err_handler(target_table->get_last(&mdb_key, &mdb_val));
-                    ByteView key_view{static_cast<uint8_t*>(mdb_key.mv_data), mdb_key.mv_size};
+                    ByteView key_view{db::from_mdb_val(mdb_key)};
                     auto last_processed_block{boost::endian::load_big_u64(&key_view[0])};
                     db::stages::set_stage_progress(db_transaction_, db::stages::kSendersKey, last_processed_block);
 
@@ -734,7 +734,7 @@ class RecoveryFarm final {
 
             // Read all headers up to block_to included
             while (!rc) {
-                ByteView key_view{static_cast<uint8_t*>(mdb_key.mv_data), mdb_key.mv_size};
+                ByteView key_view{db::from_mdb_val(mdb_key)};
                 reached_block_num = boost::endian::load_big_u64(&key_view[0]);
                 if (reached_block_num != expected_block_num) {
                     SILKWORM_LOG(LogLevel::Error) << "Bad header hash sequence ! Expected " << expected_block_num

--- a/cmd/hashstate.cpp
+++ b/cmd/hashstate.cpp
@@ -25,6 +25,7 @@
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/db/tables.hpp>
+#include <silkworm/db/util.hpp>
 #include <silkworm/etl/collector.hpp>
 
 using namespace silkworm;
@@ -85,9 +86,9 @@ void promote_clean_state(lmdb::Transaction* txn, std::string etl_path) {
     int percent{0};
     uint64_t next_start_byte{0};
     while (!rc) { /* Loop as long as we have no errors*/
-        Bytes mdb_key_as_bytes{static_cast<uint8_t*>(mdb_key.mv_data), mdb_key.mv_size};
-        Bytes mdb_value_as_bytes{static_cast<uint8_t*>(mdb_data.mv_data), mdb_data.mv_size};
-        if (static_cast<uint8_t>(mdb_key_as_bytes.at(0)) >= next_start_byte) {
+        Bytes mdb_key_as_bytes{db::from_mdb_val(mdb_key)};
+        Bytes mdb_value_as_bytes{db::from_mdb_val(mdb_data)};
+        if (mdb_key_as_bytes.at(0) >= next_start_byte) {
             SILKWORM_LOG(LogLevel::Info) << "Progress: " << percent << "%" << std::endl;
             percent += 10;
             next_start_byte += 25;
@@ -130,8 +131,8 @@ void promote_clean_code(lmdb::Transaction* txn, std::string etl_path) {
     etl::Collector collector(etl_path.c_str(), 512 * kMebi);
     SILKWORM_LOG(LogLevel::Info) << "Hashing code keys" << std::endl;
     while (!rc) { /* Loop as long as we have no errors*/
-        Bytes mdb_key_as_bytes{static_cast<uint8_t*>(mdb_key.mv_data), mdb_key.mv_size};
-        Bytes mdb_value_as_bytes{static_cast<uint8_t*>(mdb_data.mv_data), mdb_data.mv_size};
+        Bytes mdb_key_as_bytes{db::from_mdb_val(mdb_key)};
+        Bytes mdb_value_as_bytes{db::from_mdb_val(mdb_data)};
 
         Bytes new_key(kHashLength + db::kIncarnationLength, '\0');
         std::memcpy(&new_key[0], keccak256(mdb_key_as_bytes.substr(0, kAddressLength)).bytes, kHashLength);
@@ -188,8 +189,8 @@ void promote(lmdb::Transaction* txn, Operation operation) {
     int rc{changeset_table->seek(&mdb_key, &mdb_data)};
 
     while (!rc) {
-        Bytes mdb_key_as_bytes{static_cast<uint8_t*>(mdb_key.mv_data), mdb_key.mv_size};
-        Bytes mdb_value_as_bytes{static_cast<uint8_t*>(mdb_data.mv_data), mdb_data.mv_size};
+        Bytes mdb_key_as_bytes{db::from_mdb_val(mdb_key)};
+        Bytes mdb_value_as_bytes{db::from_mdb_val(mdb_data)};
         Bytes db_key{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
         if (operation == HashAccount) {
             // We get account and hash its key.

--- a/cmd/hashstate.cpp
+++ b/cmd/hashstate.cpp
@@ -77,9 +77,9 @@ std::pair<lmdb::TableConfig, lmdb::TableConfig> get_tables_for_promote(Operation
 void promote_clean_state(lmdb::Transaction* txn, std::string etl_path) {
     SILKWORM_LOG(LogLevel::Info) << "Hashing state" << std::endl;
     auto source_table{txn->open(db::table::kPlainState)};
-    MDB_val mdb_key{db::to_mdb_val(Bytes(8, '\0'))};
+    MDB_val mdb_key;
     MDB_val mdb_data;
-    int rc{source_table->seek(&mdb_key, &mdb_data)};
+    int rc{source_table->get_first(&mdb_key, &mdb_data)};
     fs::create_directories(etl_path);
     etl::Collector collector_account(etl_path.c_str(), 512 * kMebi);
     etl::Collector collector_storage(etl_path.c_str(), 512 * kMebi);
@@ -124,9 +124,9 @@ void promote_clean_state(lmdb::Transaction* txn, std::string etl_path) {
 
 void promote_clean_code(lmdb::Transaction* txn, std::string etl_path) {
     auto source_table{txn->open(db::table::kPlainContractCode)};
-    MDB_val mdb_key{db::to_mdb_val(Bytes(8, '\0'))};
+    MDB_val mdb_key;
     MDB_val mdb_data;
-    int rc{source_table->seek(&mdb_key, &mdb_data)};
+    int rc{source_table->get_first(&mdb_key, &mdb_data)};
     fs::create_directories(etl_path);
     etl::Collector collector(etl_path.c_str(), 512 * kMebi);
     SILKWORM_LOG(LogLevel::Info) << "Hashing code keys" << std::endl;


### PR DESCRIPTION
`MDB_val mdb_key{db::to_mdb_val(Bytes(8, '\0'))};`
contains a bug. `Bytes(8, '\0')` creates a temporary object, which is destroyed after the line. And later we try to access an already deallocated memory via the view. (`MDB_val` is a view, essentially the same as `std::string_view`)