### PR TITLE
Hashstate unwind clarification

### DIFF
--- a/db/silkworm/stagedsync/stage_hashstate.cpp
+++ b/db/silkworm/stagedsync/stage_hashstate.cpp
@@ -264,6 +264,9 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
 
     Bytes start_key{db::block_key(unwind_to + 1)};
     auto changeset_data{changeset_table.lower_bound(db::to_slice(start_key), /*throw_notfound*/ false)};
+    if (!changeset_data) {
+        return;
+    }
 
     db::WalkFunc unwind_func;
     switch (operation) {

--- a/db/silkworm/stagedsync/stage_hashstate.cpp
+++ b/db/silkworm/stagedsync/stage_hashstate.cpp
@@ -271,9 +271,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
     switch (operation) {
         case silkworm::stagedsync::HashstateOperation::HashAccount:
             unwind_func = [&target_table](::mdbx::cursor::move_result data) -> bool {
-                Bytes mdb_key_as_bytes{db::from_slice(data.key)};
-                Bytes mdb_value_as_bytes{db::from_slice(data.value)};
-                auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
+                auto [db_key, _]{convert_to_db_format(db::from_slice(data.key), db::from_slice(data.value))};
                 auto hash{keccak256(db_key)};
                 if (target_table.seek(db::to_slice(hash.bytes))) {
                     target_table.erase();
@@ -283,9 +281,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
             break;
         case silkworm::stagedsync::HashstateOperation::HashStorage:
             unwind_func = [&target_table](::mdbx::cursor::move_result data) -> bool {
-                Bytes mdb_key_as_bytes{db::from_slice(data.key)};
-                Bytes mdb_value_as_bytes{db::from_slice(data.value)};
-                auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
+                auto [db_key, _]{convert_to_db_format(db::from_slice(data.key), db::from_slice(data.value))};
 
                 // We get storage value and hash its key.
                 Bytes key(kHashLength * 2 + db::kIncarnationLength, '\0');
@@ -302,10 +298,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
             break;
         case silkworm::stagedsync::HashstateOperation::Code:
             unwind_func = [&target_table, &plainstate_table](::mdbx::cursor::move_result data) -> bool {
-                Bytes mdb_key_as_bytes{db::from_slice(data.key)};
-                Bytes mdb_value_as_bytes{db::from_slice(data.value)};
-                auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
-
+                auto [db_key, _]{convert_to_db_format(db::from_slice(data.key), db::from_slice(data.value))};
                 // Get incarnation
                 auto encoded_account{plainstate_table.find(db::to_slice(db_key), false)};
                 if (encoded_account) {

--- a/db/silkworm/stagedsync/stage_hashstate.cpp
+++ b/db/silkworm/stagedsync/stage_hashstate.cpp
@@ -41,8 +41,12 @@ std::pair<db::MapConfig, db::MapConfig> get_tables_for_promote(HashstateOperatio
             return {db::table::kPlainAccountChangeSet, db::table::kHashedAccounts};
         case HashstateOperation::HashStorage:
             return {db::table::kPlainStorageChangeSet, db::table::kHashedStorage};
-        default:
+        case HashstateOperation::Code:
             return {db::table::kPlainAccountChangeSet, db::table::kContractCode};
+        default:
+            std::string error{magic_enum::enum_name<HashstateOperation>(operation)};
+            error.append(": unknown operation");
+            throw std::runtime_error(error);
     }
 }
 /*

--- a/db/silkworm/stagedsync/stage_hashstate.cpp
+++ b/db/silkworm/stagedsync/stage_hashstate.cpp
@@ -259,7 +259,6 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
 
     auto changeset_table{db::open_cursor(txn, changeset_config)};
     auto plainstate_table{db::open_cursor(txn, db::table::kPlainState)};
-    auto codehash_table{db::open_cursor(txn, db::table::kPlainContractCode)};
     auto target_table{db::open_cursor(txn, target_config)};
 
     Bytes start_key{db::block_key(unwind_to + 1)};

--- a/db/silkworm/stagedsync/stage_hashstate.cpp
+++ b/db/silkworm/stagedsync/stage_hashstate.cpp
@@ -254,6 +254,7 @@ StageResult stage_hashstate(db::EnvConfig db_config) {
  *  Note: Standard Promotion is way slower than Clean Promotion
  */
 void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation operation) {
+
     auto [changeset_config, target_config] = get_tables_for_promote(operation);
 
     auto changeset_table{db::open_cursor(txn, changeset_config)};
@@ -264,65 +265,70 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
     Bytes start_key{db::block_key(unwind_to + 1)};
     auto changeset_data{changeset_table.lower_bound(db::to_slice(start_key), /*throw_notfound*/ false)};
 
-    while (changeset_data) {
-        Bytes mdb_key_as_bytes{db::from_slice(changeset_data.key)};
-        Bytes mdb_value_as_bytes{db::from_slice(changeset_data.value)};
-        auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
-        if (operation == HashstateOperation::HashAccount) {
-            // Hashing
-            auto hash{keccak256(db_key)};
-            auto data{target_table.find(db::to_slice(hash.bytes), /*throw_notfound*/ false)};
-            if (!data) {
-                changeset_data = changeset_table.to_next(false);
-                continue;
-            }
-            target_table.erase();
-            changeset_data = changeset_table.to_next(false);
-        } else if (operation == HashstateOperation::HashStorage) {
-            // We get storage value and hash its key.
-            Bytes key(kHashLength * 2 + db::kIncarnationLength, '\0');
+    db::WalkFunc unwind_func;
+    switch (operation) {
+        case silkworm::stagedsync::HashstateOperation::HashAccount:
+            unwind_func = [&target_table](::mdbx::cursor::move_result data) -> bool {
+                Bytes mdb_key_as_bytes{db::from_slice(data.key)};
+                Bytes mdb_value_as_bytes{db::from_slice(data.value)};
+                auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
+                auto hash{keccak256(db_key)};
+                if (target_table.seek(db::to_slice(hash.bytes))) {
+                    target_table.erase();
+                }
+                return true;
+            };
+            break;
+        case silkworm::stagedsync::HashstateOperation::HashStorage:
+            unwind_func = [&target_table](::mdbx::cursor::move_result data) -> bool {
+                Bytes mdb_key_as_bytes{db::from_slice(data.key)};
+                Bytes mdb_value_as_bytes{db::from_slice(data.value)};
+                auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
 
-            // Hashing
-            std::memcpy(&key[0], keccak256(db_key.substr(0, kAddressLength)).bytes, kHashLength);
-            std::memcpy(&key[kHashLength], &db_key[kAddressLength], db::kIncarnationLength);
-            std::memcpy(&key[kHashLength + db::kIncarnationLength],
-                        keccak256(db_key.substr(kAddressLength + db::kIncarnationLength)).bytes, kHashLength);
+                // We get storage value and hash its key.
+                Bytes key(kHashLength * 2 + db::kIncarnationLength, '\0');
+                // Hashing
+                std::memcpy(&key[0], keccak256(db_key.substr(0, kAddressLength)).bytes, kHashLength);
+                std::memcpy(&key[kHashLength], &db_key[kAddressLength], db::kIncarnationLength);
+                std::memcpy(&key[kHashLength + db::kIncarnationLength],
+                            keccak256(db_key.substr(kAddressLength + db::kIncarnationLength)).bytes, kHashLength);
+                if (target_table.seek(db::to_slice(key))) {
+                    target_table.erase();
+                }
+                return true;
+            };
+            break;
+        case silkworm::stagedsync::HashstateOperation::Code:
+            unwind_func = [&target_table, &plainstate_table](::mdbx::cursor::move_result data) -> bool {
+                Bytes mdb_key_as_bytes{db::from_slice(data.key)};
+                Bytes mdb_value_as_bytes{db::from_slice(data.value)};
+                auto [db_key, _]{convert_to_db_format(mdb_key_as_bytes, mdb_value_as_bytes)};
 
-            auto data{target_table.find(db::to_slice(key), /*throw_notfound*/ false)};
-            if (!data) {
-                changeset_data = changeset_table.to_next(false);
-                continue;
-            }
-            target_table.erase();
-            changeset_data = changeset_table.to_next(false);
-
-        } else {
-            // get incarnation
-            auto encoded_account{plainstate_table.find(db::to_slice(db_key), false)};
-            if (!encoded_account) {
-                changeset_data = changeset_table.to_next(false);
-                continue;
-            }
-            auto [incarnation, err]{extract_incarnation(db::from_slice(encoded_account.value))};
-            rlp::err_handler(err);
-            if (incarnation == 0) {
-                changeset_data = changeset_table.to_next(false);
-                continue;
-            }
-
-            // Hash and concatenate everything together
-            Bytes key(kHashLength + db::kIncarnationLength, '\0');
-            std::memcpy(&key[0], keccak256(db_key.substr(0, kAddressLength)).bytes, kHashLength);
-            boost::endian::store_big_u64(&key[kHashLength], incarnation);
-            auto data{target_table.find(db::to_slice(key), /*throw_notfound*/ false)};
-            if (!data) {
-                changeset_data = changeset_table.to_next(false);
-                continue;
-            }
-            target_table.erase();
-            changeset_data = changeset_table.to_next(false);
-        }
+                // Get incarnation
+                auto encoded_account{plainstate_table.find(db::to_slice(db_key), false)};
+                if (encoded_account) {
+                    auto [incarnation, err]{extract_incarnation(db::from_slice(encoded_account.value))};
+                    rlp::err_handler(err);
+                    if (incarnation) {
+                        Bytes key(kHashLength + db::kIncarnationLength, '\0');
+                        std::memcpy(&key[0], keccak256(db_key.substr(0, kAddressLength)).bytes, kHashLength);
+                        boost::endian::store_big_u64(&key[kHashLength], incarnation);
+                        if (target_table.seek(db::to_slice(key))) {
+                            target_table.erase();
+                        }
+                    }
+                }
+                return true;
+            };
+            break;
+        default:
+            std::string error{magic_enum::enum_name<HashstateOperation>(operation)};
+            error.append(": unknown operation");
+            throw std::runtime_error(error);
     }
+
+    (void)db::for_each(changeset_table, unwind_func);
+
 }
 
 StageResult unwind_hashstate(db::EnvConfig db_config, uint64_t unwind_to) {

--- a/db/silkworm/stagedsync/unwind_execution_test.cpp
+++ b/db/silkworm/stagedsync/unwind_execution_test.cpp
@@ -130,7 +130,7 @@ TEST_CASE("Unwind Execution") {
     // Unwind second block and checks if state is first block
     // ---------------------------------------
     db_config.create = false;  // We have already created it
-    CHECK(stagedsync::unwind_execution(db_config, 1) == stagedsync::StageResult::kStageSuccess);
+    REQUIRE_NOTHROW(stagedsync::check_stagedsync_error(stagedsync::unwind_execution(db_config, 1)));
 
     auto env2{db::open_env(db_config)};
     auto txn2{env2.start_write()};

--- a/db/silkworm/stagedsync/util.cpp
+++ b/db/silkworm/stagedsync/util.cpp
@@ -32,12 +32,12 @@ void check_stagedsync_error(StageResult code) {
 std::pair<Bytes, Bytes> convert_to_db_format(const ByteView& key, const ByteView& value) {
     if (key.size() == 8) {
         Bytes a(value.data(), kAddressLength);
-        Bytes b(value.substr(kAddressLength).data());
+        Bytes b(value.substr(kAddressLength).data(), value.size() - kAddressLength);
         return {a, b};
     }
     Bytes a(key.substr(8).data(), kAddressLength + db::kIncarnationLength);
     a.append(value.data(), kHashLength);
-    Bytes b(value.substr(kHashLength));
+    Bytes b(value.substr(kHashLength).data(), value.size() - kHashLength);
     return {a, b};
 }
 

--- a/db/silkworm/stagedsync/util.cpp
+++ b/db/silkworm/stagedsync/util.cpp
@@ -18,7 +18,9 @@
 #include <memory>
 #include <stdexcept>
 
-#include <silkworm/db/access_layer.hpp>
+#include <magic_enum.hpp>
+
+#include <silkworm/db/util.hpp>
 
 namespace silkworm::stagedsync {
 

--- a/db/silkworm/stagedsync/util.cpp
+++ b/db/silkworm/stagedsync/util.cpp
@@ -23,18 +23,9 @@
 namespace silkworm::stagedsync {
 
 void check_stagedsync_error(StageResult code) {
-    switch (code) {
-        case StageResult::kStageBadChainSequence:
-            throw std::runtime_error("BadChainSequence: Chain is not in order.");
-            break;
-        case StageResult::kStageInvalidRange:
-            throw std::runtime_error("InvalidRange: Starting block is in greater position than ending block.");
-            break;
-        case StageResult::kStageAborted:
-            throw std::runtime_error("Aborted: Stage was aborted.");
-            break;
-        default:
-            break;
+    if (code != StageResult::kStageSuccess) {
+        std::string error{magic_enum::enum_name<StageResult>(code)};
+        throw std::runtime_error(error);
     }
 }
 

--- a/db/silkworm/stagedsync/util.hpp
+++ b/db/silkworm/stagedsync/util.hpp
@@ -35,7 +35,7 @@ enum class [[nodiscard]] StageResult {
 void check_stagedsync_error(StageResult code);
 
 // Convert changesets key and value pair to plain state format
-std::pair<Bytes, Bytes> convert_to_db_format(const Bytes& key, const Bytes& value);
+std::pair<Bytes, Bytes> convert_to_db_format(const ByteView& key, const ByteView& value);
 
 }  // namespace silkworm::db
 

--- a/db/silkworm/stagedsync/util_test.cpp
+++ b/db/silkworm/stagedsync/util_test.cpp
@@ -1,0 +1,25 @@
+/*
+   Copyright 2021 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "util.hpp"
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("Check Staged Sync error") {
+    using namespace silkworm;
+    REQUIRE_NOTHROW(stagedsync::check_stagedsync_error(stagedsync::StageResult::kStageSuccess));
+    REQUIRE_THROWS_AS(stagedsync::check_stagedsync_error(stagedsync::StageResult::kStageAborted), std::runtime_error);
+}


### PR DESCRIPTION
I believe this version make unwind hashstate a bit more readable and removes branch checks on every record.
Also 
* removed double allocation of Bytes
* make use of seek on cursor when no need to retrive data
* ensure all cases of eums are covered properly (switch)
* removed leftover of unused table

Please check a run before merge 
