### PR TITLE
Restore stage uniformity

### DIFF
--- a/cmd/execute.cpp
+++ b/cmd/execute.cpp
@@ -36,30 +36,16 @@ int main(int argc, char* argv[]) {
     app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
-    uint64_t to_block{UINT64_MAX};
-    app.add_option("--to", to_block, "Block execute up to");
-
-    std::string batch_size_str{"512MB"};
-    app.add_option("--batch", batch_size_str, "Batch size of DB changes to accumulate before committing", true);
-
     CLI11_PARSE(app, argc, argv);
-
-    namespace fs = std::filesystem;
-
-    auto batch_size{parse_size(batch_size_str)};
-    if (!batch_size.has_value()) {
-        SILKWORM_LOG(LogLevel::Error) << "Invalid --batch value provided : " << batch_size_str << std::endl;
-        return -3;
-    }
 
     SILKWORM_LOG(LogLevel::Info) << "Starting block execution. DB: " << chaindata << std::endl;
 
     db::EnvConfig db_config{chaindata};
     db_config.create = false;
-    auto res{silkworm::stagedsync::stage_execution(db_config, to_block, batch_size.value())};
-    if (res != silkworm::stagedsync::StageResult::kSuccess) {
-        SILKWORM_LOG(LogLevel::Info) << "Execution returned : "
-                                     << magic_enum::enum_name<silkworm::stagedsync::StageResult>(res) << std::endl;
+    auto res{stagedsync::stage_execution(db_config)};
+    if (res != stagedsync::StageResult::kSuccess) {
+        SILKWORM_LOG(LogLevel::Info) << "Execution returned : " << magic_enum::enum_name<stagedsync::StageResult>(res)
+                                     << std::endl;
     }
-    return magic_enum::enum_integer<silkworm::stagedsync::StageResult>(res);
+    return magic_enum::enum_integer<stagedsync::StageResult>(res);
 }

--- a/db/silkworm/stagedsync/stage_execution.cpp
+++ b/db/silkworm/stagedsync/stage_execution.cpp
@@ -84,7 +84,7 @@ namespace {
     }
 }  // namespace
 
-StageResult stage_execution(db::EnvConfig db_config) {
+StageResult stage_execution(db::EnvConfig db_config, size_t batch_size) {
     StageResult res{StageResult::kSuccess};
 
     try {
@@ -115,8 +115,7 @@ StageResult stage_execution(db::EnvConfig db_config) {
         }
 
         for (; block_num <= max_block; ++block_num) {
-            res = execute_batch_of_blocks(txn, chain_config.value(), max_block, storage_mode, kDefaultBatchSize,
-                                          block_num);
+            res = execute_batch_of_blocks(txn, chain_config.value(), max_block, storage_mode, batch_size, block_num);
             if (res == StageResult::kSuccess) {
                 db::stages::set_stage_progress(txn, db::stages::kExecutionKey, block_num);
                 txn.commit();

--- a/db/silkworm/stagedsync/stagedsync.hpp
+++ b/db/silkworm/stagedsync/stagedsync.hpp
@@ -40,7 +40,9 @@ StageResult stage_headers(db::EnvConfig);
 StageResult stage_blockhashes(db::EnvConfig);
 StageResult stage_bodies(db::EnvConfig);
 StageResult stage_senders(db::EnvConfig);
-StageResult stage_execution(db::EnvConfig);
+StageResult stage_execution(db::EnvConfig, size_t batch_size);
+inline StageResult stage_execution(db::EnvConfig db_config) { return stage_execution(db_config, kDefaultBatchSize); }
+
 /* HashState Promotion Functions*/
 
 /*

--- a/db/silkworm/stagedsync/stagedsync.hpp
+++ b/db/silkworm/stagedsync/stagedsync.hpp
@@ -40,7 +40,7 @@ StageResult stage_headers(db::EnvConfig);
 StageResult stage_blockhashes(db::EnvConfig);
 StageResult stage_bodies(db::EnvConfig);
 StageResult stage_senders(db::EnvConfig);
-StageResult stage_execution(db::EnvConfig, std::optional<uint64_t> to_block = std::nullopt, size_t batch_size = kDefaultBatchSize);
+StageResult stage_execution(db::EnvConfig);
 /* HashState Promotion Functions*/
 
 /*

--- a/db/silkworm/stagedsync/stages.cpp
+++ b/db/silkworm/stagedsync/stages.cpp
@@ -20,20 +20,20 @@ namespace silkworm::stagedsync {
 
 StageResult no_unwind(db::EnvConfig, uint64_t) { return StageResult::kSuccess; }
 
-// Stages are not meant to have all the same parameters
-
-//std::vector<Stage> get_default_stages() {
-//    return std::vector<Stage>({{stage_headers, no_unwind, 1},
-//                               {stage_blockhashes, no_unwind, 2},
-//                               {stage_bodies, no_unwind, 3},
-//                               {stage_senders, unwind_senders, 4},
-//                               {stage_execution, unwind_execution, 5},
-//                               {stage_hashstate, unwind_hashstate, 6},
-//                               {stage_interhashes, unwind_hashstate, 7},
-//                               {stage_account_history, unwind_account_history, 8},
-//                               {stage_storage_history, unwind_storage_history, 9},
-//                               {stage_log_index, unwind_log_index, 10},
-//                               {stage_tx_lookup, unwind_tx_lookup, 11}});
-//}
+std::vector<Stage> get_default_stages() {
+    return {
+        {stage_headers, no_unwind, 1},
+        {stage_blockhashes, no_unwind, 2},
+        {stage_bodies, no_unwind, 3},
+        {stage_senders, unwind_senders, 4},
+        {stage_execution, unwind_execution, 5},
+        {stage_hashstate, unwind_hashstate, 6},
+        {stage_interhashes, unwind_hashstate, 7},
+        {stage_account_history, unwind_account_history, 8},
+        {stage_storage_history, unwind_storage_history, 9},
+        {stage_log_index, unwind_log_index, 10},
+        {stage_tx_lookup, unwind_tx_lookup, 11},
+    };
+}
 
 }  // namespace silkworm::stagedsync


### PR DESCRIPTION
Stage uniformity is useful for future work (something similar to `erigon/eth/stagedsync/default_stages.go`).
