### PR TITLE
issue #195 - speedup etl by avoiding unnecessary copies

### DIFF
--- a/node/silkworm/etl/collector.cpp
+++ b/node/silkworm/etl/collector.cpp
@@ -57,6 +57,14 @@ void Collector::collect(const Entry& entry) {
     }
 }
 
+void Collector::collect(Entry&& entry) {
+    buffer_.put(std::move(entry));
+    ++size_;
+    if (buffer_.overflows()) {
+        flush_buffer();
+    }
+}
+
 void Collector::load(mdbx::cursor& target, LoadFunc load_func, MDBX_put_flags_t flags, uint32_t log_every_percent) {
     const auto overall_size{size()};  // Amount of work
 

--- a/node/silkworm/etl/collector.hpp
+++ b/node/silkworm/etl/collector.hpp
@@ -44,6 +44,7 @@ class Collector {
     ~Collector();
 
     void collect(const Entry& entry);  // Store key-value pair in memory or on disk
+    void collect(Entry&& entry);       // Store key-value pair in memory or on disk
 
     /** @brief Loads and optionally transforms collected entries into db
      *

--- a/node/silkworm/stagedsync/recovery/recovery_farm.cpp
+++ b/node/silkworm/stagedsync/recovery/recovery_farm.cpp
@@ -248,8 +248,7 @@ bool RecoveryFarm::bufferize_workers_results() {
 
                     auto etl_key{db::block_key(block_num, headers_it_2_->bytes)};
                     Bytes etl_data(db::from_slice(data));
-                    etl::Entry entry{etl_key, etl_data};
-                    collector_.collect(entry);  // TODO check for errors (eg. disk full)
+                    collector_.collect(etl::Entry{etl_key, etl_data});  // TODO check for errors (eg. disk full)
                     headers_it_2_++;
                 }
                 SILKWORM_LOG(LogLevel::Info)

--- a/node/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.cpp
@@ -62,9 +62,8 @@ StageResult stage_blockhashes(TransactionManager& txn, const std::filesystem::pa
             return StageResult::kBadBlockHash;
         }
 
-        etl::Entry etl_entry{Bytes(static_cast<uint8_t*>(header_data.value.iov_base), header_data.value.iov_len),
-                             Bytes(static_cast<uint8_t*>(header_data.key.iov_base), header_data.key.iov_len)};
-        collector.collect(etl_entry);
+        collector.collect(etl::Entry{Bytes(static_cast<uint8_t*>(header_data.value.iov_base), header_data.value.iov_len),
+                                     Bytes(static_cast<uint8_t*>(header_data.key.iov_base), header_data.key.iov_len)});
 
         // Save last processed block_number and expect next in sequence
         ++blocks_processed_count;

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -43,8 +43,7 @@ static StageResult history_index_stage(TransactionManager& txn, const std::files
         for (const auto& [bitmap_key, bitmap] : bitmaps) {
             Bytes bitmap_bytes(bitmap.getSizeInBytes(), '\0');
             bitmap.write(byte_ptr_cast(bitmap_bytes.data()));
-            etl::Entry entry{Bytes(byte_ptr_cast(bitmap_key.c_str()), bitmap_key.size()), bitmap_bytes};
-            collector.collect(entry);
+            collector.collect(etl::Entry{Bytes(byte_ptr_cast(bitmap_key.c_str()), bitmap_key.size()), bitmap_bytes});
         }
         bitmaps.clear();
     };
@@ -195,8 +194,7 @@ StageResult history_index_unwind(TransactionManager& txn, const std::filesystem:
                 std::memcpy(&new_key[0], key.data(), key.size());
                 endian::store_big_u32(&new_key[new_key.size() - 4], UINT32_MAX);
                 // replace with new index
-                etl::Entry entry{new_key, new_bitmap};
-                collector.collect(entry);
+                collector.collect(etl::Entry{new_key, new_bitmap});
             }
             index_table.erase(/* whole_multivalue = */ true);
             data = index_table.to_next(/*throw_notfound*/ false);

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -68,8 +68,7 @@ static void flush_bitmaps(etl::Collector& collector, std::unordered_map<std::str
     for (const auto& [key, bm] : map) {
         Bytes bitmap_bytes(bm.getSizeInBytes(), '\0');
         bm.write(byte_ptr_cast(bitmap_bytes.data()));
-        etl::Entry entry{Bytes(byte_ptr_cast(key.c_str()), key.size()), bitmap_bytes};
-        collector.collect(entry);
+        collector.collect(etl::Entry{Bytes(byte_ptr_cast(key.c_str()), key.size()), bitmap_bytes});
     }
     map.clear();
 }
@@ -188,8 +187,7 @@ static StageResult unwind_log_index(TransactionManager& txn, etl::Collector& col
                 std::memcpy(&new_key[0], key.data(), key.size());
                 endian::store_big_u32(&new_key[new_key.size() - 4], UINT32_MAX);
                 // collect higher bitmap
-                etl::Entry entry{new_key, new_bitmap};
-                collector.collect(entry);
+                collector.collect(etl::Entry{new_key, new_bitmap});
             }
             // erase index
             index_table.erase(true);

--- a/node/silkworm/trie/intermediate_hashes.cpp
+++ b/node/silkworm/trie/intermediate_hashes.cpp
@@ -82,7 +82,7 @@ DbTrieLoader::DbTrieLoader(mdbx::txn& txn, etl::Collector& account_collector, et
         etl::Entry e;
         e.key = unpacked_key;
         e.value = marshal_node(node);
-        account_collector.collect(e);
+        account_collector.collect(std::move(e));
     };
 }
 
@@ -135,7 +135,7 @@ evmc::bytes32 DbTrieLoader::calculate_root() {
                 storage_hb.node_collector = [&](ByteView unpacked_key, const Node& node) {
                     etl::Entry e{acc_with_inc, marshal_node(node)};
                     e.key.append(unpacked_key);
-                    storage_collector_.collect(e);
+                    storage_collector_.collect(std::move(e));
                 };
 
                 for (storage_trie.seek_to_account(acc_with_inc);; storage_trie.next()) {


### PR DESCRIPTION
I haven't tested it besides running core_test and node_test, but it is simple enough that it should work and avoid unnecessary etl::Entry copies.
Each etl::Entry copy will cause two `malloc()` when allocating the new std::basic_string, two data copies,  and two `free()` when the original is destructed. Doing a move avoids all this.