### PR TITLE
Reorganize CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,9 +185,17 @@ else()
 endif()
 
 
-# We don't accept old-style-cast in silkworm
+# Compiler enforcements on Silkworm
 if(NOT MSVC)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
+  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-Wno-attributes)
+  endif()
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    add_compile_definitions(_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)
+    add_compile_options(-Wthread-safety)
+  endif()
 endif()
 
 # Silkworm itself

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,6 @@ if(MSVC)
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_GMP USE_FIELD_INV_NUM USE_SCALAR_INV_NUM)
   target_compile_definitions(secp256k1 PUBLIC USE_FIELD_10X26 USE_SCALAR_8X32)
 
-  REMOVE_FLAG_FROM_TARGET(secp256k1 /W3)
-  REMOVE_FLAG_FROM_TARGET(secp256k1 /W4)
   target_compile_options(secp256k1 PRIVATE /w) # Not much we can do about warnings
 
 else()
@@ -128,7 +126,10 @@ if(NOT SILKWORM_CORE_ONLY)
   # Roaring Bitmaps
   set(ENABLE_ROARING_TESTS OFF)
   option(ROARING_BUILD_STATIC "Build a static library" ON)
-  option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" ON)
+  if(NOT MSVC)
+    # Not supported on MSVC
+    option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" ON)
+  endif()
   add_subdirectory(CRoaring EXCLUDE_FROM_ALL)
 
   # CBOR
@@ -140,9 +141,9 @@ if(NOT SILKWORM_CORE_ONLY)
                   lmdb-go/lmdb/midl.c
                   lmdb-go/lmdb/midl.h)
   target_include_directories(lmdb PUBLIC lmdb-go)
-  REMOVE_FLAG_FROM_TARGET(lmdb /W3)
-  REMOVE_FLAG_FROM_TARGET(lmdb /W4)
-  target_compile_options(lmdb PRIVATE /w) # Not much we can do about warnings
+  if(MSVC)
+    target_compile_options(lmdb PRIVATE /w) # Not much we can do about warnings
+  endif()
 endif()
 
 # evmone with dependencies
@@ -176,9 +177,6 @@ target_include_directories(evmone PUBLIC evmone/include evmone/lib)
 target_link_libraries(evmone PUBLIC evmc intx::intx PRIVATE evmc::instructions evmc::hex ethash)
 
 if(MSVC)
-  REMOVE_FLAG_FROM_TARGET(evmone /EHa)
-  REMOVE_FLAG_FROM_TARGET(evmone /W3)
-  REMOVE_FLAG_FROM_TARGET(evmone /W4)
   target_compile_options(evmone PRIVATE /EHsc /w)
 else()
   target_compile_options(evmone PRIVATE -fno-exceptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,16 +94,22 @@ set_target_properties(
 add_library(secp256k1 secp256k1/src/secp256k1.c)
 
 if(MSVC)
+
   target_link_libraries(secp256k1 PRIVATE gmp)
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_GMP USE_FIELD_INV_NUM USE_SCALAR_INV_NUM)
   target_compile_definitions(secp256k1 PUBLIC USE_FIELD_10X26 USE_SCALAR_8X32)
 
+  REMOVE_FLAG_FROM_TARGET(secp256k1 /W3)
+  REMOVE_FLAG_FROM_TARGET(secp256k1 /W4)
   target_compile_options(secp256k1 PRIVATE /w) # Not much we can do about warnings
 
 else()
+
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_NONE USE_FIELD_INV_BUILTIN USE_SCALAR_INV_BUILTIN)
   target_compile_definitions(secp256k1 PUBLIC USE_FIELD_5X52 USE_SCALAR_4X64 HAVE___INT128)
+
 endif()
