### PR TITLE
Format: consistently use left pointer (and ref) alignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,10 @@ ColumnLimit: 120
 IndentWidth: 4
 AccessModifierOffset: -2
 NamespaceIndentation: Inner
+
+DerivePointerAlignment: false
+PointerAlignment: Left
+
 IncludeCategories:
   # Silkworm headers
   - Regex:           '<silkworm.*'

--- a/cmd/history_index.cpp
+++ b/cmd/history_index.cpp
@@ -30,7 +30,7 @@
 
 using namespace silkworm;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     namespace fs = std::filesystem;
 
     CLI::App app{"Generates History Indexes"};
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
     data_dir.create_tree();
     db::EnvConfig db_config{data_dir.get_chaindata_path().string()};
     db::MapConfig index_config = storage ? db::table::kStorageHistory : db::table::kAccountHistory;
-    const char *stage_key = storage ? db::stages::kStorageHistoryIndexKey : db::stages::kAccountHistoryIndexKey;
+    const char* stage_key = storage ? db::stages::kStorageHistoryIndexKey : db::stages::kAccountHistoryIndexKey;
 
     try {
         auto env{db::open_env(db_config)};
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
             stagedsync::check_stagedsync_error(stagedsync::stage_account_history(tm, data_dir.get_etl_path()));
         }
 
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;
     }

--- a/cmd/log_index.cpp
+++ b/cmd/log_index.cpp
@@ -36,7 +36,7 @@
 
 using namespace silkworm;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     namespace fs = std::filesystem;
 
     CLI::App app{"Generates Log Index"};
@@ -69,7 +69,7 @@ int main(int argc, char *argv[]) {
 
         stagedsync::TransactionManager tm{env};
         stagedsync::check_stagedsync_error(stagedsync::stage_log_index(tm, data_dir.get_etl_path()));
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;
     }

--- a/cmd/unwind_history_index.cpp
+++ b/cmd/unwind_history_index.cpp
@@ -30,7 +30,7 @@
 
 using namespace silkworm;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     namespace fs = std::filesystem;
 
     CLI::App app{"Unwind History Indexes"};
@@ -52,11 +52,13 @@ int main(int argc, char *argv[]) {
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
         if (storage) {
-            stagedsync::check_stagedsync_error(stagedsync::unwind_storage_history(tm, data_dir.get_etl_path(), unwind_to));
+            stagedsync::check_stagedsync_error(
+                stagedsync::unwind_storage_history(tm, data_dir.get_etl_path(), unwind_to));
         } else {
-            stagedsync::check_stagedsync_error(stagedsync::unwind_account_history(tm, data_dir.get_etl_path(), unwind_to));
+            stagedsync::check_stagedsync_error(
+                stagedsync::unwind_account_history(tm, data_dir.get_etl_path(), unwind_to));
         }
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;
     }

--- a/cmd/unwind_log_index.cpp
+++ b/cmd/unwind_log_index.cpp
@@ -35,7 +35,7 @@
 
 using namespace silkworm;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     namespace fs = std::filesystem;
 
     CLI::App app{"Generates Log Index"};
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
         stagedsync::check_stagedsync_error(stagedsync::unwind_log_index(tm, data_dir.get_etl_path(), unwind_to));
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;
     }

