### PR TITLE
Clarify the difference between code and recipient

### DIFF
--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -161,7 +161,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
     }
 
     // See Section 8 "Message Call" of the Yellow Paper for the difference between code & recipient.
-    // destination in evmc_message can mean either code or recipent, depending on the context.
+    // destination in evmc_message can mean either code or recipient, depending on the context.
     const evmc_address code_address{message.destination};
     const evmc_address recipient_address{recipient_of_call_message(message)};
 

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -154,7 +154,7 @@ evmc::result EVM::create(const evmc_message& message) noexcept {
 evmc::result EVM::call(const evmc_message& message) noexcept {
     evmc::result res{EVMC_SUCCESS, message.gas, nullptr, 0};
 
-    auto value{intx::be::load<intx::uint256>(message.value)};
+    const auto value{intx::be::load<intx::uint256>(message.value)};
     if (message.kind != EVMC_DELEGATECALL && state_.get_balance(message.sender) < value) {
         res.status_code = EVMC_INSUFFICIENT_BALANCE;
         return res;
@@ -173,7 +173,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
         return res;
     }
 
-    auto snapshot{state_.take_snapshot()};
+    const auto snapshot{state_.take_snapshot()};
 
     if (message.kind == EVMC_CALL) {
         if (message.flags & EVMC_STATIC) {
@@ -187,14 +187,14 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
     }
 
     if (precompiled) {
-        uint8_t num{code_address.bytes[kAddressLength - 1]};
+        const uint8_t num{code_address.bytes[kAddressLength - 1]};
         precompiled::Contract contract{precompiled::kContracts[num - 1]};
-        ByteView input{message.input_data, message.input_size};
-        int64_t gas = contract.gas(input, revision());
+        const ByteView input{message.input_data, message.input_size};
+        const int64_t gas = contract.gas(input, revision());
         if (gas < 0 || gas > message.gas) {
             res.status_code = EVMC_OUT_OF_GAS;
         } else {
-            std::optional<Bytes> output{contract.run(input)};
+            const std::optional<Bytes> output{contract.run(input)};
             if (output) {
                 res = {EVMC_SUCCESS, message.gas - gas, output->data(), output->size()};
             } else {
@@ -202,7 +202,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
             }
         }
     } else {
-        ByteView code{state_.get_code(code_address)};
+        const ByteView code{state_.get_code(code_address)};
         if (code.empty()) {
             return res;
         }

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -72,6 +72,8 @@ class EVM {
 
     evmc::result call(const evmc_message& message) noexcept;
 
+    evmc_address recipient_of_call_message(const evmc_message& message) noexcept;
+
     evmc::result execute(const evmc_message& message, ByteView code, std::optional<evmc::bytes32> code_hash) noexcept;
 
     evmc_result execute_with_baseline_interpreter(evmc_revision rev, const evmc_message& message,
@@ -88,7 +90,7 @@ class EVM {
     const ChainConfig& config_;
     const Transaction* txn_{nullptr};
     std::vector<evmc::bytes32> block_hashes_{};
-    std::stack<evmc::address> address_stack_{};
+    std::stack<evmc::address> caller_stack_{};
     evmc_vm* evm1_{nullptr};
 };
 

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -90,7 +90,7 @@ class EVM {
     const ChainConfig& config_;
     const Transaction* txn_{nullptr};
     std::vector<evmc::bytes32> block_hashes_{};
-    std::stack<evmc::address> caller_stack_{};
+    std::stack<evmc::address> address_stack_{};
     evmc_vm* evm1_{nullptr};
 };
 


### PR DESCRIPTION
An `evmc_message` contains only two addresses (sender and "destination").
However, in case of `DELEGATECALL` we need 3 addresses (sender, recipient, and code), so we recover the missing 3rd address from the `address_stack_`.

See Section 8 "Message Call" of the Yellow Paper.
`destination` in `evmc_message` can mean either code or recipient, depending on the context.