+
 target_compile_definitions(secp256k1 PUBLIC ECMULT_WINDOW_SIZE=15 ECMULT_GEN_PREC_BITS=4 USE_ENDOMORPHISM)
 target_compile_definitions(secp256k1 PUBLIC ENABLE_MODULE_RECOVERY)
 target_include_directories(secp256k1 PRIVATE secp256k1 INTERFACE secp256k1/include)
@@ -134,6 +140,8 @@ if(NOT SILKWORM_CORE_ONLY)
                   lmdb-go/lmdb/midl.c
                   lmdb-go/lmdb/midl.h)
   target_include_directories(lmdb PUBLIC lmdb-go)
+  REMOVE_FLAG_FROM_TARGET(lmdb /W3)
+  REMOVE_FLAG_FROM_TARGET(lmdb /W4)
   target_compile_options(lmdb PRIVATE /w) # Not much we can do about warnings
 endif()
 
@@ -168,9 +176,18 @@ target_include_directories(evmone PUBLIC evmone/include evmone/lib)
 target_link_libraries(evmone PUBLIC evmc intx::intx PRIVATE evmc::instructions evmc::hex ethash)
 
 if(MSVC)
-  target_compile_options(evmone PRIVATE /EHa- /EHsc /w)
+  REMOVE_FLAG_FROM_TARGET(evmone /EHa)
+  REMOVE_FLAG_FROM_TARGET(evmone /W3)
+  REMOVE_FLAG_FROM_TARGET(evmone /W4)
+  target_compile_options(evmone PRIVATE /EHsc /w)
 else()
   target_compile_options(evmone PRIVATE -fno-exceptions)
+endif()
+
+
+# We don't accept old-style-cast in silkworm
+if(NOT MSVC)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
 endif()
 
 # Silkworm itself

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,42 +59,16 @@ HunterGate(
 project(silkworm)
 
 option(SILKWORM_WASM_API "Build WebAssembly API" OFF)
-
 option(SILKWORM_CORE_ONLY "Only build Silkworm Core" OFF)
+option(SILKWORM_CLANG_COVERAGE "Clang instrumentation for code coverage reports" OFF)
+
+include(compiler_settings)
 
 include(cmake/Hunter/core_packages.cmake)
 if(NOT SILKWORM_CORE_ONLY)
   include(cmake/Hunter/extra_packages.cmake)
 endif()
 
-option(SILKWORM_CLANG_COVERAGE "Clang instrumentation for code coverage reports" OFF)
-
-if(SILKWORM_CLANG_COVERAGE)
-  add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
-  add_link_options(-fprofile-instr-generate -fcoverage-mapping)
-endif()
-
-# minimal debug info for sampling profiler
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang$")
-    add_compile_options(-gline-tables-only)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-g1)
-  endif()
-endif()
-
-# Windows tweaks
-if(MSVC)
-  add_definitions(-D_WIN32_WINNT=0x0602) # Min Windows 8
-  add_definitions(-DVC_EXTRALEAN)        # Process windows headers faster ...
-  add_definitions(-DWIN32_LEAN_AND_MEAN) # ... and prevent winsock mismatch with Boost's
-  add_definitions(-DNOMINMAX)            # Prevent MSVC to tamper with std::min/std::max
-
-  # LINK : fatal error LNK1104: cannot open file 'libboost_date_time-vc142-mt-x64-1_72.lib
-  # is solved by this (issue only for MVC)
-  add_definitions(-DBOOST_DATE_TIME_NO_LIB) 
-
-endif()
 
 # GMP
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
@@ -123,13 +97,15 @@ if(MSVC)
   target_link_libraries(secp256k1 PRIVATE gmp)
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_GMP USE_FIELD_INV_NUM USE_SCALAR_INV_NUM)
   target_compile_definitions(secp256k1 PUBLIC USE_FIELD_10X26 USE_SCALAR_8X32)