--- a/core/silkworm/crypto/sha-256.c
+++ b/core/silkworm/crypto/sha-256.c
@@ -72,7 +72,7 @@ static const uint32_t k[] = {
     0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
 
 struct buffer_state {
-    const uint8_t *p;
+    const uint8_t* p;
     size_t len;
     size_t total_len;
     bool single_one_delivered;
@@ -87,7 +87,7 @@ static inline uint32_t right_rot(uint32_t value, unsigned int count) {
     return value >> count | value << (32 - count);
 }
 
-static void init_buf_state(struct buffer_state *state, const void *input, size_t len) {
+static void init_buf_state(struct buffer_state* state, const void* input, size_t len) {
     state->p = input;
     state->len = len;
     state->total_len = len;
@@ -95,7 +95,7 @@ static void init_buf_state(struct buffer_state *state, const void *input, size_t
     state->total_len_delivered = false;
 }
 
-static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state *state) {
+static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state* state) {
     if (state->total_len_delivered) {
         return false;
     }
@@ -150,7 +150,7 @@ static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state *state) {
     return true;
 }
 
-static inline ALWAYS_INLINE void sha_256_implementation(uint32_t h[8], const void *input, size_t len) {
+static inline ALWAYS_INLINE void sha_256_implementation(uint32_t h[8], const void* input, size_t len) {
     /*
      * Note 1: All integers (expect indexes) are 32-bit unsigned integers and addition is calculated modulo 2^32.
      *
@@ -179,7 +179,7 @@ static inline ALWAYS_INLINE void sha_256_implementation(uint32_t h[8], const voi
             ah[i] = h[i];
         }
 
-        const uint8_t *p = chunk;
+        const uint8_t* p = chunk;
 
         /* Compression function main loop: */
         for (i = 0; i < 4; i++) {
@@ -237,13 +237,13 @@ static inline ALWAYS_INLINE void sha_256_implementation(uint32_t h[8], const voi
     }
 }
 
-static void sha_256_generic(uint32_t h[8], const void *input, size_t len) { sha_256_implementation(h, input, len); }
+static void sha_256_generic(uint32_t h[8], const void* input, size_t len) { sha_256_implementation(h, input, len); }
 
-static void (*sha_256_best)(uint32_t h[8], const void *input, size_t len) = sha_256_generic;
+static void (*sha_256_best)(uint32_t h[8], const void* input, size_t len) = sha_256_generic;
 
 #if defined(__x86_64__)
 
-__attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(uint32_t h[8], const void *input, size_t len) {
+__attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(uint32_t h[8], const void* input, size_t len) {
     sha_256_implementation(h, input, len);
 }
 
@@ -252,7 +252,7 @@ __attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(uint32_t h[8], c
 /*   Written and place in public domain by Jeffrey Walton  */
 /*   Based on code from Intel, and by Sean Gulley for      */
 /*   the miTLS project.                                    */
-__attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8], const void *input, size_t len) {
+__attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8], const void* input, size_t len) {
     __m128i STATE0, STATE1;
     __m128i MSG, TMP;
     __m128i MSG0, MSG1, MSG2, MSG3;
@@ -260,8 +260,8 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
     const __m128i MASK = _mm_set_epi64x(0x0c0d0e0f08090a0bULL, 0x0405060700010203ULL);
 
     /* Load initial values */
-    TMP = _mm_loadu_si128((const __m128i *)&h[0]);
-    STATE1 = _mm_loadu_si128((const __m128i *)&h[4]);
+    TMP = _mm_loadu_si128((const __m128i*)&h[0]);
+    STATE1 = _mm_loadu_si128((const __m128i*)&h[4]);
 
     TMP = _mm_shuffle_epi32(TMP, 0xB1);          /* CDAB */
     STATE1 = _mm_shuffle_epi32(STATE1, 0x1B);    /* EFGH */
@@ -280,7 +280,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
         CDGH_SAVE = STATE1;
 
         /* Rounds 0-3 */
-        MSG = _mm_loadu_si128((const __m128i *)(chunk + 0));
+        MSG = _mm_loadu_si128((const __m128i*)(chunk + 0));
         MSG0 = _mm_shuffle_epi8(MSG, MASK);
         MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0xE9B5DBA5B5C0FBCFULL, 0x71374491428A2F98ULL));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
@@ -288,7 +288,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
         STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
 
         /* Rounds 4-7 */
-        MSG1 = _mm_loadu_si128((const __m128i *)(chunk + 16));
+        MSG1 = _mm_loadu_si128((const __m128i*)(chunk + 16));
         MSG1 = _mm_shuffle_epi8(MSG1, MASK);
         MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0xAB1C5ED5923F82A4ULL, 0x59F111F13956C25BULL));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
@@ -297,7 +297,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
         MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
 
         /* Rounds 8-11 */
-        MSG2 = _mm_loadu_si128((const __m128i *)(chunk + 32));
+        MSG2 = _mm_loadu_si128((const __m128i*)(chunk + 32));
         MSG2 = _mm_shuffle_epi8(MSG2, MASK);
         MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0x550C7DC3243185BEULL, 0x12835B01D807AA98ULL));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
@@ -306,7 +306,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
         MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
 
         /* Rounds 12-15 */
-        MSG3 = _mm_loadu_si128((const __m128i *)(chunk + 48));
+        MSG3 = _mm_loadu_si128((const __m128i*)(chunk + 48));
         MSG3 = _mm_shuffle_epi8(MSG3, MASK);
         MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0xC19BF1749BDC06A7ULL, 0x80DEB1FE72BE5D74ULL));
         STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
