### PR TITLE
Fix inconsistent block_num set in stagesync execute

### DIFF
--- a/db/silkworm/stagedsync/stage_execution.cpp
+++ b/db/silkworm/stagedsync/stage_execution.cpp
@@ -31,56 +31,60 @@
 
 namespace silkworm::stagedsync {
 
-StageResult execute(mdbx::txn& txn, const ChainConfig& config, const uint64_t max_block, uint64_t* block_num,
-                    const db::StorageMode& storage_mode, size_t batch_size) {
-    db::Buffer buffer{txn};
-    AnalysisCache analysis_cache;
-    ExecutionStatePool state_pool;
+namespace {
+    // block_num is input-output
+    StageResult execute_batch_of_blocks(mdbx::txn& txn, const ChainConfig& config, const uint64_t max_block,
+                                        const db::StorageMode& storage_mode, const size_t batch_size,
+                                        uint64_t& block_num) noexcept {
+        db::Buffer buffer{txn};
+        AnalysisCache analysis_cache;
+        ExecutionStatePool state_pool;
 
-    try {
-        for (; *block_num <= max_block; ++*block_num) {
-            std::optional<BlockWithHash> bh{db::read_block(txn, *block_num, /*read_senders=*/true)};
-            if (!bh) {
-                return StageResult::kBadChainSequence;
-            }
+        try {
+            for (; block_num <= max_block; ++block_num) {
+                std::optional<BlockWithHash> bh{db::read_block(txn, block_num, /*read_senders=*/true)};
+                if (!bh) {
+                    return StageResult::kBadChainSequence;
+                }
 
-            auto [receipts, err]{execute_block(bh->block, buffer, config, &analysis_cache, &state_pool)};
-            if (err != ValidationResult::kOk) {
-                SILKWORM_LOG(LogLevel::Error) << "Validation error " << magic_enum::enum_name<ValidationResult>(err)
-                                              << " at block " << block_num << std::endl;
-                return StageResult::kInvalidBlock;
-            }
+                auto [receipts, err]{execute_block(bh->block, buffer, config, &analysis_cache, &state_pool)};
+                if (err != ValidationResult::kOk) {
+                    SILKWORM_LOG(LogLevel::Error) << "Validation error " << magic_enum::enum_name<ValidationResult>(err)
+                                                  << " at block " << block_num << std::endl;
+                    return StageResult::kInvalidBlock;
+                }
 
-            if (storage_mode.Receipts) {
-                buffer.insert_receipts(*block_num, receipts);
-            }
+                if (storage_mode.Receipts) {
+                    buffer.insert_receipts(block_num, receipts);
+                }
 
-            if (buffer.current_batch_size() >= batch_size) {
-                buffer.write_to_db();
-                return StageResult::kSuccess;
-            }
-        };
+                if (buffer.current_batch_size() >= batch_size) {
+                    buffer.write_to_db();
+                    return StageResult::kSuccess;
+                }
+            };
 
-        buffer.write_to_db();
-        return StageResult::kSuccess;
+            buffer.write_to_db();
+            return StageResult::kSuccess;
 
-    } catch (const mdbx::exception& ex) {
-        SILKWORM_LOG(LogLevel::Error) << "DB error " << ex.what() << " at block " << *block_num << std::endl;
-        return StageResult::kDbError;
-    } catch (const db::MissingSenders&) {
-        SILKWORM_LOG(LogLevel::Error) << "Missing or incorrect senders at block " << *block_num << std::endl;
-        return StageResult::kMissingSenders;
-    } catch (const rlp::DecodingError& ex) {
-        SILKWORM_LOG(LogLevel::Error) << ex.what() << " at block " << *block_num << std::endl;
-        return StageResult::kDecodingError;
-    } catch (const std::exception& ex) {
-        SILKWORM_LOG(LogLevel::Error) << "Unexpected error " << ex.what() << " at block " << *block_num << std::endl;
-        return StageResult::kUnexpectedError;
-    } catch (...) {
-        SILKWORM_LOG(LogLevel::Error) << "Unkown error at block " << *block_num << std::endl;
-        return StageResult::kUnknownError;
+        } catch (const mdbx::exception& ex) {
+            SILKWORM_LOG(LogLevel::Error) << "DB error " << ex.what() << " at block " << block_num << std::endl;
+            return StageResult::kDbError;
+        } catch (const db::MissingSenders&) {
+            SILKWORM_LOG(LogLevel::Error) << "Missing or incorrect senders at block " << block_num << std::endl;
+            return StageResult::kMissingSenders;
+        } catch (const rlp::DecodingError& ex) {
+            SILKWORM_LOG(LogLevel::Error) << ex.what() << " at block " << block_num << std::endl;
+            return StageResult::kDecodingError;
+        } catch (const std::exception& ex) {
+            SILKWORM_LOG(LogLevel::Error) << "Unexpected error " << ex.what() << " at block " << block_num << std::endl;
+            return StageResult::kUnexpectedError;
+        } catch (...) {
+            SILKWORM_LOG(LogLevel::Error) << "Unkown error at block " << block_num << std::endl;
+            return StageResult::kUnknownError;
+        }
     }
-}
+}  // namespace
 
 StageResult stage_execution(db::EnvConfig db_config, std::optional<uint64_t> to_block, size_t batch_size) {
     StageResult res{StageResult::kSuccess};
@@ -116,7 +120,7 @@ StageResult stage_execution(db::EnvConfig db_config, std::optional<uint64_t> to_
         }
 
         while (block_num <= max_block) {
-            res = execute(txn, chain_config.value(), max_block, &block_num, storage_mode, batch_size);
+            res = execute_batch_of_blocks(txn, chain_config.value(), max_block, storage_mode, batch_size, block_num);
             if (res == StageResult::kSuccess) {
                 db::stages::set_stage_progress(txn, db::stages::kExecutionKey, block_num);
                 txn.commit();


### PR DESCRIPTION
There was a bug related to the `execute` function `stage_execution.cpp`. It set `block_num` to the last executed block number when the buffer was full, but to `max_block + 1` when `max_block` was reached. Thus in the later case the subsequent `set_stage_progress` was called with `max_block + 1`  instead of `max_block`.

Also, I've made some improvements to the function:
1. Put the function into an anonymous namespace
2. Rename to `execute_batch_of_blocks` for clarity
3. Move `block_num` (an input-output) after all purely input args as per [Google's code style](https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs)
4. Make `block_num` a reference
5. Mark as `noexcept`