+
+  target_compile_options(secp256k1 PRIVATE /W4- /w) # Not much we can do about warnings
+
 else()
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_NONE USE_FIELD_INV_BUILTIN USE_SCALAR_INV_BUILTIN)
   target_compile_definitions(secp256k1 PUBLIC USE_FIELD_5X52 USE_SCALAR_4X64 HAVE___INT128)
 endif()
 target_compile_definitions(secp256k1 PUBLIC ECMULT_WINDOW_SIZE=15 ECMULT_GEN_PREC_BITS=4 USE_ENDOMORPHISM)
 target_compile_definitions(secp256k1 PUBLIC ENABLE_MODULE_RECOVERY)
-
 target_include_directories(secp256k1 PRIVATE secp256k1 INTERFACE secp256k1/include)
 
 # libff
@@ -158,6 +134,7 @@ if(NOT SILKWORM_CORE_ONLY)
                   lmdb-go/lmdb/midl.c
                   lmdb-go/lmdb/midl.h)
   target_include_directories(lmdb PUBLIC lmdb-go)
+  target_compile_options(lmdb PRIVATE /W4- /w) # Not much we can do about warnings
 endif()
 
 # evmone with dependencies
@@ -165,10 +142,9 @@ if(SILKWORM_WASM_API)
   add_compile_definitions(EVMC_LOADER_MOCK)
 endif()
 
+find_package(intx CONFIG REQUIRED) # Required from here below
 add_subdirectory(evmone/evmc)
 add_subdirectory(ethash)
-
-find_package(intx CONFIG REQUIRED)
 
 add_library(evmone evmone/lib/evmone/analysis.cpp
                    evmone/lib/evmone/analysis.hpp
@@ -192,36 +168,9 @@ target_include_directories(evmone PUBLIC evmone/include evmone/lib)
 target_link_libraries(evmone PUBLIC evmc intx::intx PRIVATE evmc::instructions evmc::hex ethash)
 
 if(MSVC)
-  target_compile_options(evmone PRIVATE /EHsc)
+  target_compile_options(evmone PRIVATE /EHa- /EHsc /W4- /w)
 else()
   target_compile_options(evmone PRIVATE -fno-exceptions)
-endif()
-
-# Warnings options
-if(MSVC)
-  # Abseil triggeres some deprecation warnings
-  add_compile_definitions(_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
-  add_compile_definitions(_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING)
-
-  add_compile_options(/wd5030) # Silence warnings about GNU attributes
-  add_compile_options(/wd4324) # Silence warning C4324: 'xxx': structure was padded due to alignment specifier
-  add_compile_options(/wd4068) # Silence warning C4068: unknown pragma
-  add_compile_options(/wd5030) # Silence warning C5030: unknown gnu/clang attribute
-  add_compile_options(/W4)
-
-  add_link_options(/ignore:4099)
-else()
-  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
-endif()
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options(-Wno-attributes)
-endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  add_compile_definitions(_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)
-  add_compile_options(-Wthread-safety)
 endif()
 
 # Silkworm itself

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if(MSVC)
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_GMP USE_FIELD_INV_NUM USE_SCALAR_INV_NUM)
   target_compile_definitions(secp256k1 PUBLIC USE_FIELD_10X26 USE_SCALAR_8X32)
 
-  target_compile_options(secp256k1 PRIVATE /W4- /w) # Not much we can do about warnings
+  target_compile_options(secp256k1 PRIVATE /w) # Not much we can do about warnings
 
 else()
   target_compile_definitions(secp256k1 PUBLIC USE_NUM_NONE USE_FIELD_INV_BUILTIN USE_SCALAR_INV_BUILTIN)
@@ -134,7 +134,7 @@ if(NOT SILKWORM_CORE_ONLY)
                   lmdb-go/lmdb/midl.c
                   lmdb-go/lmdb/midl.h)
   target_include_directories(lmdb PUBLIC lmdb-go)
-  target_compile_options(lmdb PRIVATE /W4- /w) # Not much we can do about warnings
+  target_compile_options(lmdb PRIVATE /w) # Not much we can do about warnings
 endif()
 
 # evmone with dependencies
