### PR TITLE
max_size instead of inmemory in db::EnvConfig

### DIFF
--- a/db/silkworm/db/access_layer_test.cpp
+++ b/db/silkworm/db/access_layer_test.cpp
@@ -85,6 +85,7 @@ namespace db {
         // Empty dir
         std::string empty{};
         db::EnvConfig db_config{empty};
+        db_config.max_size = 64 * kMebi;
         REQUIRE_THROWS_AS(db::open_env(db_config), std::invalid_argument);
 
         // Conflicting flags
@@ -103,32 +104,29 @@ namespace db {
         ::mdbx::env_managed env2;
         REQUIRE_THROWS(env2 = db::open_env(db_config));
 
-        // Close env and destroy tmp_dir
         env.close();
-        tmp_dir.~TemporaryDirectory();
 
         // Conflicting flags
-        tmp_dir = TemporaryDirectory();
-        db_config = db::EnvConfig{tmp_dir.path()};
+        TemporaryDirectory tmp_dir2;
+        db_config = db::EnvConfig{tmp_dir2.path()};
+        db_config.max_size = 64 * kMebi;
         db_config.create = true;
         db_config.readonly = true;
         REQUIRE_THROWS_AS(db::open_env(db_config), std::runtime_error);
 
         // Must open
         db_config.readonly = false;
-        db_config.inmemory = true;
         db_config.exclusive = true;
         REQUIRE_NOTHROW(env = db::open_env(db_config));
 
         env.close();
-        tmp_dir.~TemporaryDirectory();
     }
 
     TEST_CASE("Schema Version") {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
-        db_config.inmemory = true;
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -157,6 +155,7 @@ namespace db {
     TEST_CASE("Storage Mode") {
         TemporaryDirectory tmp_dir;
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -199,6 +198,7 @@ namespace db {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -235,6 +235,7 @@ namespace db {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -331,7 +332,7 @@ namespace db {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
-        db_config.inmemory = true;
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -372,6 +373,7 @@ namespace db {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -435,6 +437,7 @@ namespace db {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);
@@ -547,6 +550,7 @@ namespace db {
         TemporaryDirectory tmp_dir;
 
         db::EnvConfig db_config{tmp_dir.path(), /*create*/ true};
+        db_config.max_size = 64 * kMebi;
         auto env{db::open_env(db_config)};
         auto txn{env.start_write()};
         table::create_all(txn);

--- a/db/silkworm/db/mdbx.cpp
+++ b/db/silkworm/db/mdbx.cpp
@@ -18,7 +18,6 @@
 
 namespace silkworm::db {
 
-
 ::mdbx::env_managed open_env(const EnvConfig& config) {
     namespace fs = std::filesystem;
 
@@ -61,9 +60,6 @@ namespace silkworm::db {
     if (config.readonly) {
         flags |= MDBX_RDONLY;
     }
-    if (config.inmemory) {
-        flags |= MDBX_NOMETASYNC;
-    }
     if (config.exclusive) {
         flags |= MDBX_EXCLUSIVE;
     }
@@ -73,14 +69,14 @@ namespace silkworm::db {
 
     ::mdbx::env_managed::create_parameters cp{};  // Default create parameters
     if (!(config.shared)) {
-        size_t max_map_size{config.inmemory ? 64 * kMebi : 2 * kTebi};
-        size_t growth_size{config.inmemory ? 2 * kMebi : 2 * kGibi};
+        const size_t max_map_size{config.max_size};
+        const size_t growth_size{config.max_size / 1024};
         cp.geometry.make_dynamic(0, max_map_size);
         cp.geometry.growth_step = growth_size;
         cp.geometry.pagesize = 4 * kKibi;
     }
 
-    ::mdbx::env::operate_parameters op{};         // Operational parameters
+    ::mdbx::env::operate_parameters op{};  // Operational parameters
     op.mode = op.mode_from_flags(static_cast<MDBX_env_flags_t>(flags));
     op.options = op.options_from_flags(static_cast<MDBX_env_flags_t>(flags));
     op.durability = op.durability_from_flags(static_cast<MDBX_env_flags_t>(flags));

--- a/db/silkworm/db/mdbx.hpp
+++ b/db/silkworm/db/mdbx.hpp
@@ -38,10 +38,14 @@ struct EnvConfig {
     bool create{false};         // Whether or not db file must be created
     bool readonly{false};       // Whether or not db should be opened in RO mode
     bool exclusive{false};      // Whether or not this process has exclusive access
-    bool inmemory{false};       // Whether or not this db is in memory
     bool shared{false};         // Whether or not this process opens a db already opened by another process
     uint32_t max_tables{128};   // Default max number of named tables
     uint32_t max_readers{100};  // Default max number of readers
+
+    // Default maximum size of the DB.
+    // For better performance set it to a small value when you only need a small DB (e.g. in tests).
+    // This is especially important with AddressSanitizer.
+    size_t max_size{2 * kTebi};
 };
 
 struct MapConfig {

--- a/db/silkworm/etl/collector_test.cpp
+++ b/db/silkworm/etl/collector_test.cpp
@@ -55,7 +55,7 @@ void run_collector_test(LoadFunc load_func) {
 
     // Initialize temporary Database
     db::EnvConfig db_config{db_tmp_dir.path(), /*create*/ true};
-    db_config.inmemory = true;
+    db_config.max_size = 64 * kMebi;
 
     auto env{db::open_env(db_config)};
     auto txn{env.start_write()};

--- a/db/silkworm/stagedsync/unwind_execution_test.cpp
+++ b/db/silkworm/stagedsync/unwind_execution_test.cpp
@@ -14,24 +14,22 @@
    limitations under the License.
 */
 
-#include "stagedsync.hpp"
-
-#include <cstring>
-
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
-#include <iostream>
-#include <silkworm/execution/execution.hpp>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
+#include <silkworm/common/temp_dir.hpp>
+#include <silkworm/db/buffer.hpp>
+#include <silkworm/db/stages.hpp>
 #include <silkworm/execution/address.hpp>
+#include <silkworm/execution/execution.hpp>
 #include <silkworm/rlp/encode.hpp>
 #include <silkworm/state/memory_buffer.hpp>
 #include <silkworm/types/account.hpp>
 #include <silkworm/types/block.hpp>
-#include <silkworm/common/temp_dir.hpp>
-#include <silkworm/db/buffer.hpp>
-#include <silkworm/db/stages.hpp>
+
+#include "stagedsync.hpp"
 
 TEST_CASE("Unwind Execution") {
     using namespace silkworm;
@@ -40,6 +38,7 @@ TEST_CASE("Unwind Execution") {
 
     // Initialize temporary Database
     db::EnvConfig db_config{db_tmp_dir.path(), /*create*/ true};
+    db_config.max_size = 64 * kMebi;
     auto env{db::open_env(db_config)};
     auto txn{env.start_write()};
     db::table::create_all(txn);
@@ -130,7 +129,7 @@ TEST_CASE("Unwind Execution") {
     // ---------------------------------------
     // Unwind second block and checks if state is first block
     // ---------------------------------------
-    db_config.create = false; // We have already created it
+    db_config.create = false;  // We have already created it
     CHECK(stagedsync::unwind_execution(db_config, 1) == stagedsync::StageResult::kStageSuccess);
 
     auto env2{db::open_env(db_config)};

--- a/db/silkworm/trie/db_trie_test.cpp
+++ b/db/silkworm/trie/db_trie_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE("Account and storage trie") {
 
     // Initialize temporary Database
     db::EnvConfig db_config{tmp_dir1.path(), /*create*/ true};
-    db_config.inmemory = true;
+    db_config.max_size = 64 * kMebi;
     auto env{db::open_env(db_config)};
     auto txn{env.start_write()};
     db::table::create_all(txn);
@@ -223,7 +223,7 @@ TEST_CASE("Account trie around extension node") {
 
     // Initialize temporary Database
     db::EnvConfig db_config{tmp_dir1.path(), /*create*/ true};
-    db_config.inmemory = true;
+    db_config.max_size = 64 * kMebi;
     auto env{db::open_env(db_config)};
     auto txn{env.start_write()};
     db::table::create_all(txn);


### PR DESCRIPTION
max_size is more precise than inmemory.
Also `db_test` now runs fine under Address Sanitizer.