### PR TITLE
Gather concurrency things in silkworm/concurrency

### DIFF
--- a/cmd/check_senders.cpp
+++ b/cmd/check_senders.cpp
@@ -28,7 +28,7 @@
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/log.hpp>
-#include <silkworm/common/worker.hpp>
+#include <silkworm/concurrency/worker.hpp>
 #include <silkworm/crypto/ecdsa.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/mdbx.hpp>

--- a/node/silkworm/concurrency/active_component.hpp
+++ b/node/silkworm/concurrency/active_component.hpp
@@ -14,10 +14,10 @@
    limitations under the License.
 */
 
-#include <atomic>
+#ifndef SILKWORM_CONCURRENCY_ACTIVE_COMPONENT_HPP_
+#define SILKWORM_CONCURRENCY_ACTIVE_COMPONENT_HPP_
 
-#ifndef SILKWORM_ACTIVECOMPONENT_H
-#define SILKWORM_ACTIVECOMPONENT_H
+#include <atomic>
 
 namespace silkworm {
 
@@ -28,19 +28,18 @@ namespace silkworm {
  * Here we prefer not to provide a thread facility and let the user provide one more suitable to the context,
  * so perhaps a better name is LongRunningComponent.
  */
-
 class ActiveComponent {
   public:
     virtual void execution_loop() = 0;
 
-    void need_exit() { exiting_.store(true); }
+    void stop() { stopping_.store(true); }
 
-    bool exiting() { return exiting_.load(); }
+    bool is_stopping() const { return stopping_.load(); }
 
   protected:
-    std::atomic<bool> exiting_{false};
+    std::atomic<bool> stopping_{false};
 };
 
-} // namespace silkworm
+}  // namespace silkworm
 
-#endif  // SILKWORM_ACTIVECOMPONENT_H
+#endif  // SILKWORM_CONCURRENCY_ACTIVE_COMPONENT_HPP_

--- a/node/silkworm/concurrency/containers.hpp
+++ b/node/silkworm/concurrency/containers.hpp
@@ -14,16 +14,17 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_CONCURRENTCONTAINERS_HPP
-#define SILKWORM_CONCURRENTCONTAINERS_HPP
+#ifndef SILKWORM_CONCURRENCY_CONTAINERS_HPP_
+#define SILKWORM_CONCURRENCY_CONTAINERS_HPP_
 
 /*
  * Decisions about concurrent containers
  */
 
-#include "ThreadSafeQueue.hpp"
+#include <silkworm/concurrency/thread_safe_queue.hpp>
 
 template <typename T>
-using ConcurrentQueue = ThreadSafeQueue<T>;  // todo: use a better alternative from a known library (Intel oneTBB concurrent_queue<T>?)
+using ConcurrentQueue =
+    ThreadSafeQueue<T>;  // todo: use a better alternative from a known library (Intel oneTBB concurrent_queue<T>?)
 
-#endif  // SILKWORM_CONCURRENTCONTAINERS_HPP
+#endif  // SILKWORM_CONCURRENCY_CONTAINERS_HPP_

