### PR TITLE
First byte histogram

### DIFF
--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -129,4 +129,6 @@ if(NOT SILKWORM_CORE_ONLY)
   add_executable(benchmark_precompile benchmark_precompile.cpp)
   target_link_libraries(benchmark_precompile silkworm_core benchmark::benchmark)
 
+  add_subdirectory(hack)
+
 endif(NOT SILKWORM_CORE_ONLY)

--- a/cmd/hack/CMakeLists.txt
+++ b/cmd/hack/CMakeLists.txt
@@ -1,0 +1,18 @@
+#[[
+   Copyright 2021 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+add_executable(first_byte first_byte.cpp)
+target_link_libraries(first_byte PRIVATE silkworm_node CLI11::CLI11)

--- a/cmd/hack/first_byte.cpp
+++ b/cmd/hack/first_byte.cpp
@@ -1,0 +1,68 @@
+/*
+   Copyright 2021 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <array>
+
+#include <CLI/CLI.hpp>
+
+#include <silkworm/common/data_dir.hpp>
+#include <silkworm/common/log.hpp>
+#include <silkworm/db/mdbx.hpp>
+#include <silkworm/db/stages.hpp>
+#include <silkworm/db/tables.hpp>
+
+int main(int argc, char* argv[]) {
+    using namespace silkworm;
+
+    CLI::App app{"Produce a histogram of the first byte of deployed smart contracts"};
+
+    std::string chaindata{DataDirectory{}.get_chaindata_path().string()};
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+        ->check(CLI::ExistingDirectory);
+
+    CLI11_PARSE(app, argc, argv);
+
+    SILKWORM_LOG(LogLevel::Info) << "Starting. DB: " << chaindata << "\n";
+
+    try {
+        db::EnvConfig db_config{chaindata};
+        auto env{db::open_env(db_config)};
+        auto txn{env.start_read()};
+
+        std::array<size_t, 256> histogram{};
+
+        auto code_table{db::open_cursor(txn, db::table::kCode)};
+        db::for_each(code_table, [&histogram](mdbx::cursor::move_result& entry) {
+            if (entry.value.length() > 0) {
+                uint8_t first_byte{entry.value.at(0)};
+                ++histogram[first_byte];
+            }
+            return true;
+        });
+
+        BlockNum last_block{db::stages::get_stage_progress(txn, db::stages::kExecutionKey)};
+        SILKWORM_LOG(LogLevel::Info) << "Done. Last block: " << last_block << "\n\n";
+
+        for (size_t i{0}; i < 256; ++i) {
+            std::cout << std::hex << i << '\t' << std::dec << histogram[i] << "\n";
+        }
+
+    } catch (const std::exception& ex) {
+        SILKWORM_LOG(LogLevel::Error) << ex.what() << "\n";
+        return -1;
+    }
+    return 0;
+}

--- a/cmd/hack/first_byte.cpp
+++ b/cmd/hack/first_byte.cpp
@@ -44,8 +44,9 @@ int main(int argc, char* argv[]) {
 
         std::array<size_t, 256> histogram{};
 
-        auto code_table{db::open_cursor(txn, db::table::kCode)};
-        db::for_each(code_table, [&histogram](mdbx::cursor::move_result& entry) {
+        auto code_cursor{db::open_cursor(txn, db::table::kCode)};
+        code_cursor.to_first();
+        db::for_each(code_cursor, [&histogram](mdbx::cursor::move_result& entry) {
             if (entry.value.length() > 0) {
                 uint8_t first_byte{entry.value.at(0)};
                 ++histogram[first_byte];

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -34,7 +34,7 @@ namespace silkworm::db {
     if (!config.create) {
         if (!fs::exists(db_path) || !fs::is_directory(db_path) || fs::is_empty(db_path) || !fs::exists(db_file) ||
             !fs::is_regular_file(db_file) || !fs::file_size(db_file)) {
-            throw std::runtime_error("Unable to locate " + db_file.string() + ". Must exist has been set");
+            throw std::runtime_error("Unable to locate " + db_file.string() + ", which is required to exist");
         }
     } else {
         if (!fs::exists(db_path)) {


### PR DESCRIPTION
A utility to calculate the number of smart contracts whose first byte is 0xEF. See [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541).