@@ -168,7 +168,7 @@ target_include_directories(evmone PUBLIC evmone/include evmone/lib)
 target_link_libraries(evmone PUBLIC evmc intx::intx PRIVATE evmc::instructions evmc::hex ethash)
 
 if(MSVC)
-  target_compile_options(evmone PRIVATE /EHa- /EHsc /W4- /w)
+  target_compile_options(evmone PRIVATE /EHa- /EHsc /w)
 else()
   target_compile_options(evmone PRIVATE -fno-exceptions)
 endif()

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -10,8 +10,20 @@
       "cmakeCommandArgs": "-Wno-dev",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
-      "addressSanitizerEnabled": true,
-      "variables": []
+      "addressSanitizerEnabled": true
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Visual Studio 16 2019 Win64",
+      "configurationType": "Release",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\silkworm\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\silkworm\\install\\${name}",
+      "cmakeCommandArgs": "-Wno-dev",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [],
+      "addressSanitizerEnabled": true
     }
   ]
 }

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -14,6 +14,21 @@
    limitations under the License.
 ]]
 
+#
+# Removes the specified compile flag from the specified target.
+#   _target     - The target to remove the compile flag from
+#   _flag       - The compile flag to remove
+#
+# Pre: apply_global_cxx_flags_to_all_targets() must be invoked.
+#
+macro(remove_flag_from_target _target _flag)
+    get_target_property(_target_cxx_flags ${_target} COMPILE_OPTIONS)
+    if(_target_cxx_flags)
+        list(REMOVE_ITEM _target_cxx_flags ${_flag})
+        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${_target_cxx_flags}")
+    endif()
+endmacro()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 
@@ -58,7 +73,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
   add_compile_options(-Wno-attributes)
   add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-g1)
@@ -67,7 +81,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
 
   add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
 
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -55,6 +55,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   add_compile_options(/wd5030) # Silence warning C5030: unknown gnu/clang attribute
   add_compile_options(/W4)     # Display all other unsilenced warnings
 
+  # Required for proper detection of __cplusplus
+  # see https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160
+  add_compile_options(/Zc:__cplusplus)
+
   add_link_options(/ignore:4099)
 
   if(CMAKE_BUILD_TYPE MATCHES "Release")

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -31,7 +31,6 @@ endmacro()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
-
   add_definitions(-D_WIN32_WINNT=0x0602)  # Min Windows 8
   add_definitions(-DVC_EXTRALEAN)         # Process windows headers faster ...
   add_definitions(-DWIN32_LEAN_AND_MEAN)  # ... and prevent winsock mismatch with Boost's
@@ -75,16 +74,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-  add_compile_options(-Wno-attributes)
-  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
-
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-g1)
   endif()
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
-
-  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
 
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
@@ -93,11 +87,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-gline-tables-only)
-  endif()
-
-  if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    add_compile_definitions(_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)
-    add_compile_options(-Wthread-safety)
   endif()
 
 else ()

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -14,21 +14,6 @@
    limitations under the License.
 ]]
 