--- a/node/silkworm/concurrency/worker.hpp
+++ b/node/silkworm/concurrency/worker.hpp
@@ -24,6 +24,7 @@
 
 namespace silkworm {
 
+// If you only need stoppability, use ActiveComponent instead.
 class Worker {
   public:
     enum class WorkerState { kStopped, kStarting, kStarted, kStopping };

--- a/node/silkworm/concurrency/worker.hpp
+++ b/node/silkworm/concurrency/worker.hpp
@@ -31,7 +31,7 @@ class Worker {
 
     Worker() = default;
 
-    /* Not moveable / copyable */
+    /* Not movable nor copyable */
     Worker(Worker const&) = delete;
     Worker& operator=(Worker const&) = delete;
 
@@ -41,7 +41,7 @@ class Worker {
     void stop(bool wait = false);  // Stops worker thread (optionally wait for complete stop)
     void kick();                   // Kicks worker thread if waiting
 
-    // Whether or not this worker/thread should stop
+    // Whether this worker/thread has received a stopping request
     bool is_stopping() const { return state_.load() == WorkerState::kStopping; }
 
     // Retrieves current state of thread
@@ -54,10 +54,10 @@ class Worker {
      * Returns True if the kick has been received and should go ahead
      * otherwise False (i.e. the thread has been asked to stop)
      *
-     * @param timeout: Timeout for conditional variable wait (seconds)
+     * @param [in] timeout: Timeout for conditional variable wait (seconds). Defaults to 1 second
      */
     bool wait_for_kick(uint32_t timeout_seconds = 1);  // Puts a thread in non-busy wait for data to process
-    std::atomic_bool kicked_{false};                   // Whether or not the kick has been received
+    std::atomic_bool kicked_{false};                   // Whether the kick has been received
     std::condition_variable kicked_cv_{};              // Condition variable to wait for kick
     std::mutex kick_mtx_{};                            // Mutex for conditional wait of kick
 

--- a/node/silkworm/concurrency/worker.hpp
+++ b/node/silkworm/concurrency/worker.hpp
@@ -41,7 +41,7 @@ class Worker {
     void stop(bool wait = false);  // Stops worker thread (optionally wait for complete stop)
     void kick();                   // Kicks worker thread if waiting
 
-    // Whether this worker/thread has received a stopping request
+    // Whether this worker/thread has received a stop request
     bool is_stopping() const { return state_.load() == WorkerState::kStopping; }
 
     // Retrieves current state of thread

--- a/node/silkworm/concurrency/worker.hpp
+++ b/node/silkworm/concurrency/worker.hpp
@@ -14,8 +14,8 @@
    limitations under the License.
 */
 
-#ifndef SILKWORM_WORKER_HPP_
-#define SILKWORM_WORKER_HPP_
+#ifndef SILKWORM_CONCURRENCY_WORKER_HPP_
+#define SILKWORM_CONCURRENCY_WORKER_HPP_
 
 #include <atomic>
 #include <condition_variable>
@@ -41,7 +41,7 @@ class Worker {
     void kick();                   // Kicks worker thread if waiting
 
     // Whether or not this worker/thread should stop
-    bool should_stop() { return state_.load() == WorkerState::kStopping; }
+    bool is_stopping() const { return state_.load() == WorkerState::kStopping; }
 
     // Retrieves current state of thread
     WorkerState get_state() { return state_.load(); }
@@ -65,6 +65,7 @@ class Worker {
     std::unique_ptr<std::thread> thread_{nullptr};
     virtual void work() = 0;  // Derived classes must override
 };
+
 }  // namespace silkworm
 
-#endif  // SILKWORM_WORKER_HPP_
+#endif  // SILKWORM_CONCURRENCY_WORKER_HPP_

--- a/node/silkworm/downloader/SentryClient.cpp
+++ b/node/silkworm/downloader/SentryClient.cpp
@@ -20,13 +20,10 @@
 
 namespace silkworm {
 
-SentryClient::SentryClient(std::string sentry_addr): base_t(grpc::CreateChannel(sentry_addr, grpc::InsecureChannelCredentials())) {
+SentryClient::SentryClient(std::string sentry_addr)
+    : base_t(grpc::CreateChannel(sentry_addr, grpc::InsecureChannelCredentials())) {}
 
-}
-
-void SentryClient::exec_remotely(std::shared_ptr<SentryRpc> rpc) {
-    base_t::exec_remotely(rpc);
-}
+void SentryClient::exec_remotely(std::shared_ptr<SentryRpc> rpc) { base_t::exec_remotely(rpc); }
 
 std::shared_ptr<SentryRpc> SentryClient::receive_one_reply() {
     // check the gRPC queue, and trigger gRPC processing (gRPC will create a message)
@@ -37,11 +34,10 @@ std::shared_ptr<SentryRpc> SentryClient::receive_one_reply() {
         auto status = executed_rpc->status();
         if (status.ok()) {
             SILKWORM_LOG(LogLevel::Trace) << "RPC ok, " << executed_rpc->name() << "\n";
-        }
-        else {
+        } else {
             SILKWORM_LOG(LogLevel::Warn) << "RPC failed, " << executed_rpc->name() << ", error: '"
-                << status.error_message() << "', code: " << status.error_code()
-                << ", details: " << status.error_details() << std::endl;
+                                         << status.error_message() << "', code: " << status.error_code()
+                                         << ", details: " << status.error_details() << std::endl;
         }
     }
 
@@ -50,15 +46,16 @@ std::shared_ptr<SentryRpc> SentryClient::receive_one_reply() {
 
 void ActiveSentryClient::execution_loop() {
     try {
-        while (!exiting_) {
+        while (!stopping_) {
             receive_one_reply();
         }
     } catch (const std::exception& e) {
-        SILKWORM_LOG(LogLevel::Critical) << "SentryClient execution_loop exiting due to exception: " << e.what() << "\n";
+        SILKWORM_LOG(LogLevel::Critical) << "SentryClient execution_loop exiting due to exception: " << e.what()
+                                         << "\n";
         throw e;
     }
 
     SILKWORM_LOG(LogLevel::Info) << "SentryClient execution_loop exiting...\n";
 }
 
-} // namespace silkworm
+}  // namespace silkworm

--- a/node/silkworm/downloader/SentryClient.hpp
+++ b/node/silkworm/downloader/SentryClient.hpp
@@ -13,13 +13,16 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
 #ifndef SILKWORM_SENTRYCLIENT_HPP
 #define SILKWORM_SENTRYCLIENT_HPP
 
 #include <interfaces/sentry.grpc.pb.h>
+
+#include <silkworm/concurrency/active_component.hpp>
+
 #include "TypesForGrpc.hpp"
 #include "gRPCAsyncClient.hpp"
-#include "ActiveComponent.hpp"
 
 namespace silkworm {
 
@@ -48,10 +51,11 @@ class SentryClient : public rpc::AsyncClient<sentry::Sentry> {
 // A SentryClient with an infinite loop to receive rpc forever
 class ActiveSentryClient : public SentryClient, public ActiveComponent {
   public:
-    using SentryClient::SentryClient;   // use parent constructor
+    using SentryClient::SentryClient;  // use parent constructor
 
     virtual void execution_loop();
 };
 
-}
+}  // namespace silkworm
+
 #endif  // SILKWORM_SENTRYCLIENT_HPP

--- a/node/silkworm/downloader/gRPCAsyncClient.hpp
+++ b/node/silkworm/downloader/gRPCAsyncClient.hpp
@@ -17,23 +17,21 @@
 #ifndef SILKWORM_GRPCASYNCCLIENT_HPP
 #define SILKWORM_GRPCASYNCCLIENT_HPP
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 #include <grpcpp/grpcpp.h>
 
+#include <silkworm/chain/config.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>
-#include <silkworm/db/util.hpp>
 #include <silkworm/db/tables.hpp>
-
-#include <silkworm/chain/config.hpp>
+#include <silkworm/db/util.hpp>
 
 #include "Types.hpp"
-#include "ConcurrentContainers.hpp"
 
 //#define UNUSED(x) (void)(x) - Replaced by [[maybe_unused]]
 
@@ -55,22 +53,23 @@ class AsyncCall {
     // Virtual destructor allows correct child destruction
     virtual ~AsyncCall() = default;
 
-    void on_receive_reply(callback_t f) {callback_ = f;}
+    void on_receive_reply(callback_t f) { callback_ = f; }
 
     virtual bool terminated() { return terminated_; };
 
     grpc::Status status() {
-        if (!terminated_)
+        if (!terminated_) {
             throw std::logic_error("AsyncCall status not ready");
+        }
         return status_;
     }
 
-    void* tag() {return tag_;}
+    void* tag() { return tag_; }
 
-    std::string name() {return name_;}
+    std::string name() { return name_; }
 
   protected:
-    friend class AsyncClient<STUB>; // only to give access to start & reply_received
+    friend class AsyncClient<STUB>;  // only to give access to start & reply_received
 
     // Start the remote proc call sending request to the server
     virtual void start(typename STUB::Stub* stub, grpc::CompletionQueue* cq) = 0;
@@ -79,9 +78,9 @@ class AsyncCall {
     virtual void reply_received(bool ok) = 0;
 
     // See concrete implementations for a public constructor
-    AsyncCall(std::string name): name_(std::move(name)) { tag_ = static_cast<void*>(this); }
+    AsyncCall(std::string name) : name_(std::move(name)) { tag_ = static_cast<void*>(this); }
 
-    static AsyncCall<STUB>* detag(void* tag) {return static_cast<AsyncCall<STUB>*>(tag);}  // UNSAFE
+    static AsyncCall<STUB>* detag(void* tag) { return static_cast<AsyncCall<STUB>*>(tag); }  // UNSAFE
 
     // Name, used for logging purposes
     std::string name_;
@@ -111,12 +110,12 @@ class AsyncClient {
     using stub_t = STUB;
     using call_t = AsyncCall<STUB>;
 
-    explicit AsyncClient(std::shared_ptr<grpc::Channel> channel)
-        : channel_(channel), stub_(stub_t::NewStub(channel)) {}
+    explicit AsyncClient(std::shared_ptr<grpc::Channel> channel) : channel_(channel), stub_(stub_t::NewStub(channel)) {}
 
     // send an remote call asynchronously
     void exec_remotely(std::shared_ptr<call_t> call) {
-        call->pin_ = call; // trick to save shared_ptr and extend call lifetime without using a queue, not so beautiful, todo: improve
+        call->pin_ = call;  // trick to save shared_ptr and extend call lifetime without using a queue,
+                            // not so beautiful, todo: improve
         call->start(stub_.get(), &completionQueue_);
     }
 
@@ -129,11 +128,13 @@ class AsyncClient {
 
         // Block until the next result is available in the completion queue
         bool got_event = completionQueue_.Next(&got_tag, &ok);  // todo: use AsyncNext to support a timeout
-        if (!got_event) // the queue is fully drained and shut down
+        if (!got_event) {
+            // the queue is fully drained and shut down
             return nullptr;
+        }
 
         // The tag in this example is the memory location of the call object
-        call_t* raw_call = call_t::detag(got_tag); // UNSAFE
+        call_t* raw_call = call_t::detag(got_tag);  // UNSAFE
         std::shared_ptr<call_t> call = raw_call->pin_;
 
         // Verify that the request was completed successfully. Note that "ok"
@@ -143,8 +144,9 @@ class AsyncClient {
         // Delegate status & reply handling to the call
         call->reply_received(ok);
 
-        if (call->terminated())
+        if (call->terminated()) {
             call->pin_.reset();
+        }
 
         // Return the call for custom processing or deletion
         return call;
@@ -152,33 +154,33 @@ class AsyncClient {
 
   protected:
     std::shared_ptr<grpc::Channel> channel_;
-    std::unique_ptr<typename STUB::Stub> stub_; // the stub class generated from grpc proto
-    grpc::CompletionQueue completionQueue_;  // receives async-call completion events from the gRPC runtime
+    std::unique_ptr<typename STUB::Stub> stub_;  // the stub class generated from grpc proto
+    grpc::CompletionQueue completionQueue_;      // receives async-call completion events from the gRPC runtime
 };
 
 // AsyncUnaryCall -----------------------------------------------------------------------------------------------------
 template <class STUB, class REQUEST, class REPLY>
-class AsyncUnaryCall: public AsyncCall<STUB> {
+class AsyncUnaryCall : public AsyncCall<STUB> {
   public:
     using call_t = AsyncCall<STUB>;
     using request_t = REQUEST;
     using reply_t = REPLY;
     using response_reader_t = std::unique_ptr<grpc::ClientAsyncResponseReader<reply_t>>;
-    using prepare_call_t = response_reader_t (STUB::Stub::*)(grpc::ClientContext* context, const request_t& request, grpc::CompletionQueue* cq);
-    //using callback_t = std::function<void(AsyncUnaryCall&)>;
+    using prepare_call_t = response_reader_t (STUB::Stub::*)(grpc::ClientContext* context, const request_t& request,
+                                                             grpc::CompletionQueue* cq);
+    // using callback_t = std::function<void(AsyncUnaryCall&)>;
     using call_t::context_, call_t::status_, call_t::tag_;
 
-    AsyncUnaryCall(std::string name, prepare_call_t pc, request_t request) : call_t{std::move(name)}, prepare_call_{pc}, request_{std::move(request)} {
-    }
+    AsyncUnaryCall(std::string name, prepare_call_t pc, request_t request)
+        : call_t{std::move(name)}, prepare_call_{pc}, request_{std::move(request)} {}
 
     virtual ~AsyncUnaryCall() = default;
 
-    //void on_complete(callback_t f) {callback_ = f;}
+    // void on_complete(callback_t f) {callback_ = f;}
 
-    reply_t& reply() {return reply_;}
+    reply_t& reply() { return reply_; }
 
   protected:
-
     void start(typename STUB::Stub* stub, grpc::CompletionQueue* cq) override {
         response_reader_ = (stub->*prepare_call_)(&context_, request_, cq);  // creates an RPC object
 
@@ -191,36 +193,38 @@ class AsyncUnaryCall: public AsyncCall<STUB> {
         call_t::terminated_ = true;
 
         // use status & reply
-        if (call_t::callback_)
+        if (call_t::callback_) {
             call_t::callback_(*this);
+        }
     }
 
-    prepare_call_t prepare_call_; // Pointer to the prepare call method of the Stub
+    prepare_call_t prepare_call_;  // Pointer to the prepare call method of the Stub
 
-    response_reader_t response_reader_; // return type of the prepare call method of the Stub
+    response_reader_t response_reader_;  // return type of the prepare call method of the Stub
 
-    request_t request_; // Container for the request we send to the server
+    request_t request_;  // Container for the request we send to the server
 
-    reply_t reply_; // Container for the data we expect from the server.
+    reply_t reply_;  // Container for the data we expect from the server.
 
-    //callback_t callback_; // Callback that will be called on completion (i.e. response arrival)
+    // callback_t callback_; // Callback that will be called on completion (i.e. response arrival)
 };
 
 // AsyncOutStreamingCall ----------------------------------------------------------------------------------------------
 // A generic async RPC call with preparation, executing and reply handling
 template <class STUB, class REQUEST, class REPLY>
-class AsyncOutStreamingCall: public AsyncCall<STUB> {
+class AsyncOutStreamingCall : public AsyncCall<STUB> {
   public:
     using call_t = AsyncCall<STUB>;
     using request_t = REQUEST;
     using reply_t = REPLY;
     using response_reader_t = std::unique_ptr<::grpc::ClientAsyncReader<reply_t>>;
-    using prepare_call_t = response_reader_t (STUB::Stub::*)(grpc::ClientContext* context, const request_t& request, grpc::CompletionQueue* cq);
-    //using callback_t = std::function<void(AsyncOutStreamingCall&)>;
+    using prepare_call_t = response_reader_t (STUB::Stub::*)(grpc::ClientContext* context, const request_t& request,
+                                                             grpc::CompletionQueue* cq);
+    // using callback_t = std::function<void(AsyncOutStreamingCall&)>;
     using call_t::context_, call_t::status_, call_t::tag_;
 
-    AsyncOutStreamingCall(std::string name, prepare_call_t pc, const request_t& request): call_t{std::move(name)}, prepare_call_{pc}, request_{std::move(request)} {
-    }
+    AsyncOutStreamingCall(std::string name, prepare_call_t pc, const request_t& request)
+        : call_t{std::move(name)}, prepare_call_{pc}, request_{std::move(request)} {}
 
     ~AsyncOutStreamingCall() {
         if (!call_t::terminated_) {
@@ -230,9 +234,9 @@ class AsyncOutStreamingCall: public AsyncCall<STUB> {
         // no one will be able to check status_.ok(), maybe we need to have a stop method / todo: provide a stop method
     }
 
-    //void on_complete(callback_t f) {callback_ = f;}
+    // void on_complete(callback_t f) {callback_ = f;}
 
-    reply_t& reply() {return reply_;}
+    reply_t& reply() { return reply_; }
 
   protected:
     void start(typename STUB::Stub* stub, grpc::CompletionQueue* cq) override {
@@ -242,43 +246,45 @@ class AsyncOutStreamingCall: public AsyncCall<STUB> {
     }
 
     void reply_received(bool ok) override {
-        if (!ok) {         // todo: check if it is correct!
-            response_reader_->Finish(&status_, tag_);   // this will populate status with the error condition
+        if (!ok) {                                     // todo: check if it is correct!
+            response_reader_->Finish(&status_, tag_);  // this will populate status with the error condition
             call_t::terminated_ = true;
         }
 
         if (!started_) {
             started_ = true;
-            response_reader_->Read(&reply_, tag_); // we have an output stream so we need call Read
+            response_reader_->Read(&reply_, tag_);  // we have an output stream so we need call Read
             return;
         }
 
         // use status & reply
-        if (call_t::callback_)
+        if (call_t::callback_) {
             call_t::callback_(*this);
+        }
 
-        if (call_t::terminated_)
-            return;     // exceptional path
+        if (call_t::terminated_) {
+            return;  // exceptional path
+        }
 
         // todo: erase reply_ ?
         reply_ = {};
 
         // request next message
-        response_reader_->Read(&reply_, tag_); // we have an output stream so we need call Read
+        response_reader_->Read(&reply_, tag_);  // we have an output stream so we need call Read
     }
 
-    prepare_call_t prepare_call_; // Pointer to the prepare call method of the Stub
+    prepare_call_t prepare_call_;  // Pointer to the prepare call method of the Stub
 
-    response_reader_t response_reader_; // return type of the prepare call method of the Stub
+    response_reader_t response_reader_;  // return type of the prepare call method of the Stub
 
-    request_t request_; // Container for the request we send to the server
+    request_t request_;  // Container for the request we send to the server
 
-    reply_t reply_; // Container for the data we expect from the server
+    reply_t reply_;  // Container for the data we expect from the server
 
     bool started_ = false;
-    //callback_t callback_; // Callback that will be called on completion (i.e. response arrival)
+    // callback_t callback_; // Callback that will be called on completion (i.e. response arrival)
 };
 
-} // namespace end
+}  // namespace silkworm::rpc
 
 #endif  // SILKWORM_GRPCASYNCCLIENT_HPP

--- a/node/silkworm/downloader/stage1.cpp
+++ b/node/silkworm/downloader/stage1.cpp
@@ -22,27 +22,20 @@
 
 #include "HeaderLogic.hpp"
 #include "messages/InboundMessage.hpp"
+#include "rpc/PeerMinBlock.hpp"
 #include "rpc/ReceiveMessages.hpp"
-#include "rpc/SetStatus.hpp"
 #include "rpc/SendMessageById.hpp"
 #include "rpc/SendMessageByMinBlock.hpp"
-#include "rpc/PeerMinBlock.hpp"
+#include "rpc/SetStatus.hpp"
 
 namespace silkworm {
 
 std::string result(std::shared_ptr<SentryRpc> rpc);  // for logging purposes
 
+BlockProvider::BlockProvider(ActiveSentryClient& sentry, ChainIdentity chain_identity, std::string db_path)
+    : chain_identity_(std::move(chain_identity)), db_{db_path}, sentry_{sentry} {}
 
-BlockProvider::BlockProvider(ActiveSentryClient& sentry, ChainIdentity chain_identity, std::string db_path):
-    chain_identity_(std::move(chain_identity)),
-    db_{db_path},
-    sentry_{sentry}
-{
-}
-
-BlockProvider::~BlockProvider() {
-    SILKWORM_LOG(LogLevel::Error) << "BlockProvider destroyed\n";
-}
+BlockProvider::~BlockProvider() { SILKWORM_LOG(LogLevel::Error) << "BlockProvider destroyed\n"; }
 
 void BlockProvider::send_status() {
     HeaderRetrieval headers(db_);
@@ -50,20 +43,20 @@ void BlockProvider::send_status() {
     auto set_status = rpc::SetStatus::make(chain_identity_.chain, chain_identity_.genesis_hash,
                                            chain_identity_.distinct_fork_numbers(), head_hash, head_td);
     set_status->on_receive_reply([&, set_status](auto& call) {
-      if (!call.status().ok()) {
-          exiting_ = true;
-          sentry_.need_exit();
-          SILKWORM_LOG(LogLevel::Critical)
-              << "BlockProvider failed to set status to the remote sentry, cause:'" << call.status().error_message() << "', exiting...\n";
-          return;
-      }
-      SILKWORM_LOG(LogLevel::Trace) << "set-status reply arrived\n";
-      sentry::SetStatusReply& reply = set_status->reply();
-      sentry::Protocol supported_protocol = reply.protocol();
-      if (supported_protocol != sentry::Protocol::ETH66) {
-          exiting_ = true;
-          SILKWORM_LOG(LogLevel::Critical) << "BlockProvider: sentry do not support eth/66 protocol, exiting...\n";
-      }
+        if (!call.status().ok()) {
+            stopping_ = true;
+            sentry_.stop();
+            SILKWORM_LOG(LogLevel::Critical) << "BlockProvider failed to set status to the remote sentry, cause:'"
+                                             << call.status().error_message() << "', exiting...\n";
+            return;
+        }
+        SILKWORM_LOG(LogLevel::Trace) << "set-status reply arrived\n";
+        sentry::SetStatusReply& reply = set_status->reply();
+        sentry::Protocol supported_protocol = reply.protocol();
+        if (supported_protocol != sentry::Protocol::ETH66) {
+            stopping_ = true;
+            SILKWORM_LOG(LogLevel::Critical) << "BlockProvider: sentry do not support eth/66 protocol, exiting...\n";
+        }
     });
     sentry_.exec_remotely(set_status);
 }
@@ -72,25 +65,25 @@ void BlockProvider::send_message_subscription(MessageQueue& messages) {
     // create a message subscription rpc
     auto receive_messages = rpc::ReceiveMessages::make();
     receive_messages->on_receive_reply([&, receive_messages](auto& call) {
-      // warning: this code will be executed in a foreign thread
-      SILKWORM_LOG(LogLevel::Trace) << "BlockProvider, receive-messages reply arrived\n";
-      if (!call.terminated()) {
-          // receiving a message... copy it in the message queue for later processing
-          sentry::InboundMessage& reply = receive_messages->reply();
+        // warning: this code will be executed in a foreign thread
+        SILKWORM_LOG(LogLevel::Trace) << "BlockProvider, receive-messages reply arrived\n";
+        if (!call.terminated()) {
+            // receiving a message... copy it in the message queue for later processing
+            sentry::InboundMessage& reply = receive_messages->reply();
 
-          auto message = InboundBlockRequestMessage::make_from_raw_message(reply, db_);
-          if (message) {
-              SILKWORM_LOG(LogLevel::Info) << "BlockProvider, message received from remote peer " << identify(*message) << "\n";
-              messages.push(message);
-          }
-      }
-      else {
-          // this call is a long running call, if it terminates there was an error on the link with the sentry
-          exiting_ = true;
-          sentry_.need_exit();
-          SILKWORM_LOG(LogLevel::Critical)
-              << "BlockProvider receiving messages stream interrupted, cause:'" << call.status().error_message() << "', exiting...\n";
-      }
+            auto message = InboundBlockRequestMessage::make_from_raw_message(reply, db_);
+            if (message) {
+                SILKWORM_LOG(LogLevel::Info)
+                    << "BlockProvider, message received from remote peer " << identify(*message) << "\n";
+                messages.push(message);
+            }
+        } else {
+            // this call is a long running call, if it terminates there was an error on the link with the sentry
+            stopping_ = true;
+            sentry_.stop();
+            SILKWORM_LOG(LogLevel::Critical) << "BlockProvider receiving messages stream interrupted, cause:'"
+                                             << call.status().error_message() << "', exiting...\n";
+        }
     });
 
     // send the subscription rpc
@@ -103,7 +96,9 @@ void BlockProvider::process_one_message(MessageQueue& messages) {
     // pop a message from the queue
     std::shared_ptr<Message> message;
     bool present = messages.timed_wait_and_pop(message, 1000ms);
-    if (!present) return;   // timeout, needed to check exiting_
+    if (!present) {
+        return;  // timeout, needed to check stopping_
+    }
 
     if (std::dynamic_pointer_cast<InboundMessage>(message)) {
         SILKWORM_LOG(LogLevel::Info) << "Processing message " << *message << "\n";
@@ -113,11 +108,14 @@ void BlockProvider::process_one_message(MessageQueue& messages) {
     auto rpc_bundle = message->execute();
 
     // send remote rpcs if the message need them as result of processing
-    for(auto& rpc: rpc_bundle) {
-        SILKWORM_LOG(LogLevel::Info) << "BlockProvider replying to " << identify(*message) << " with " << rpc->name() << "\n";
+    for (auto& rpc : rpc_bundle) {
+        SILKWORM_LOG(LogLevel::Info) << "BlockProvider replying to " << identify(*message) << " with " << rpc->name()
+                                     << "\n";
 
-        rpc->on_receive_reply([message, rpc](auto&) { // copy message and rpc to retain their lifetime (shared_ptr) [avoid rpc passing using make_shared_from_this in AsyncCall]
-            SILKWORM_LOG(LogLevel::Info) << "Received rpc result of " << identify(*message) << ": " << result(rpc) << "\n";
+        rpc->on_receive_reply([message, rpc](auto&) {  // copy message and rpc to retain their lifetime (shared_ptr)
+                                                       // [avoid rpc passing using make_shared_from_this in AsyncCall]
+            SILKWORM_LOG(LogLevel::Info) << "Received rpc result of " << identify(*message) << ": " << result(rpc)
+                                         << "\n";
         });
 
         sentry_.exec_remotely(rpc);
@@ -129,25 +127,24 @@ void BlockProvider::execution_loop() {
     using namespace std::chrono_literals;
 
     // set status
-    send_status(); // todo: use a future to wait the result and decide if break or continue, erase the following line
-    std::this_thread::sleep_for(3s); // wait for connection setup before submit other requests
+    send_status();  // todo: use a future to wait the result and decide if break or continue, erase the following line
+    std::this_thread::sleep_for(3s);  // wait for connection setup before submit other requests
 
     // thread safe queue where receive messages from sentry thread
     MessageQueue messages{};
 
     // start message receiving (headers & blocks requests)
-    send_message_subscription(messages); // messages will be copied in the message queue
+    send_message_subscription(messages);  // messages will be copied in the message queue
 
     // message processing
     try {
-        while (!exiting_ && !sentry_.exiting()) {
+        while (!stopping_ && !sentry_.is_stopping()) {
             process_one_message(messages);  // pop a message from the queue and process it
         }
-    }
-    catch(const std::exception& e) {
+    } catch (const std::exception& e) {
         SILKWORM_LOG(LogLevel::Error) << "BlockProvider execution_loop exiting due to exception: " << e.what() << "\n";
-        exiting_ = true;
-        sentry_.need_exit();
+        stopping_ = true;
+        sentry_.stop();
     }
 
     SILKWORM_LOG(LogLevel::Info) << "BlockProvider execution_loop exiting...\n";
@@ -175,4 +172,3 @@ std::string result(std::shared_ptr<SentryRpc> rpc) {
 }
 
 }  // namespace silkworm
-

--- a/node/silkworm/downloader/stage1.hpp
+++ b/node/silkworm/downloader/stage1.hpp
@@ -16,13 +16,12 @@
 #ifndef SILKWORM_STAGE1_HPP
 #define SILKWORM_STAGE1_HPP
 
-#include <atomic>
 #include <chrono>
 
 #include <silkworm/chain/identity.hpp>
+#include <silkworm/concurrency/active_component.hpp>
+#include <silkworm/concurrency/containers.hpp>
 
-#include "ActiveComponent.hpp"
-#include "ConcurrentContainers.hpp"
 #include "DbTx.hpp"
 #include "SentryClient.hpp"
 #include "Singleton.hpp"
@@ -30,7 +29,6 @@
 #include "messages/Message.hpp"
 
 namespace silkworm {
-
 
 class BlockProvider : public ActiveComponent {  // but also an active component that must run always
 
@@ -40,8 +38,8 @@ class BlockProvider : public ActiveComponent {  // but also an active component 
 
   public:
     BlockProvider(ActiveSentryClient& sentry, ChainIdentity chain_identity, std::string db_path);
-    BlockProvider(const BlockProvider&) = delete; // not copyable
-    BlockProvider(BlockProvider&&) = delete; // nor movable
+    BlockProvider(const BlockProvider&) = delete;  // not copyable
+    BlockProvider(BlockProvider&&) = delete;       // nor movable
     ~BlockProvider();
 
     DbTx& db_tx() { return db_; }

--- a/node/silkworm/stagedsync/recovery/recovery_worker.cpp
+++ b/node/silkworm/stagedsync/recovery/recovery_worker.cpp
@@ -64,7 +64,7 @@ void RecoveryWorker::work() {
                 block_result_offset += block_result_length;
                 block_result_length = 0;
                 block_num = package.block_num;
-                if (should_stop()) {
+                if (is_stopping()) {
                     status_.store(Status::Aborted);
                     break;
                 }

--- a/node/silkworm/stagedsync/recovery/recovery_worker.hpp
+++ b/node/silkworm/stagedsync/recovery/recovery_worker.hpp
@@ -26,7 +26,7 @@
 
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/log.hpp>
-#include <silkworm/common/worker.hpp>
+#include <silkworm/concurrency/worker.hpp>
 #include <silkworm/crypto/ecdsa.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>


### PR DESCRIPTION
Move `ActiveComponent`, `ThreadSafeQueue`, and `Worker` into silkworm/concurrency. More consistent function names between `ActiveComponent` and `Worker`.