### PR TITLE
Execute deployment code with baseline rather than advanced interpreter

### DIFF
--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -252,7 +252,7 @@ evmc::result EVM::execute(const evmc_message& msg, ByteView code, std::optional<
     } else if (code_hash != std::nullopt && advanced_analysis_cache != nullptr) {
         res = execute_with_default_interpreter(rev, msg, code, code_hash);
     } else {
-        // for one-off execution baseline interpeter is generally faster
+        // for one-off execution baseline interpreter is generally faster
         res = execute_with_baseline_interpreter(rev, msg, code);
     }
 

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -59,7 +59,8 @@ class EVM {
 
     evmc_revision revision() const noexcept;
 
-    AnalysisCache* analysis_cache{nullptr};  // use for better performance
+    // Point to a cache instance in order to enable execution with evmone advanced rather than baseline interpreter
+    AnalysisCache* advanced_analysis_cache{nullptr};
 
     ExecutionStatePool* state_pool{nullptr};  // use for better performance
 

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE("Maximum call depth") {
     EVM evm{block, state, kMainnetConfig};
 
     AnalysisCache analysis_cache{/*maxSize=*/16};
-    evm.analysis_cache = &analysis_cache;
+    evm.advanced_analysis_cache = &analysis_cache;
 
     Transaction txn{};
     txn.from = caller;

--- a/core/silkworm/execution/execution.cpp
+++ b/core/silkworm/execution/execution.cpp
@@ -32,7 +32,7 @@ std::pair<std::vector<Receipt>, ValidationResult> execute_block(const Block& blo
 
     IntraBlockState state{buffer};
     ExecutionProcessor processor{block, state, config};
-    processor.evm().analysis_cache = analysis_cache;
+    processor.evm().advanced_analysis_cache = analysis_cache;
     processor.evm().state_pool = state_pool;
     processor.evm().exo_evm = exo_evm;
 


### PR DESCRIPTION
This is a performance optimization. For one-off execution (such as deployment code) evmone baseline interpreter is generally faster. In my tests this change decreased the total execution time of all mainnet blocks by 3%.