### PR TITLE
Fix AddressSanitizer: stack-use-after-scope in read_chain_config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 ignore:
   - "**/*_test.cpp"
   - "cmd"
-  - libmdbx
+  - "libmdbx"
+  - "ethash/ethash"

--- a/db/silkworm/db/access_layer.cpp
+++ b/db/silkworm/db/access_layer.cpp
@@ -487,14 +487,13 @@ bool migration_happened(mdbx::txn& txn, const char* name) {
 
 std::optional<ChainConfig> read_chain_config(mdbx::txn& txn) {
     auto src{db::open_cursor(txn, table::kCanonicalHashes)};
-    auto key{to_slice(block_key(0))};
-    auto data{src.find(key, /*throw_notfound=*/false)};
+    auto data{src.find(to_slice(block_key(0)), /*throw_notfound=*/false)};
     if (!data) {
         return std::nullopt;
     }
 
     src = db::open_cursor(txn, table::kConfig);
-    key = data.value;
+    const auto key{data.value};
     data = src.find(key, /*throw_notfound=*/false);
     if (!data) {
         return std::nullopt;


### PR DESCRIPTION
```
auto key{to_slice(block_key(0))};
```
is problematic.

`block_key(0)` returns a temporary `Bytes` instance, which is then destroyed at the end of the line, so we end up with a view of a destroyed (byte)string.