### PR TITLE
SILKWORM_LOG printed an extra space

### DIFF
--- a/db/silkworm/common/log.cpp
+++ b/db/silkworm/common/log.cpp
@@ -37,10 +37,10 @@ void log_set_streams_(std::ostream& o1, std::ostream& o2) { log_streams_.set_str
 std::mutex log_::log_mtx_;
 
 std::ostream& log_::header_(LogLevel level) {
-    log_streams_ << kLogTags_[static_cast<int>(level)]
-                << "[" << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone()) << "] ";
+    log_streams_ << kLogTags_[static_cast<int>(level)] << "["
+                 << absl::FormatTime("%m-%d|%H:%M:%E3S", absl::Now(), absl::LocalTimeZone()) << "]";
     if (log_thread_enabled_) {
-        log_streams_ << std::this_thread::get_id() << " ";
+        log_streams_ << " " << std::this_thread::get_id();
     }
     return log_streams_;
 }

--- a/db/silkworm/common/log_test.cpp
+++ b/db/silkworm/common/log_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 - 2021 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ namespace silkworm {
 
 namespace {
     std::ostringstream stream1, stream2;
-    const std::string kInfix(R"(\[\d\d-\d\d|\d\d:\d\d:\d\d\.\d{3}\] )");
+    const std::string kInfix(R"(\[\d\d-\d\d\|\d\d:\d\d:\d\d\.\d{3}\] )");
 
     bool test_log(std::string prefix, std::string infix, std::string suffix) {
         std::string string1(stream1.str());
@@ -36,7 +36,9 @@ namespace {
         stream1.str("");
         stream2.clear();
         stream2.str("");
-        if (string1 != string2) return false;
+        if (string1 != string2) {
+            return false;
+        }
 
         const std::string pattern = prefix + infix + suffix;
         const std::regex rx(pattern);


### PR DESCRIPTION
Before:
```
INFO [07-23|16:26:18.391]  Blocks <= 3994982 committed
```

After:
```
INFO [07-23|16:26:18.391] Blocks <= 3994982 committed
```