-#
-# Removes the specified compile flag from the specified target.
-#   _target     - The target to remove the compile flag from
-#   _flag       - The compile flag to remove
-#
-# Pre: apply_global_cxx_flags_to_all_targets() must be invoked.
-#
-macro(remove_flag_from_target _target _flag)
-    get_target_property(_target_cxx_flags ${_target} COMPILE_OPTIONS)
-    if(_target_cxx_flags)
-        list(REMOVE_ITEM _target_cxx_flags ${_flag})
-        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${_target_cxx_flags}")
-    endif()
-endmacro()
-
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
   add_definitions(-D_WIN32_WINNT=0x0602)  # Min Windows 8

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -1,0 +1,90 @@
+#[[
+   Copyright 2021 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+
+
+  add_definitions(-D_WIN32_WINNT=0x0602)  # Min Windows 8
+  add_definitions(-DVC_EXTRALEAN)         # Process windows headers faster ...
+  add_definitions(-DWIN32_LEAN_AND_MEAN)  # ... and prevent winsock mismatch with Boost's
+  add_definitions(-DNOMINMAX)             # Prevent MSVC to tamper with std::min/std::max
+
+  # LINK : fatal error LNK1104: cannot open file 'libboost_date_time-vc142-mt-x64-1_72.lib
+  # is solved by this (issue only for MVC)
+  add_definitions(-DBOOST_DATE_TIME_NO_LIB) 
+
+  # Abseil triggeres some deprecation warnings
+  add_compile_definitions(_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
+  add_compile_definitions(_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING)
+
+  add_compile_options(/MP)     # Enable parallel compilation
+  add_compile_options(/EHa)    # Enable standard C++ unwinding
+
+  add_compile_options(/wd4127) # Silence warnings about "conditional expression is constant" (abseil mainly)
+  add_compile_options(/wd5030) # Silence warnings about GNU attributes
+  add_compile_options(/wd4324) # Silence warning C4324: 'xxx': structure was padded due to alignment specifier
+  add_compile_options(/wd4068) # Silence warning C4068: unknown pragma
+  add_compile_options(/wd5030) # Silence warning C5030: unknown gnu/clang attribute
+  add_compile_options(/W4)     # Display all other unsilenced warnings
+
+  add_link_options(/ignore:4099)
+
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    add_compile_options(/GL)                                                  # Enable LTCG for faster builds
+    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG")       # Enable LTCG for faster builds
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")             # Enable LTCG for faster builds
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /OPT:REF /OPT:ICF") # Enable unused references removal
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /RELEASE")          # Enable RELEASE so that the executable file has its checksum set
+  endif()
+
+  if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /VERBOSE /TIME")    # Debug linker
+  endif()
+
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+
+  add_compile_options(-Wno-attributes)
+  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_options(-g1)
+  endif()
+
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
+
+  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
+
+  if(SILKWORM_CLANG_COVERAGE)
+    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+  endif()
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_options(-gline-tables-only)
+  endif()
+
+  if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    add_compile_definitions(_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)
+    add_compile_options(-Wthread-safety)
+  endif()
+
+else ()
+
+ message(WARNING "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues")
+
+endif()

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB_RECURSE SILKWORM_CORE_TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/cor
 add_executable(core_test unit_test.cpp ${SILKWORM_CORE_TESTS})
 target_link_libraries(core_test silkworm_core Catch2::Catch2)
 if(MSVC)
-  target_compile_options(core_test PRIVATE /EHsc)
+  target_compile_options(core_test PRIVATE /Ea- /EHsc)
 else()
   target_compile_options(core_test PRIVATE -fno-exceptions)
 endif()

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB_RECURSE SILKWORM_CORE_TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/cor
 add_executable(core_test unit_test.cpp ${SILKWORM_CORE_TESTS})
 target_link_libraries(core_test silkworm_core Catch2::Catch2)
 if(MSVC)
-  target_compile_options(core_test PRIVATE /Ea- /EHsc)
+  target_compile_options(core_test PRIVATE /EHa- /EHsc)
 else()
   target_compile_options(core_test PRIVATE -fno-exceptions)
 endif()

--- a/ethash/CMakeLists.txt
+++ b/ethash/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(intx CONFIG REQUIRED)
 file(GLOB_RECURSE ETHASH_SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp" "*.c" "*.h")
 add_library(ethash ${ETHASH_SRC})
 target_include_directories(ethash PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
* create compiler_settings.cmake : store (roughly) all settings for compilers in one place so we can more easily manage different compilers
* add parallel builds for MSVC
* add LTCG for MSVC
* silence a good amount of warnings on MSVC
* add proper value for `__cplusplus` definition on MSVC (in preparation of MDBX)
* add `Release` build for Visual Studio users