### PR TITLE
Include type into receipt CBOR

### DIFF
--- a/db/silkworm/types/receipt_cbor.cpp
+++ b/db/silkworm/types/receipt_cbor.cpp
@@ -32,8 +32,9 @@ Bytes cbor_encode(const std::vector<Receipt>& v) {
     }
 
     for (const Receipt& r : v) {
-        encoder.write_array(3);
+        encoder.write_array(4);
 
+        encoder.write_int(r.type.value_or(0));
         encoder.write_null();  // no PostState
         encoder.write_int(r.success ? 1u : 0u);
         encoder.write_int(static_cast<unsigned long long>(r.cumulative_gas_used));

--- a/db/silkworm/types/receipt_cbor.cpp
+++ b/db/silkworm/types/receipt_cbor.cpp
@@ -38,6 +38,8 @@ Bytes cbor_encode(const std::vector<Receipt>& v) {
         encoder.write_null();  // no PostState
         encoder.write_int(r.success ? 1u : 0u);
         encoder.write_int(static_cast<unsigned long long>(r.cumulative_gas_used));
+
+        // Bloom filter and logs are omitted, same as in Erigon
     }
 
     return Bytes{output.data(), output.size()};

--- a/db/silkworm/types/receipt_cbor.hpp
+++ b/db/silkworm/types/receipt_cbor.hpp
@@ -22,7 +22,7 @@
 namespace silkworm {
 
 // Erigon-compatible CBOR encoding for storage.
-// See core/types/receipt.go
+// See core/types/receipt.go and migrations/receipt_cbor.go
 Bytes cbor_encode(const std::vector<Receipt>& v);
 
 }  // namespace silkworm

--- a/db/silkworm/types/receipt_cbor_test.cpp
+++ b/db/silkworm/types/receipt_cbor_test.cpp
@@ -19,6 +19,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/common/util.hpp>
+#include <silkworm/types/transaction.hpp>
 
 namespace silkworm {
 
@@ -29,6 +30,7 @@ TEST_CASE("CBOR encoding of receipts") {
 
     v.resize(2);
 
+    v[0].type = std::nullopt;
     v[0].success = false;
     v[0].cumulative_gas_used = 0x32f05d;
     v[0].logs = {
@@ -44,13 +46,14 @@ TEST_CASE("CBOR encoding of receipts") {
         },
     };
 
+    v[1].type = kEip1559TransactionType;
     v[1].success = true;
     v[1].cumulative_gas_used = 0xbeadd0;
     v[1].logs = {};
 
     encoded = cbor_encode(v);
 
-    CHECK(to_hex(encoded) == "8283f6001a0032f05d83f6011a00beadd0");
+    CHECK(to_hex(encoded) == "828400f6001a0032f05d8402f6011a00beadd0");
 }
 
 }  // namespace silkworm


### PR DESCRIPTION
CBOR encoding of receipts now includes [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) transactions types; see https://github.com/ledgerwatch/erigon/pull/2221