@@ -442,8 +442,8 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
     STATE1 = _mm_alignr_epi8(STATE1, TMP, 8);    /* ABEF */
 
     /* Save state */
-    _mm_storeu_si128((__m128i *)&h[0], STATE0);
-    _mm_storeu_si128((__m128i *)&h[4], STATE1);
+    _mm_storeu_si128((__m128i*)&h[0], STATE0);
+    _mm_storeu_si128((__m128i*)&h[4], STATE1);
 }
 
 // https://stackoverflow.com/questions/6121792/how-to-check-if-a-cpu-supports-the-sse3-instruction-set
@@ -484,7 +484,7 @@ __attribute__((constructor)) static void select_sha256_implementation() {
 /*   Written and placed in public domain by Jeffrey Walton    */
 /*   Based on code from ARM, and by Johannes Schneiders, Skip */
 /*   Hovsmith and Barry O'Rourke for the mbedTLS project.     */
-static void sha_256_arm_v8(uint32_t h[8], const void *input, size_t len) {
+static void sha_256_arm_v8(uint32_t h[8], const void* input, size_t len) {
     uint32x4_t STATE0, STATE1, ABEF_SAVE, CDGH_SAVE;
     uint32x4_t MSG0, MSG1, MSG2, MSG3;
     uint32x4_t TMP0, TMP1, TMP2;
@@ -505,10 +505,10 @@ static void sha_256_arm_v8(uint32_t h[8], const void *input, size_t len) {
         CDGH_SAVE = STATE1;
 
         /* Load message */
-        MSG0 = vld1q_u32((const uint32_t *)(chunk + 0));
-        MSG1 = vld1q_u32((const uint32_t *)(chunk + 16));
-        MSG2 = vld1q_u32((const uint32_t *)(chunk + 32));
-        MSG3 = vld1q_u32((const uint32_t *)(chunk + 48));
+        MSG0 = vld1q_u32((const uint32_t*)(chunk + 0));
+        MSG1 = vld1q_u32((const uint32_t*)(chunk + 16));
+        MSG2 = vld1q_u32((const uint32_t*)(chunk + 32));
+        MSG3 = vld1q_u32((const uint32_t*)(chunk + 48));
 
         /* Reverse for little endian */
         MSG0 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSG0)));
@@ -675,7 +675,7 @@ __attribute__((constructor)) static void select_sha256_implementation() {
  *   for bit string lengths that are not multiples of eight, and it really operates on arrays of bytes.
  *   In particular, the len parameter is a number of bytes.
  */
-void calc_sha_256(uint8_t hash[32], const void *input, size_t len, bool use_cpu_extensions) {
+void calc_sha_256(uint8_t hash[32], const void* input, size_t len, bool use_cpu_extensions) {
     /*
      * Initialize hash values:
      * (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):

--- a/core/silkworm/crypto/sha-256.h
+++ b/core/silkworm/crypto/sha-256.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-void calc_sha_256(uint8_t hash[32], const void *input, size_t len, bool use_cpu_extensions);
+void calc_sha_256(uint8_t hash[32], const void* input, size_t len, bool use_cpu_extensions);
 
 #if defined(__cplusplus)
 }

--- a/db/silkworm/common/stopwatch.hpp
+++ b/db/silkworm/common/stopwatch.hpp
@@ -19,15 +19,13 @@
 #define SILKWORM_STOPWATCH_HPP_
 
 #include <chrono>
-#include <optional>
-
+#include <iomanip>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
-
 #include <utility>
 #include <vector>
-#include <iomanip>
 
 namespace silkworm {
 /// <summary>
@@ -92,6 +90,6 @@ class StopWatch {
     std::vector<std::pair<TimePoint, Duration>> laps_{};
 };
 
-
 }  // namespace silkworm
+
 #endif  // !SILKWORM_STOPWATCH_HPP_

--- a/db/silkworm/db/bitmap.cpp
+++ b/db/silkworm/db/bitmap.cpp
@@ -24,7 +24,7 @@ roaring::Roaring64Map read(ByteView serialized) {
     return roaring::Roaring64Map::readSafe(byte_ptr_cast(serialized.data()), serialized.size());
 }
 
-std::optional<uint64_t> seek(const roaring::Roaring64Map &bitmap, uint64_t n) {
+std::optional<uint64_t> seek(const roaring::Roaring64Map& bitmap, uint64_t n) {
     auto it{bitmap.begin()};
     if (it.move(n)) {
         return *it;
@@ -32,7 +32,7 @@ std::optional<uint64_t> seek(const roaring::Roaring64Map &bitmap, uint64_t n) {
     return std::nullopt;
 }
 
-roaring::Roaring64Map cut_left(roaring::Roaring64Map &bm, uint64_t size_limit) {
+roaring::Roaring64Map cut_left(roaring::Roaring64Map& bm, uint64_t size_limit) {
     if (bm.getSizeInBytes() <= size_limit) {
         roaring::Roaring64Map res(
             roaring::api::roaring_bitmap_from_range(bm.minimum(), bm.maximum() + 1, 1));  // With range
@@ -68,7 +68,7 @@ roaring::Roaring64Map cut_left(roaring::Roaring64Map &bm, uint64_t size_limit) {
     return res;
 }
 
-roaring::Roaring cut_left(roaring::Roaring &bm, uint64_t size_limit) {
+roaring::Roaring cut_left(roaring::Roaring& bm, uint64_t size_limit) {
     if (bm.getSizeInBytes() <= size_limit) {
         roaring::Roaring res(roaring::api::roaring_bitmap_from_range(bm.minimum(), bm.maximum() + 1, 1));  // With range
         res &= bm;

--- a/db/silkworm/db/bitmap.hpp
+++ b/db/silkworm/db/bitmap.hpp
@@ -36,11 +36,11 @@ roaring::Roaring64Map read(ByteView serialized);
 // Return the first value in the bitmap that is not less than (i.e. greater or equal to) n,
 // or std::nullopt if no such element is found.
 // See Erigon SeekInBitmap64.
-std::optional<uint64_t> seek(const roaring::Roaring64Map &bitmap, uint64_t n);
+std::optional<uint64_t> seek(const roaring::Roaring64Map& bitmap, uint64_t n);
 
 // Return cut bitmap of given size limit
-roaring::Roaring64Map cut_left(roaring::Roaring64Map &bitmap, uint64_t len);
-roaring::Roaring cut_left(roaring::Roaring &bitmap, uint64_t len);
+roaring::Roaring64Map cut_left(roaring::Roaring64Map& bitmap, uint64_t len);
+roaring::Roaring cut_left(roaring::Roaring& bitmap, uint64_t len);
 
 };  // namespace silkworm::db::bitmap
 

--- a/db/silkworm/db/bitmap_test.cpp
+++ b/db/silkworm/db/bitmap_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("cut_left") {
     while (bitmap.cardinality() != 0) {
         bitmap_chunks.push_back(cut_left(bitmap, kBitmapChunkLimit));
     }
-    for (const auto &chunk : bitmap_chunks) {
+    for (const auto& chunk : bitmap_chunks) {
         actual |= chunk;
     }
     CHECK(actual == expected);

--- a/db/silkworm/db/stages.hpp
+++ b/db/silkworm/db/stages.hpp
@@ -49,9 +49,21 @@ constexpr const char* kMiningFinishKey{"MiningFinish"};               // Mining 
 // clang-format on
 
 constexpr const char* kAllStages[]{
-    kHeadersKey,   kBlockHashesKey,    kBlockBodiesKey,         kSendersKey,  kExecutionKey,  kIntermediateHashesKey,
-    kHashStateKey, kAccountHistoryIndexKey, kStorageHistoryIndexKey, kLogIndexKey, kCallTracesKey, kTxLookupKey,
-    kTxPoolKey,    kFinishKey};
+    kHeadersKey,
+    kBlockHashesKey,
+    kBlockBodiesKey,
+    kSendersKey,
+    kExecutionKey,
+    kIntermediateHashesKey,
+    kHashStateKey,
+    kAccountHistoryIndexKey,
+    kStorageHistoryIndexKey,
+    kLogIndexKey,
+    kCallTracesKey,
+    kTxLookupKey,
+    kTxPoolKey,
+    kFinishKey,
+};
 
 // Gets the progress (block height) of any given stage
 uint64_t get_stage_progress(mdbx::txn& txn, const char* stage_name);

--- a/db/silkworm/etl/collector.hpp
+++ b/db/silkworm/etl/collector.hpp
@@ -14,8 +14,8 @@
 #ifndef SILKWORM_ETL_COLLECTOR_HPP_
 #define SILKWORM_ETL_COLLECTOR_HPP_
 
-#include <silkworm/etl/buffer.hpp>
 #include <silkworm/db/mdbx.hpp>
+#include <silkworm/etl/buffer.hpp>
 #include <silkworm/etl/file_provider.hpp>
 #include <silkworm/etl/util.hpp>
 
@@ -50,8 +50,8 @@ class Collector {
      * @param flags : Optional whether to append or upsert (default)
      * @param log_every_percent : Emits a log line indicating progress every this percent increment in processed items
      */
-    void load(mdbx::cursor& target, LoadFunc load_func = nullptr, MDBX_put_flags_t flags = MDBX_put_flags_t::MDBX_UPSERT,
-              uint32_t log_every_percent = 100u);
+    void load(mdbx::cursor& target, LoadFunc load_func = nullptr,
+              MDBX_put_flags_t flags = MDBX_put_flags_t::MDBX_UPSERT, uint32_t log_every_percent = 100u);
 
     /** @brief Returns the number of actually collected items
      */

--- a/db/silkworm/etl/file_provider.cpp
+++ b/db/silkworm/etl/file_provider.cpp
@@ -29,7 +29,7 @@ FileProvider::FileProvider(std::string file_name, size_t id) : id_{id}, file_nam
 
 FileProvider::~FileProvider(void) { reset(); }
 
-void FileProvider::flush(Buffer &buffer) {
+void FileProvider::flush(Buffer& buffer) {
     head_t head{};
 
     // Check we have enough space to store all data
@@ -48,7 +48,7 @@ void FileProvider::flush(Buffer &buffer) {
         throw etl_error(strerror(errno));
     };
 
-    for (const auto &entry : entries) {
+    for (const auto& entry : entries) {
         head.lengths[0] = entry.key.size();
         head.lengths[1] = entry.value.size();
         if (!file_.write(byte_ptr_cast(head.bytes), 8) ||

--- a/db/silkworm/stagedsync/listener_log_index.hpp
+++ b/db/silkworm/stagedsync/listener_log_index.hpp
@@ -29,9 +29,9 @@ namespace silkworm::stagedsync {
 
 class listener_log_index : public cbor::listener {
   public:
-    listener_log_index(uint64_t block_number, std::unordered_map<std::string, roaring::Roaring> *topics_map,
-                       std::unordered_map<std::string, roaring::Roaring> *addrs_map, uint64_t *allocated_topics,
-                       uint64_t *allocated_addrs_)
+    listener_log_index(uint64_t block_number, std::unordered_map<std::string, roaring::Roaring>* topics_map,
+                       std::unordered_map<std::string, roaring::Roaring>* addrs_map, uint64_t* allocated_topics,
+                       uint64_t* allocated_addrs_)
         : block_number_(block_number),
           topics_map_(topics_map),
           addrs_map_(addrs_map),
@@ -40,7 +40,7 @@ class listener_log_index : public cbor::listener {
 
     void on_integer(int) override{};
 
-    void on_bytes(unsigned char *data, int size) override {
+    void on_bytes(unsigned char* data, int size) override {
         std::string key(byte_ptr_cast(data), size);
         if (size == kHashLength) {
             if (topics_map_->find(key) == topics_map_->end()) {
@@ -57,7 +57,7 @@ class listener_log_index : public cbor::listener {
         }
     }
 
-    void on_string(std::string &) override{};
+    void on_string(std::string&) override{};
 
     void on_array(int) override {}
 
@@ -73,7 +73,7 @@ class listener_log_index : public cbor::listener {
 
     void on_undefined() override{};
 
-    void on_error(const char *) override{};
+    void on_error(const char*) override{};
 
     void on_extra_integer(unsigned long long, int) override{};
 
@@ -89,10 +89,10 @@ class listener_log_index : public cbor::listener {
 
   private:
     uint64_t block_number_;
-    std::unordered_map<std::string, roaring::Roaring> *topics_map_;
-    std::unordered_map<std::string, roaring::Roaring> *addrs_map_;
-    uint64_t *allocated_topics_;
-    uint64_t *allocated_addrs_;
+    std::unordered_map<std::string, roaring::Roaring>* topics_map_;
+    std::unordered_map<std::string, roaring::Roaring>* addrs_map_;
+    uint64_t* allocated_topics_;
+    uint64_t* allocated_addrs_;
 };
 
 }  // namespace silkworm::stagedsync

--- a/db/silkworm/stagedsync/recovery/recovery_worker.cpp
+++ b/db/silkworm/stagedsync/recovery/recovery_worker.cpp
@@ -25,8 +25,7 @@ RecoveryWorker::RecoveryWorker(uint32_t id, size_t data_size) : id_(id), data_si
     if (!data_) {
         throw std::runtime_error("Memory allocation failed");
     }
-};
-
+}
 
 void RecoveryWorker::set_work(uint32_t batch_id, std::unique_ptr<std::vector<package>> batch) {
     batch_ = std::move(batch);
@@ -44,9 +43,9 @@ bool RecoveryWorker::pull_results(Status status, std::vector<std::pair<uint64_t,
     if (status_.compare_exchange_strong(status, Status::Idle)) {
         std::swap(out, results_);
         return true;
-    };
+    }
     return false;
-};
+}
 
 void RecoveryWorker::work() {
     while (wait_for_kick()) {
@@ -101,5 +100,6 @@ void RecoveryWorker::work() {
     }
 
     std::free(data_);
-};
-};
+}
+
+}  // namespace silkworm::stagedsync::recovery

--- a/db/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/db/silkworm/stagedsync/stage_blockhashes.cpp
@@ -30,7 +30,7 @@ namespace silkworm::stagedsync {
 
 namespace fs = std::filesystem;
 
-StageResult stage_blockhashes(TransactionManager &txn, const std::filesystem::path &etl_path) {
+StageResult stage_blockhashes(TransactionManager& txn, const std::filesystem::path& etl_path) {
     fs::create_directories(etl_path);
     etl::Collector collector(etl_path.string().c_str(), /* flush size */ 512_Mebi);
     uint32_t block_number{0};
@@ -48,7 +48,7 @@ StageResult stage_blockhashes(TransactionManager &txn, const std::filesystem::pa
     auto header_key{db::block_key(expected_block_number)};
     auto header_data{canonical_hashes_table.lower_bound(db::to_slice(header_key), /*throw_notfound*/ false)};
     while (header_data) {
-        auto reached_block_number{boost::endian::load_big_u64(static_cast<uint8_t *>(header_data.key.iov_base))};
+        auto reached_block_number{boost::endian::load_big_u64(static_cast<uint8_t*>(header_data.key.iov_base))};
         if (reached_block_number != expected_block_number) {
             // Something wrong with db
             // Blocks are out of sequence for any reason
@@ -63,8 +63,8 @@ StageResult stage_blockhashes(TransactionManager &txn, const std::filesystem::pa
             return StageResult::kBadBlockHash;
         }
 
-        etl::Entry etl_entry{Bytes(static_cast<uint8_t *>(header_data.value.iov_base), header_data.value.iov_len),
-                             Bytes(static_cast<uint8_t *>(header_data.key.iov_base), header_data.key.iov_len)};
+        etl::Entry etl_entry{Bytes(static_cast<uint8_t*>(header_data.value.iov_base), header_data.value.iov_len),
+                             Bytes(static_cast<uint8_t*>(header_data.key.iov_base), header_data.key.iov_len)};
         collector.collect(etl_entry);
 
         // Save last processed block_number and expect next in sequence
@@ -110,18 +110,17 @@ StageResult stage_blockhashes(TransactionManager &txn, const std::filesystem::pa
     return StageResult::kSuccess;
 }
 
-StageResult unwind_blockhashes(TransactionManager &txn, const std::filesystem::path &, uint64_t unwind_to) {
-
+StageResult unwind_blockhashes(TransactionManager& txn, const std::filesystem::path&, uint64_t unwind_to) {
     // We take data from header table and transform it and put it in blockhashes table
     auto canonical_hashes_table{db::open_cursor(*txn, db::table::kCanonicalHashes)};
     auto blockhashes_table{db::open_cursor(*txn, db::table::kHeaderNumbers)};
     // Extract
     SILKWORM_LOG(LogLevel::Info) << "Started BlockHashes Extraction" << std::endl;
 
-    auto header_key{db::block_key(unwind_to+1)};
+    auto header_key{db::block_key(unwind_to + 1)};
     auto header_data{canonical_hashes_table.lower_bound(db::to_slice(header_key), /*throw_notfound*/ false)};
     while (header_data) {
-        if(blockhashes_table.seek(header_data.value)) {
+        if (blockhashes_table.seek(header_data.value)) {
             blockhashes_table.erase(true);
         }
         header_data = canonical_hashes_table.to_next(/*throw_notfound*/ false);

--- a/db/silkworm/stagedsync/stage_blockhashes_test.cpp
+++ b/db/silkworm/stagedsync/stage_blockhashes_test.cpp
@@ -16,6 +16,7 @@
 
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
+#include <evmc/evmc.hpp>
 
 #include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
@@ -31,7 +32,6 @@
 #include <silkworm/types/block.hpp>
 
 #include "stagedsync.hpp"
-#include <evmc/evmc.hpp>
 
 using namespace evmc::literals;
 

--- a/db/silkworm/stagedsync/stage_bodies.cpp
+++ b/db/silkworm/stagedsync/stage_bodies.cpp
@@ -18,7 +18,7 @@
 
 namespace silkworm::stagedsync {
 
-StageResult stage_bodies(TransactionManager &, const std::filesystem::path &) {
+StageResult stage_bodies(TransactionManager&, const std::filesystem::path&) {
     throw std::runtime_error("Not Implemented.");
 }
 

--- a/db/silkworm/stagedsync/stage_headers.cpp
+++ b/db/silkworm/stagedsync/stage_headers.cpp
@@ -18,7 +18,7 @@
 
 namespace silkworm::stagedsync {
 
-StageResult stage_headers(TransactionManager &, const std::filesystem::path &) {
+StageResult stage_headers(TransactionManager&, const std::filesystem::path&) {
     throw std::runtime_error("Not Implemented.");
 }
 

--- a/db/silkworm/stagedsync/stage_interhashes.cpp
+++ b/db/silkworm/stagedsync/stage_interhashes.cpp
@@ -18,11 +18,11 @@
 
 namespace silkworm::stagedsync {
 
-StageResult stage_interhashes(TransactionManager &, const std::filesystem::path &) {
+StageResult stage_interhashes(TransactionManager&, const std::filesystem::path&) {
     throw std::runtime_error("Not Implemented.");
 }
 
-StageResult unwind_interhashes(TransactionManager &, const std::filesystem::path &, uint64_t) {
+StageResult unwind_interhashes(TransactionManager&, const std::filesystem::path&, uint64_t) {
     throw std::runtime_error("Not Implemented.");
 }
 

--- a/db/silkworm/stagedsync/stage_senders.cpp
+++ b/db/silkworm/stagedsync/stage_senders.cpp
@@ -22,7 +22,7 @@ namespace silkworm::stagedsync {
 
 namespace fs = std::filesystem;
 
-StageResult stage_senders(TransactionManager &txn, const std::filesystem::path &etl_path) {
+StageResult stage_senders(TransactionManager& txn, const std::filesystem::path& etl_path) {
     fs::create_directories(etl_path);
     etl::Collector collector(etl_path.string().c_str(), /* flush size */ 512 * kMebi);
 
@@ -43,7 +43,7 @@ StageResult stage_senders(TransactionManager &txn, const std::filesystem::path &
     return res;
 }
 
-StageResult unwind_senders(TransactionManager &txn, const std::filesystem::path &etl_path, uint64_t unwind_point) {
+StageResult unwind_senders(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_point) {
     fs::create_directories(etl_path);
     etl::Collector collector(etl_path.string().c_str(), /* flush size */ 512 * kMebi);
 

--- a/db/silkworm/stagedsync/stagedsync.hpp
+++ b/db/silkworm/stagedsync/stagedsync.hpp
@@ -28,8 +28,8 @@ namespace silkworm::stagedsync {
 
 constexpr size_t kDefaultBatchSize = 512 * kMebi;
 
-typedef StageResult (*StageFunc)(TransactionManager &, const std::filesystem::path &etl_path);
-typedef StageResult (*UnwindFunc)(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
+typedef StageResult (*StageFunc)(TransactionManager&, const std::filesystem::path& etl_path);
+typedef StageResult (*UnwindFunc)(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
 
 struct Stage {
     StageFunc stage_func;
@@ -38,12 +38,12 @@ struct Stage {
 };
 
 // Stage functions
-StageResult stage_headers(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_blockhashes(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_bodies(TransactionManager &, const std::filesystem::path &etl_pat);
-StageResult stage_senders(TransactionManager &, const std::filesystem::path &etl_pat);
-StageResult stage_execution(TransactionManager &, const std::filesystem::path &etl_path, size_t batch_size);
-inline StageResult stage_execution(TransactionManager &txn, const std::filesystem::path &etl_path) {
+StageResult stage_headers(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_blockhashes(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_bodies(TransactionManager&, const std::filesystem::path& etl_pat);
+StageResult stage_senders(TransactionManager&, const std::filesystem::path& etl_pat);
+StageResult stage_execution(TransactionManager&, const std::filesystem::path& etl_path, size_t batch_size);
+inline StageResult stage_execution(TransactionManager& txn, const std::filesystem::path& etl_path) {
     return stage_execution(txn, etl_path, kDefaultBatchSize);
 }
 
@@ -62,29 +62,29 @@ enum class HashstateOperation {
     Code,
 };
 
-void hashstate_promote(mdbx::txn &, HashstateOperation);
-void hashstate_promote_clean_code(mdbx::txn &, std::string);
-void hashstate_promote_clean_state(mdbx::txn &, std::string);
+void hashstate_promote(mdbx::txn&, HashstateOperation);
+void hashstate_promote_clean_code(mdbx::txn&, std::string);
+void hashstate_promote_clean_state(mdbx::txn&, std::string);
 
 /* **************************** */
-StageResult stage_hashstate(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_interhashes(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_account_history(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_storage_history(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_log_index(TransactionManager &, const std::filesystem::path &etl_path);
-StageResult stage_tx_lookup(TransactionManager &, const std::filesystem::path &etl_path);
+StageResult stage_hashstate(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_interhashes(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_account_history(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_storage_history(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_log_index(TransactionManager&, const std::filesystem::path& etl_path);
+StageResult stage_tx_lookup(TransactionManager&, const std::filesystem::path& etl_path);
 
 // Unwind functions
-StageResult no_unwind(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_blockhashes(TransactionManager &txn, const std::filesystem::path &, uint64_t unwind_to);
-StageResult unwind_senders(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_execution(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_hashstate(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_interhashes(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_account_history(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_storage_history(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_log_index(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
-StageResult unwind_tx_lookup(TransactionManager &, const std::filesystem::path &etl_path, uint64_t unwind_to);
+StageResult no_unwind(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_blockhashes(TransactionManager& txn, const std::filesystem::path&, uint64_t unwind_to);
+StageResult unwind_senders(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_execution(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_hashstate(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_interhashes(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_account_history(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_storage_history(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_log_index(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_tx_lookup(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
 
 std::vector<Stage> get_default_stages();
 

--- a/db/silkworm/stagedsync/stages.cpp
+++ b/db/silkworm/stagedsync/stages.cpp
@@ -18,7 +18,7 @@
 
 namespace silkworm::stagedsync {
 
-StageResult no_unwind(TransactionManager &, const std::filesystem::path &, uint64_t) { return StageResult::kSuccess; }
+StageResult no_unwind(TransactionManager&, const std::filesystem::path&, uint64_t) { return StageResult::kSuccess; }
 
 std::vector<Stage> get_default_stages() {
     return {

--- a/db/silkworm/stagedsync/util.hpp
+++ b/db/silkworm/stagedsync/util.hpp
@@ -13,9 +13,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#include <silkworm/common/base.hpp>
+
 #ifndef SILKWORM_STAGEDSYNC_UTIL_HPP_
 #define SILKWORM_STAGEDSYNC_UTIL_HPP_
+
+#include <silkworm/common/base.hpp>
 
 /*
 Part of the compatibility layer with the Erigon DB format;
@@ -44,6 +46,6 @@ void check_stagedsync_error(StageResult code);
 // Convert changesets key and value pair to plain state format
 std::pair<Bytes, Bytes> convert_to_db_format(const ByteView& key, const ByteView& value);
 
-}  // namespace silkworm::db
+}  // namespace silkworm::stagedsync
 
-#endif  // SILKWORM_DB_UTIL_HPP_
+#endif  // SILKWORM_STAGEDSYNC_UTIL_HPP_


### PR DESCRIPTION
Add
```
DerivePointerAlignment: false
PointerAlignment: Left
```
to `.clang-format` and reformat the code.

Most of our code already uses left pointer (and reference) alignment.
