### PR TITLE
Clang format all files

### DIFF
--- a/cmd/log_index.cpp
+++ b/cmd/log_index.cpp
@@ -14,8 +14,6 @@
    limitations under the License.
 */
 
-
-
 #include <CLI/CLI.hpp>
 
 #include <silkworm/common/directories.hpp>

--- a/core/silkworm/chain/genesis.hpp
+++ b/core/silkworm/chain/genesis.hpp
@@ -22,9 +22,9 @@
 namespace silkworm {
 
 /*
-* \brief Returns genesis data given a known chain_id.
-* If id is not recognized returns an invalid json string
-*/
+ * \brief Returns genesis data given a known chain_id.
+ * If id is not recognized returns an invalid json string
+ */
 std::string read_genesis_data(unsigned int chain_id);
 
 }  // namespace silkworm

--- a/core/silkworm/chain/genesis_test.cpp
+++ b/core/silkworm/chain/genesis_test.cpp
@@ -30,7 +30,6 @@
 namespace silkworm {
 
 TEST_CASE("genesis config") {
-
     std::string genesis_data = read_genesis_data(static_cast<uint32_t>(kMainnetConfig.chain_id));
     nlohmann::json genesis_json = nlohmann::json::parse(genesis_data, nullptr, /* allow_exceptions = */ false);
     CHECK_FALSE(genesis_json.is_discarded());
@@ -61,11 +60,9 @@ TEST_CASE("genesis config") {
     genesis_data = read_genesis_data(1'000u);
     genesis_json = nlohmann::json::parse(genesis_data, nullptr, /* allow_exceptions = */ false);
     CHECK(genesis_json.is_discarded());
-
 }
 
 TEST_CASE("mainnet_genesis") {
-
     // Parse genesis data
     std::string genesis_data = read_genesis_data(static_cast<uint32_t>(kMainnetConfig.chain_id));
     nlohmann::json genesis_json = nlohmann::json::parse(genesis_data, nullptr, /* allow_exceptions = */ false);

--- a/core/silkworm/crypto/blake2.h
+++ b/core/silkworm/crypto/blake2.h
@@ -32,7 +32,7 @@ typedef struct blake2b_state__ {
 } blake2b_state;
 
 // https://tools.ietf.org/html/rfc7693#section-3.2
-void blake2b_compress(blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES], size_t r);
+void blake2b_compress(blake2b_state* S, const uint8_t block[BLAKE2B_BLOCKBYTES], size_t r);
 
 #if defined(__cplusplus)
 }

--- a/core/silkworm/crypto/blake2b-ref.c
+++ b/core/silkworm/crypto/blake2b-ref.c
@@ -31,7 +31,7 @@ static const uint8_t blake2b_sigma[12][16] = {
     {6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5}, {10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0},
     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3}};
 
-static inline uint64_t load64(const void *src) {
+static inline uint64_t load64(const void* src) {
     uint64_t w;
     memcpy(&w, src, sizeof w);
     return w;
@@ -63,7 +63,7 @@ static inline uint64_t rotr64(const uint64_t w, const unsigned c) { return (w >>
         G(r, 7, v[3], v[4], v[9], v[14]);  \
     } while (0)
 
-void blake2b_compress(blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES], size_t r) {
+void blake2b_compress(blake2b_state* S, const uint8_t block[BLAKE2B_BLOCKBYTES], size_t r) {
     uint64_t m[16];
     uint64_t v[16];
     size_t i;

--- a/core/silkworm/state/in_memory_state.hpp
+++ b/core/silkworm/state/in_memory_state.hpp
@@ -34,6 +34,7 @@ class InMemoryState : public State {
     using StorageChanges =
         std::unordered_map<evmc::address,
                            std::unordered_map<uint64_t, std::unordered_map<evmc::bytes32, evmc::bytes32>>>;
+
   public:
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 

--- a/core/silkworm/types/account.hpp
+++ b/core/silkworm/types/account.hpp
@@ -46,7 +46,7 @@ struct Account {
 
 bool operator==(const Account& a, const Account& b);
 
- /*
+/*
  * Extract the incarnation from an encoded account object without fully decoding it.
  */
 std::pair<uint64_t, rlp::DecodingResult> extract_incarnation(ByteView);

--- a/node/silkworm/common/directories.cpp
+++ b/node/silkworm/common/directories.cpp
@@ -185,9 +185,7 @@ void DataDirectory::deploy() {
     nodes_.create();
 }
 
-std::filesystem::path TemporaryDirectory::get_os_temporary_path() {
-    return std::filesystem::temp_directory_path();
-}
+std::filesystem::path TemporaryDirectory::get_os_temporary_path() { return std::filesystem::temp_directory_path(); }
 
 std::filesystem::path TemporaryDirectory::get_unique_temporary_path(const std::filesystem::path& base_path) {
     if (base_path.empty()) {

--- a/node/silkworm/common/stopwatch.cpp
+++ b/node/silkworm/common/stopwatch.cpp
@@ -22,7 +22,7 @@ StopWatch::TimePoint StopWatch::start() noexcept {
     if (started_) {
         return start_time_;
     }
-    
+
     started_ = true;
     if (start_time_ == TimePoint()) {
         start_time_ = std::chrono::high_resolution_clock::now();

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -17,6 +17,7 @@
 #include "access_layer.hpp"
 
 #include <cassert>
+
 #include <nlohmann/json.hpp>
 
 #include <silkworm/common/endian.hpp>

--- a/node/silkworm/db/buffer.cpp
+++ b/node/silkworm/db/buffer.cpp
@@ -24,7 +24,7 @@
 #include <silkworm/common/util.hpp>
 #include <silkworm/types/log_cbor.hpp>
 #include <silkworm/types/receipt_cbor.hpp>
-#include <silkworm/common/endian.hpp>
+
 #include "access_layer.hpp"
 #include "tables.hpp"
 
@@ -255,15 +255,25 @@ void Buffer::insert_receipts(uint64_t block_number, const std::vector<Receipt>& 
     }
 }
 
-evmc::bytes32 Buffer::state_root_hash() const { throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented")); }
+evmc::bytes32 Buffer::state_root_hash() const {
+    throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented"));
+}
 
-uint64_t Buffer::current_canonical_block() const { throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented")); }
+uint64_t Buffer::current_canonical_block() const {
+    throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented"));
+}
 
-std::optional<evmc::bytes32> Buffer::canonical_hash(uint64_t) const { throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented")); }
+std::optional<evmc::bytes32> Buffer::canonical_hash(uint64_t) const {
+    throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented"));
+}
 
-void Buffer::canonize_block(uint64_t, const evmc::bytes32&) { throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented")); }
+void Buffer::canonize_block(uint64_t, const evmc::bytes32&) {
+    throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented"));
+}
 
-void Buffer::decanonize_block(uint64_t) { throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented")); }
+void Buffer::decanonize_block(uint64_t) {
+    throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented"));
+}
 
 void Buffer::insert_block(const Block& block, const evmc::bytes32& hash) {
     uint64_t block_number{block.header.number};
@@ -345,6 +355,8 @@ uint64_t Buffer::previous_incarnation(const evmc::address& address) const noexce
     return incarnation ? *incarnation : 0;
 }
 
-void Buffer::unwind_state_changes(uint64_t) { throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented")); }
+void Buffer::unwind_state_changes(uint64_t) {
+    throw std::runtime_error(std::string(__FUNCTION__).append(" not yet implemented"));
+}
 
 }  // namespace silkworm::db

--- a/node/silkworm/downloader/BodyLogic.cpp
+++ b/node/silkworm/downloader/BodyLogic.cpp
@@ -15,29 +15,27 @@
 */
 
 #include "BodyLogic.hpp"
+
 #include <silkworm/types/block.hpp>
 
 namespace silkworm {
 
-BodyRetrieval::BodyRetrieval(DbTx& db): db_(db) {
-
-}
+BodyRetrieval::BodyRetrieval(DbTx& db) : db_(db) {}
 
 std::vector<BlockBody> BodyRetrieval::recover(std::vector<Hash> request) {
     std::vector<BlockBody> response;
     size_t bytes = 0;
-    for(size_t i = 0; i <= request.size(); ++i) {
+    for (size_t i = 0; i <= request.size(); ++i) {
         Hash& hash = request[i];
         auto body = db_.read_body(hash);
         if (!body) continue;
         response.push_back(*body);
         bytes += rlp::length(*body);
-        if (bytes >= soft_response_limit ||
-            response.size() >= max_bodies_serve ||
-            i >= 2 * max_bodies_serve)
+        if (bytes >= soft_response_limit || response.size() >= max_bodies_serve || i >= 2 * max_bodies_serve) {
             break;
+        }
     }
     return response;
 }
 
-}
+}  // namespace silkworm

--- a/node/silkworm/downloader/BodyLogic.hpp
+++ b/node/silkworm/downloader/BodyLogic.hpp
@@ -17,15 +17,16 @@
 #ifndef SILKWORM_BODYLOGIC_HPP
 #define SILKWORM_BODYLOGIC_HPP
 
-#include "Types.hpp"
 #include "DbTx.hpp"
+#include "Types.hpp"
 
 namespace silkworm {
 
 class BodyRetrieval {
   public:
-    static const long soft_response_limit = 2 * 1024 * 1024; // Target maximum size of returned blocks, headers or node data.
-    static const long max_bodies_serve = 1024;                // Amount of block bodies to be fetched per retrieval request
+    static const long soft_response_limit =
+        2 * 1024 * 1024;                        // Target maximum size of returned blocks, headers or node data.
+    static const long max_bodies_serve = 1024;  // Amount of block bodies to be fetched per retrieval request
 
     explicit BodyRetrieval(DbTx& db);
 
@@ -35,5 +36,6 @@ class BodyRetrieval {
     DbTx& db_;
 };
 
-}
+}  // namespace silkworm
+
 #endif  // SILKWORM_BODYLOGIC_HPP

--- a/node/silkworm/downloader/HeaderLogic.hpp
+++ b/node/silkworm/downloader/HeaderLogic.hpp
@@ -17,19 +17,21 @@
 #ifndef SILKWORM_HEADERLOGIC_HPP
 #define SILKWORM_HEADERLOGIC_HPP
 
-#include "Types.hpp"
-#include "DbTx.hpp"
-#include <vector>
-#include <queue>
 #include <map>
+#include <queue>
+#include <vector>
+
+#include "DbTx.hpp"
+#include "Types.hpp"
 
 namespace silkworm {
 
 class HeaderRetrieval {
   public:
-    static const long soft_response_limit = 2 * 1024 * 1024; // Target maximum size of returned blocks, headers or node data.
-    static const long est_header_rlp_size = 500;             // Approximate size of an RLP encoded block header
-    static const long max_headers_serve = 1024;              // Amount of block headers to be fetched per retrieval request
+    static const long soft_response_limit =
+        2 * 1024 * 1024;                          // Target maximum size of returned blocks, headers or node data.
+    static const long est_header_rlp_size = 500;  // Approximate size of an RLP encoded block header
+    static const long max_headers_serve = 1024;   // Amount of block headers to be fetched per retrieval request
 
     explicit HeaderRetrieval(DbTx& db);
 
@@ -38,16 +40,17 @@ class HeaderRetrieval {
     std::vector<BlockHeader> recover_by_number(BlockNum origin, uint64_t amount, uint64_t skip, bool reverse);
 
     // Node current status
-    BlockNum                head_height();
-    std::tuple<Hash,BigInt> head_hash_and_total_difficulty();
+    BlockNum head_height();
+    std::tuple<Hash, BigInt> head_hash_and_total_difficulty();
 
     // Ancestor
-    std::tuple<Hash,BlockNum> get_ancestor(Hash hash, BlockNum blockNum, BlockNum ancestor, uint64_t& max_non_canonical);
+    std::tuple<Hash, BlockNum> get_ancestor(Hash hash, BlockNum blockNum, BlockNum ancestor,
+                                            uint64_t& max_non_canonical);
 
   protected:
     DbTx& db_;
 };
 
-}
+}  // namespace silkworm
 
 #endif  // SILKWORM_HEADERLOGIC_HPP

--- a/node/silkworm/downloader/RandomNumber.hpp
+++ b/node/silkworm/downloader/RandomNumber.hpp
@@ -17,27 +17,26 @@
 #ifndef SILKWORM_RANDOMNUMBER_HPP
 #define SILKWORM_RANDOMNUMBER_HPP
 #include <random>
+
 #include "Singleton.hpp"
 
 namespace silkworm {
 
 class RandomNumber {
-    std::mt19937_64 generator_; // the 64-bit Mersenne Twister 19937 generator
-    std::uniform_int_distribution<unsigned long long> distr_; // a uniform distribution
+    std::mt19937_64 generator_;                                // the 64-bit Mersenne Twister 19937 generator
+    std::uniform_int_distribution<unsigned long long> distr_;  // a uniform distribution
 
   public:
     RandomNumber() {
         std::random_device rd;
-        generator_.seed(rd()); // init generator_ with a random seed
+        generator_.seed(rd());  // init generator_ with a random seed
     }
 
-    int64_t generate_one() {
-        return distr_(generator_);
-    }
-
+    int64_t generate_one() { return distr_(generator_); }
 };
 
 #define RANDOM_NUMBER default_instantiating::Singleton<RandomNumber>::instance()
 
-}
+}  // namespace silkworm
+
 #endif  // SILKWORM_RANDOMNUMBER_HPP

--- a/node/silkworm/downloader/Singleton.hpp
+++ b/node/silkworm/downloader/Singleton.hpp
@@ -23,29 +23,32 @@ namespace owning {
 template <class T>
 class Singleton {
     static inline std::unique_ptr<T> instance_;
+
   public:
-    static void instance(std::unique_ptr<T> instance) {instance_ = instance;}
-    static T& instance() {return *instance_;}
+    static void instance(std::unique_ptr<T> instance) { instance_ = instance; }
+    static T& instance() { return *instance_; }
 };
-}
+}  // namespace owning
 
 namespace non_owning {
 template <class T>
 class Singleton {
     static inline T* instance_;
+
   public:
-    static void instance(T* instance) {instance_ = instance;}
-    static T& instance() {return *instance_;}
+    static void instance(T* instance) { instance_ = instance; }
+    static T& instance() { return *instance_; }
 };
-}
+}  // namespace non_owning
 
 namespace default_instantiating {
 template <class T>
 class Singleton {
     static inline T instance_;
+
   public:
-    static T& instance() {return instance_;}
+    static T& instance() { return instance_; }
 };
-}
+}  // namespace default_instantiating
 
 #endif  // SILKWORM_SINGLETON_HPP

--- a/node/silkworm/downloader/TypesForGrpc.hpp
+++ b/node/silkworm/downloader/TypesForGrpc.hpp
@@ -17,9 +17,11 @@
 #ifndef SILKWORM_TYPESFORGRPC_HPP
 #define SILKWORM_TYPESFORGRPC_HPP
 
-#include "Types.hpp"
-#include <interfaces/types.pb.h>
 #include <memory>
+
+#include <interfaces/types.pb.h>
+
+#include "Types.hpp"
 
 namespace silkworm {
 
@@ -28,8 +30,9 @@ std::unique_ptr<types::H256> to_H256(const Hash& orig);
 std::unique_ptr<types::H512> to_H512(const std::string& orig);
 
 intx::uint256 uint256_from_H256(const types::H256& orig);
-Hash          hash_from_H256(const types::H256& orig);
-std::string   string_from_H512(const types::H512& orig);
+Hash hash_from_H256(const types::H256& orig);
+std::string string_from_H512(const types::H512& orig);
 
-}   // namespace
+}  // namespace silkworm
+
 #endif  // SILKWORM_TYPESFORGRPC_HPP

--- a/node/silkworm/downloader/TypesForGrpc_test.cpp
+++ b/node/silkworm/downloader/TypesForGrpc_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,39 +14,40 @@
    limitations under the License.
 */
 
-#include <catch2/catch.hpp>
 #include "TypesForGrpc.hpp"
+
+#include <catch2/catch.hpp>
 
 namespace silkworm {
 
 TEST_CASE("H256/512 to/from conversions") {
     using namespace std;
 
-    SECTION( "H256 to/from Hash" ) {
+    SECTION("H256 to/from Hash") {
         Hash orig_hash = Hash::from_hex("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
         Hash transf_hash = hash_from_H256(*to_H256(orig_hash));
 
         REQUIRE(orig_hash == transf_hash);
     }
 
-    SECTION( "H256 to/from number" ) {
+    SECTION("H256 to/from number") {
         intx::uint256 orig_big{int64_t{789}, int64_t{567}, int64_t{345}, int64_t{123}};
         intx::uint256 transf_big = uint256_from_H256(*to_H256(orig_big));
 
         REQUIRE(orig_big == transf_big);
     }
 
-    for(auto len: {64,64,64,64,64,60,70}) {
-        SECTION( "H512 to/from string, len="+to_string(len) ) {
+    for (auto len : {64, 64, 64, 64, 64, 60, 70}) {
+        SECTION("H512 to/from string, len=" + to_string(len)) {
             string orig_string(len, 0);
             generate_n(orig_string.begin(), len, [] { return static_cast<char>(rand() % 255); });
 
             string transf_string = string_from_H512(*to_H512(orig_string));
 
-            orig_string.resize(64,0);   // transf_string is always of 64 bytes with trailing zeros if needed
+            orig_string.resize(64, 0);  // transf_string is always of 64 bytes with trailing zeros if needed
             REQUIRE(orig_string == transf_string);
         }
     }
 }
 
-}
+}  // namespace silkworm

--- a/node/silkworm/downloader/messages/CompletionMessage.cpp
+++ b/node/silkworm/downloader/messages/CompletionMessage.cpp
@@ -15,4 +15,3 @@
 */
 
 #include "CompletionMessage.hpp"
-

--- a/node/silkworm/downloader/messages/CompletionMessage.hpp
+++ b/node/silkworm/downloader/messages/CompletionMessage.hpp
@@ -24,24 +24,29 @@ namespace silkworm {
 // Special message needed to handle a message rpc completion in the same message processing thread
 // coroutine would avoid avoid this
 
-class CompletionMessage: public Message {
+class CompletionMessage : public Message {
   public:
-    CompletionMessage(std::shared_ptr<Message> waiting_completion, rpc_t completed_rpc):
-        msg_waiting_completion_(waiting_completion), completed_rpc_(completed_rpc) {}
+    CompletionMessage(std::shared_ptr<Message> waiting_completion, rpc_t completed_rpc)
+        : msg_waiting_completion_(waiting_completion), completed_rpc_(completed_rpc) {}
 
-    std::string name() const override {return "CompletionMessage";}
-    std::string content() const override {return "-";}
-    uint64_t reqId() const override {return msg_waiting_completion_->reqId();};
+    std::string name() const override { return "CompletionMessage"; }
+    std::string content() const override { return "-"; }
+    uint64_t reqId() const override { return msg_waiting_completion_->reqId(); };
 
-    rpc_bundle_t execute() override {msg_waiting_completion_->handle_completion(*completed_rpc_); return {};}
+    rpc_bundle_t execute() override {
+        msg_waiting_completion_->handle_completion(*completed_rpc_);
+        return {};
+    }
 
-    static std::shared_ptr<CompletionMessage> make(std::shared_ptr<Message> waiting_completion, rpc_t completed_rpc)
-        {return std::make_shared<CompletionMessage>(waiting_completion, completed_rpc);}
+    static std::shared_ptr<CompletionMessage> make(std::shared_ptr<Message> waiting_completion, rpc_t completed_rpc) {
+        return std::make_shared<CompletionMessage>(waiting_completion, completed_rpc);
+    }
 
   private:
     std::shared_ptr<Message> msg_waiting_completion_;
     rpc_t completed_rpc_;
 };
 
-}
+}  // namespace silkworm
+
 #endif  // SILKWORM_COMPLETIONMESSAGE_HPP

--- a/node/silkworm/downloader/messages/InboundGetBlockBodies.hpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockBodies.hpp
@@ -17,16 +17,17 @@
 #ifndef SILKWORM_INBOUNDGETBLOCKBODIES_HPP
 #define SILKWORM_INBOUNDGETBLOCKBODIES_HPP
 
-#include "InboundMessage.hpp"
 #include <silkworm/downloader/packets/GetBlockBodiesPacket.hpp>
+
+#include "InboundMessage.hpp"
 
 namespace silkworm {
 
-class InboundGetBlockBodies: public InboundMessage {
+class InboundGetBlockBodies : public InboundMessage {
   public:
     InboundGetBlockBodies(const sentry::InboundMessage& msg, DbTx& db);
 
-    std::string name() const override {return "InboundGetBlockBodies";}
+    std::string name() const override { return "InboundGetBlockBodies"; }
     std::string content() const override;
     uint64_t reqId() const override;
 
@@ -40,5 +41,6 @@ class InboundGetBlockBodies: public InboundMessage {
     DbTx& db_;
 };
 
-}
+}  // namespace silkworm
+
 #endif  // SILKWORM_INBOUNDGETBLOCKBODIES_HPP

--- a/node/silkworm/downloader/messages/InboundGetBlockHeaders.cpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockHeaders.cpp
@@ -23,7 +23,8 @@
 
 namespace silkworm {
 
-InboundGetBlockHeaders::InboundGetBlockHeaders(const sentry::InboundMessage& msg, DbTx& db) : InboundMessage(), db_(db) {
+InboundGetBlockHeaders::InboundGetBlockHeaders(const sentry::InboundMessage& msg, DbTx& db)
+    : InboundMessage(), db_(db) {
     if (msg.id() != sentry::MessageId::GET_BLOCK_HEADERS_66) {
         throw std::logic_error("InboundGetBlockHeaders received wrong InboundMessage");
     }
@@ -46,10 +47,11 @@ InboundMessage::reply_calls_t InboundGetBlockHeaders::execute() {
     reply.requestId = packet_.requestId;
     if (holds_alternative<Hash>(packet_.request.origin)) {
         reply.request = header_retrieval.recover_by_hash(get<Hash>(packet_.request.origin), packet_.request.amount,
-                                                     packet_.request.skip, packet_.request.reverse);
+                                                         packet_.request.skip, packet_.request.reverse);
     } else {
-        reply.request = header_retrieval.recover_by_number(get<BlockNum>(packet_.request.origin), packet_.request.amount,
-                                                       packet_.request.skip, packet_.request.reverse);
+        reply.request =
+            header_retrieval.recover_by_number(get<BlockNum>(packet_.request.origin), packet_.request.amount,
+                                               packet_.request.skip, packet_.request.reverse);
     }
 
     Bytes rlp_encoding;

--- a/node/silkworm/downloader/messages/InboundGetBlockHeaders.hpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockHeaders.hpp
@@ -17,17 +17,17 @@
 #ifndef SILKWORM_INBOUNDGETBLOCKHEADERS_HPP
 #define SILKWORM_INBOUNDGETBLOCKHEADERS_HPP
 
-#include "InboundMessage.hpp"
 #include <silkworm/downloader/packets/GetBlockHeadersPacket.hpp>
 
+#include "InboundMessage.hpp"
 
 namespace silkworm {
 
-class InboundGetBlockHeaders: public InboundMessage {
+class InboundGetBlockHeaders : public InboundMessage {
   public:
     InboundGetBlockHeaders(const sentry::InboundMessage& msg, DbTx& db);
 
-    std::string name() const override {return "InboundGetBlockHeaders";}
+    std::string name() const override { return "InboundGetBlockHeaders"; }
     std::string content() const override;
     uint64_t reqId() const override;
 
@@ -41,5 +41,6 @@ class InboundGetBlockHeaders: public InboundMessage {
     DbTx& db_;
 };
 
-}
+}  // namespace silkworm
+
 #endif  // SILKWORM_INBOUNDGETBLOCKHEADERS_HPP

--- a/node/silkworm/downloader/messages/InboundMessage.cpp
+++ b/node/silkworm/downloader/messages/InboundMessage.cpp
@@ -15,22 +15,26 @@
 */
 
 #include "InboundMessage.hpp"
-#include "InboundGetBlockHeaders.hpp"
-#include "InboundGetBlockBodies.hpp"
-#include <silkworm/common/log.hpp>
+
 #include <iostream>
+
+#include <silkworm/common/log.hpp>
+
+#include "InboundGetBlockBodies.hpp"
+#include "InboundGetBlockHeaders.hpp"
 
 namespace silkworm {
 
-std::shared_ptr<InboundMessage> InboundBlockRequestMessage::make_from_raw_message(const sentry::InboundMessage& raw_message, DbTx& db) {
+std::shared_ptr<InboundMessage> InboundBlockRequestMessage::make_from_raw_message(
+    const sentry::InboundMessage& raw_message, DbTx& db) {
     std::shared_ptr<InboundMessage> message;
     if (raw_message.id() == sentry::MessageId::GET_BLOCK_HEADERS_66)
         message = std::make_shared<InboundGetBlockHeaders>(raw_message, db);
     else if (raw_message.id() == sentry::MessageId::GET_BLOCK_BODIES_66)
         message = std::make_shared<InboundGetBlockBodies>(raw_message, db);
     else
-        SILKWORM_LOG(LogLevel::Warn)
-            << "InboundMessage " << sentry::MessageId_Name(raw_message.id()) << " received but ignored\n";
+        SILKWORM_LOG(LogLevel::Warn) << "InboundMessage " << sentry::MessageId_Name(raw_message.id())
+                                     << " received but ignored\n";
     return message;
 }
 
@@ -39,7 +43,4 @@ std::ostream& operator<<(std::ostream& os, const silkworm::InboundMessage& msg) 
     return os;
 }
 
-}
-
-
-
+}  // namespace silkworm

--- a/node/silkworm/downloader/messages/InboundMessage.hpp
+++ b/node/silkworm/downloader/messages/InboundMessage.hpp
@@ -19,20 +19,17 @@
 
 #include <memory>
 
+#include <silkworm/downloader/DbTx.hpp>
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/rlp/encode.hpp>
 
-#include <silkworm/downloader/DbTx.hpp>
-
 #include "Message.hpp"
-
 
 namespace silkworm {
 
-
 class InboundMessage : public Message {
   public:
-    using reply_call_t = rpc_t; // a more specific name
+    using reply_call_t = rpc_t;  // a more specific name
     using reply_calls_t = rpc_bundle_t;
 
     reply_calls_t execute() override = 0;
@@ -45,6 +42,6 @@ class InboundBlockRequestMessage : public InboundMessage {
 
 std::ostream& operator<<(std::ostream&, const silkworm::InboundMessage&);
 
-}
+}  // namespace silkworm
 
 #endif  // SILKWORM_INBOUNDMESSAGE_HPP

--- a/node/silkworm/downloader/messages/Message.cpp
+++ b/node/silkworm/downloader/messages/Message.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "Message.hpp"
+
 #include <silkworm/common/log.hpp>
 
 namespace silkworm {
@@ -34,4 +35,4 @@ std::string identify(const silkworm::Message& message) {
     return message.name() + " reqId=" + std::to_string(message.reqId());
 }
 
-}
+}  // namespace silkworm

--- a/node/silkworm/downloader/messages/Message.hpp
+++ b/node/silkworm/downloader/messages/Message.hpp
@@ -20,7 +20,6 @@
 #include <silkworm/downloader/SentryClient.hpp>
 #include <silkworm/downloader/Types.hpp>
 
-
 namespace silkworm {
 
 class Message {
@@ -30,9 +29,9 @@ class Message {
 
     virtual std::string name() const = 0;
     virtual std::string content() const = 0;
-    virtual uint64_t    reqId() const = 0;
+    virtual uint64_t reqId() const = 0;
 
-    virtual rpc_bundle_t execute() = 0;    // inbound message does a reply, outbound message does a request
+    virtual rpc_bundle_t execute() = 0;  // inbound message does a reply, outbound message does a request
 
     virtual void handle_completion(SentryRpc&) {}
 
@@ -42,8 +41,6 @@ class Message {
 std::ostream& operator<<(std::ostream&, const silkworm::Message&);
 std::string identify(const silkworm::Message& message);
 
-}
-
-
+}  // namespace silkworm
 
 #endif  // SILKWORM_MESSAGE_HPP

--- a/node/silkworm/downloader/packets/BlockBodiesPacket.hpp
+++ b/node/silkworm/downloader/packets/BlockBodiesPacket.hpp
@@ -21,38 +21,43 @@
 
 namespace silkworm {
 
-    using BlockBodiesPacket = std::vector<BlockBody>;
+using BlockBodiesPacket = std::vector<BlockBody>;
 
-    struct BlockBodiesPacket66 { // eth/66 version
-        uint64_t requestId;
-        BlockBodiesPacket request;
-    };
+struct BlockBodiesPacket66 {  // eth/66 version
+    uint64_t requestId;
+    BlockBodiesPacket request;
+};
 
 namespace rlp {
 
-    // ... length(const BlockBodiesPacket& from)              implemented by rlp::length<T>(const std::vector<T>& v)
+    // ... length(const BlockBodiesPacket& from)
+    // implemented by rlp::length<T>(const std::vector<T>& v)
 
-    // ... encode(Bytes& to, const BlockBodiesPacket& from)   implemented by rlp::encode(Bytes& to, const std::vector<T>& v)
+    // ... encode(Bytes& to, const BlockBodiesPacket& from)
+    // implemented by rlp::encode(Bytes& to, const std::vector<T>& v)
     template <>
     rlp::DecodingResult decode(ByteView& from, BlockBodiesPacket& to) noexcept;
 
-    // ... length(const BlockBodiesPacket66& from)            implemented by template <Eth66Packet T> size_t length(const T& from)
+    // ... length(const BlockBodiesPacket66& from)
+    // implemented by template <Eth66Packet T> size_t length(const T& from)
 
-    // ... encode(Bytes& to, const BlockBodiesPacket66& from) implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
+    // ... encode(Bytes& to, const BlockBodiesPacket66& from)
+    // implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
 
-    // ... decode(ByteView& from, BlockBodiesPacket66& to)    implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to) --> No, it requires a c++20 compiler
+    // ... decode(ByteView& from, BlockBodiesPacket66& to)
+    // implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to)
+    // --> No, it requires a c++20 compiler
     template <>
     rlp::DecodingResult decode(ByteView& from, BlockBodiesPacket66& to) noexcept;
+}  // namespace rlp
+
+inline std::ostream& operator<<(std::ostream& os, const BlockBodiesPacket66& packet) {
+    os << "reqId=" << packet.requestId;
+    os << " bodies=" << packet.request.size();
+    return os;
 }
 
-    inline std::ostream& operator<<(std::ostream& os, const BlockBodiesPacket66& packet)
-    {
-        os <<   "reqId="  << packet.requestId;
-        os << " bodies=" << packet.request.size();
-        return os;
-    }
-
-} // silkworm namespace
+}  // namespace silkworm
 
 #include "RLPEth66PacketCoding.hpp"
 

--- a/node/silkworm/downloader/packets/BlockHeadersPacket.hpp
+++ b/node/silkworm/downloader/packets/BlockHeadersPacket.hpp
@@ -17,52 +17,59 @@
 #ifndef SILKWORM_BLOCKHEADERSPACKET_HPP
 #define SILKWORM_BLOCKHEADERSPACKET_HPP
 
-#include <silkworm/downloader/Types.hpp>
 #include <algorithm>
+
+#include <silkworm/downloader/Types.hpp>
 
 namespace silkworm {
 
-    using BlockHeadersPacket = std::vector<BlockHeader>;
+using BlockHeadersPacket = std::vector<BlockHeader>;
 
-    struct BlockHeadersPacket66 {  // eth/66 version
-        uint64_t requestId;
-        BlockHeadersPacket request;
-    };
+struct BlockHeadersPacket66 {  // eth/66 version
+    uint64_t requestId;
+    BlockHeadersPacket request;
+};
 
 namespace rlp {
 
-    // size_t length(const BlockHeadersPacket& from)           implemented by  rlp::length<T>(const std::vector<T>& v)
+    // size_t length(const BlockHeadersPacket& from)
+    // implemented by  rlp::length<T>(const std::vector<T>& v)
 
-    // void encode(Bytes& to, const BlockHeadersPacket& from)  implemented by  rlp::encode(Bytes& to, const std::vector<T>& v)
+    // void encode(Bytes& to, const BlockHeadersPacket& from)
+    //  implemented by  rlp::encode(Bytes& to, const std::vector<T>& v)
     template <>
     rlp::DecodingResult decode(ByteView& from, BlockHeadersPacket& to) noexcept;
 
-    // ... length(const BlockHeadersPacket66& from)            implemented by template <Eth66Packet T> size_t length(const T& from)
+    // ... length(const BlockHeadersPacket66& from)
+    // implemented by template <Eth66Packet T> size_t length(const T& from)
 
-    // ... encode(Bytes& to, const BlockHeadersPacket66& from) implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
+    // ... encode(Bytes& to, const BlockHeadersPacket66& from)
+    // implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
 
-    // ... decode(ByteView& from, BlockHeadersPacket66& to)    implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to) --> No, it requires a c++20 compiler
+    // ... decode(ByteView& from, BlockHeadersPacket66& to)
+    // implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to)
+    // --> No, it requires a c++20 compiler
     template <>
     rlp::DecodingResult decode(ByteView& from, BlockHeadersPacket66& to) noexcept;
 
-}
+}  // namespace rlp
 
-    inline std::ostream& operator<<(std::ostream& os, const BlockHeadersPacket66& packet)
-    {
-        os << "reqId=" << packet.requestId;
-        os << " headers(bn)=";
+inline std::ostream& operator<<(std::ostream& os, const BlockHeadersPacket66& packet) {
+    os << "reqId=" << packet.requestId;
+    os << " headers(bn)=";
 
-        const size_t max_display = 3;
-        for(size_t i = 0; i < std::min(packet.request.size(), max_display); i++) {
-            os << packet.request[i].number << ",";
-        }
-        if (packet.request.size() > max_display)
-            os << "...";
-
-        return os;
+    const size_t max_display = 3;
+    for (size_t i = 0; i < std::min(packet.request.size(), max_display); i++) {
+        os << packet.request[i].number << ",";
+    }
+    if (packet.request.size() > max_display) {
+        os << "...";
     }
 
-} // silkworm namespace
+    return os;
+}
+
+}  // namespace silkworm
 
 #include "RLPEth66PacketCoding.hpp"
 

--- a/node/silkworm/downloader/packets/GetBlockBodiesPacket.hpp
+++ b/node/silkworm/downloader/packets/GetBlockBodiesPacket.hpp
@@ -21,44 +21,47 @@
 
 namespace silkworm {
 
-    using GetBlockBodiesPacket = std::vector<Hash>;
+using GetBlockBodiesPacket = std::vector<Hash>;
 
-    struct GetBlockBodiesPacket66 { // eth/66 version
-        uint64_t requestId;
-        GetBlockBodiesPacket request;
-    };
+struct GetBlockBodiesPacket66 {  // eth/66 version
+    uint64_t requestId;
+    GetBlockBodiesPacket request;
+};
 
 namespace rlp {
 
-    // size_t length(const GetBlockBodiesPacket& from)           implemented by  rlp::length<T>(const std::vector<T>& v)
-    // void encode(Bytes& to, const GetBlockBodiesPacket& from)  implemented by  rlp::encode(Bytes& to, const std::vector<T>& v)
+    // size_t length(const GetBlockBodiesPacket& from)
+    // implemented by  rlp::length<T>(const std::vector<T>& v)
+    // void encode(Bytes& to, const GetBlockBodiesPacket& from)
+    // implemented by  rlp::encode(Bytes& to, const std::vector<T>& v)
     template <>
     rlp::DecodingResult decode(ByteView& from, GetBlockBodiesPacket& to) noexcept;
 
-    // ... length(const GetBlockBodiesPacket66& from)            implemented by template <Eth66Packet T> size_t length(const T& from)
+    // ... length(const GetBlockBodiesPacket66& from)
+    // implemented by template <Eth66Packet T> size_t length(const T& from)
 
-    // ... encode(Bytes& to, const GetBlockBodiesPacket66& from) implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
+    // ... encode(Bytes& to, const GetBlockBodiesPacket66& from)
+    // implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
 
-    // ... decode(ByteView& from, GetBlockBodiesPacket66& to)    implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to) --> No, it requires a c++20 compiler
+    // ... decode(ByteView& from, GetBlockBodiesPacket66& to)
+    // implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to)
+    // --> No, it requires a c++20 compiler
     template <>
     rlp::DecodingResult decode(ByteView& from, GetBlockBodiesPacket66& to) noexcept;
 
 }  // namespace rlp
 
-    inline std::ostream& operator<<(std::ostream& os, const GetBlockBodiesPacket66& packet)
-    {
-        os << " reqId="  << packet.requestId;
+inline std::ostream& operator<<(std::ostream& os, const GetBlockBodiesPacket66& packet) {
+    os << " reqId=" << packet.requestId;
 
-        if (packet.request.size() == 1)
-            os << " hash=" << to_hex(packet.request[0]);
-        else
-            os << " hash=" << packet.request.size() << " block hashes";
+    if (packet.request.size() == 1)
+        os << " hash=" << to_hex(packet.request[0]);
+    else
+        os << " hash=" << packet.request.size() << " block hashes";
 
-        return os;
-    }
+    return os;
+}
 
-} // silkworm namespace
-
-
+}  // namespace silkworm
 
 #endif  // SILKWORM_GETBLOCKBODIESPACKET_HPP

--- a/node/silkworm/downloader/packets/GetBlockHeadersPacket.hpp
+++ b/node/silkworm/downloader/packets/GetBlockHeadersPacket.hpp
@@ -21,17 +21,17 @@
 
 namespace silkworm {
 
-    struct GetBlockHeadersPacket {
-        HashOrNumber origin;  // Block hash or block number from which to retrieve headers
-        uint64_t amount;      // Maximum number of headers to retrieve
-        uint64_t skip;        // Blocks to skip between consecutive headers
-        bool reverse;         // Query direction (false = rising towards latest, true = falling towards genesis)
-    };
+struct GetBlockHeadersPacket {
+    HashOrNumber origin;  // Block hash or block number from which to retrieve headers
+    uint64_t amount;      // Maximum number of headers to retrieve
+    uint64_t skip;        // Blocks to skip between consecutive headers
+    bool reverse;         // Query direction (false = rising towards latest, true = falling towards genesis)
+};
 
-    struct GetBlockHeadersPacket66 { // eth/66 version
-        uint64_t requestId;
-        GetBlockHeadersPacket request;
-    };
+struct GetBlockHeadersPacket66 {  // eth/66 version
+    uint64_t requestId;
+    GetBlockHeadersPacket request;
+};
 
 namespace rlp {
 
@@ -94,28 +94,26 @@ namespace rlp {
         return from.length() == leftover ? DecodingResult::kOk : DecodingResult::kListLengthMismatch;
     }
 
-    // ... length(const GetBlockHeadersPacket66& from)            implemented by template <Eth66Packet T> size_t length(const T& from)
+    // ... length(const GetBlockHeadersPacket66& from)
+    // implemented by template <Eth66Packet T> size_t length(const T& from)
 
-    // ... encode(Bytes& to, const GetBlockHeadersPacket66& from) implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
+    // ... encode(Bytes& to, const GetBlockHeadersPacket66& from)
+    // implemented by template <Eth66Packet T> void encode(Bytes& to, const T& from)
 
-    // ... decode(ByteView& from, GetBlockHeadersPacket66& to)    implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to) --> No, it requires a c++20 compiler
+    // ... decode(ByteView& from, GetBlockHeadersPacket66& to)
+    // implemented by template <Eth66Packet T> rlp::DecodingResult decode(ByteView& from, T& to)
+    // --> No, it requires a c++20 compiler
     template <>
     rlp::DecodingResult decode(ByteView& from, GetBlockHeadersPacket66& to) noexcept;
 
-} // rlp namespace
+}  // namespace rlp
 
-    inline std::ostream& operator<<(std::ostream& os, const GetBlockHeadersPacket66& packet)
-    {
-        os <<   "reqId="  << packet.requestId
-           << " origin=" << packet.request.origin
-           << " amount=" << packet.request.amount
-           << " skip="   << packet.request.skip
-           << " reverse="<< packet.request.reverse;
-        return os;
-    }
+inline std::ostream& operator<<(std::ostream& os, const GetBlockHeadersPacket66& packet) {
+    os << "reqId=" << packet.requestId << " origin=" << packet.request.origin << " amount=" << packet.request.amount
+       << " skip=" << packet.request.skip << " reverse=" << packet.request.reverse;
+    return os;
+}
 
-} // silkworm namespace
-
-
+}  // namespace silkworm
 
 #endif  // SILKWORM_GETBLOCKHEADERSPACKET_HPP

--- a/node/silkworm/downloader/packets/HashOrNumber.hpp
+++ b/node/silkworm/downloader/packets/HashOrNumber.hpp
@@ -19,16 +19,16 @@
 
 #include <variant>
 
+#include <silkworm/downloader/Types.hpp>
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/rlp/encode.hpp>
 
-#include <silkworm/downloader/Types.hpp>
 #include "RLPError.hpp"
 
 namespace silkworm {
 
-    // HashOrNumber type def
-    using HashOrNumber = std::variant<Hash, BlockNum>;
+// HashOrNumber type def
+using HashOrNumber = std::variant<Hash, BlockNum>;
 
 // HashOrNumber rlp encoding/decoding
 namespace rlp {
@@ -48,20 +48,22 @@ namespace rlp {
     }
 
     inline DecodingResult decode(ByteView& from, HashOrNumber& to) noexcept {
-        ByteView copy(from);    // a copy because we need only decode header and not consume it
-        auto [h, err] = decode_header(copy); // so we can use full implementation of decode below
-        if (err != DecodingResult::kOk)
+        ByteView copy(from);                  // a copy because we need only decode header and not consume it
+        auto [h, err] = decode_header(copy);  // so we can use full implementation of decode below
+        if (err != DecodingResult::kOk) {
             return err;
-        if (h.list)
+        }
+        if (h.list) {
             return DecodingResult::kUnexpectedList;
+        }
 
         if (h.payload_length == 32) {
             Hash hash;
-            err = rlp::decode(from, dynamic_cast<evmc::bytes32&>(hash));    // consume header
+            err = rlp::decode(from, dynamic_cast<evmc::bytes32&>(hash));  // consume header
             to = hash;
         } else if (h.payload_length <= 8) {
             BlockNum number{};
-            err = rlp::decode(from, number);    // consume header
+            err = rlp::decode(from, number);  // consume header
             to = number;
         } else {
             err = DecodingResult::kUnexpectedLength;
@@ -69,15 +71,16 @@ namespace rlp {
         return err;
     }
 
+}  // namespace rlp
+
+inline std::ostream& operator<<(std::ostream& os, const HashOrNumber& packet) {
+    if (std::holds_alternative<Hash>(packet))
+        os << std::get<Hash>(packet);
+    else
+        os << std::get<BlockNum>(packet);
+    return os;
 }
 
-    inline std::ostream& operator<<(std::ostream& os, const HashOrNumber& packet) {
-        if (std::holds_alternative<Hash>(packet))
-            os << std::get<Hash>(packet);
-        else
-            os << std::get<BlockNum>(packet);
-        return os;
-    }
+}  // namespace silkworm
 
-}
 #endif  // SILKWORM_HASHORNUMBER_HPP

--- a/node/silkworm/downloader/packets/NewBlockHashesPacket.hpp
+++ b/node/silkworm/downloader/packets/NewBlockHashesPacket.hpp
@@ -21,18 +21,17 @@
 
 namespace silkworm {
 
-    struct NewBlockHash {     // one particular block being announced
-        Hash hash;        // hash of the block
-        BlockNum number;  // number of the block
-    };
+struct NewBlockHash {  // one particular block being announced
+    Hash hash;         // hash of the block
+    BlockNum number;   // number of the block
+};
 
-    using NewBlockHashesPacket = std::vector<NewBlockHash>;
+using NewBlockHashesPacket = std::vector<NewBlockHash>;
 
 namespace rlp {
 
     inline void encode(Bytes& to, const NewBlockHash& from) noexcept {
-        rlp::Header rlp_head{true,
-                             rlp::length(from.hash) + rlp::length(from.number)};
+        rlp::Header rlp_head{true, rlp::length(from.hash) + rlp::length(from.number)};
 
         rlp::encode_header(to, rlp_head);
 
@@ -41,8 +40,7 @@ namespace rlp {
     }
 
     inline size_t length(const NewBlockHash& from) noexcept {
-        rlp::Header rlp_head{true,
-                             rlp::length(from.hash) + rlp::length(from.number)};
+        rlp::Header rlp_head{true, rlp::length(from.hash) + rlp::length(from.number)};
 
         size_t rlp_head_len = rlp::length_of_length(rlp_head.payload_length);
         return rlp_head_len + rlp_head.payload_length;
@@ -50,7 +48,6 @@ namespace rlp {
 
     template <>
     inline rlp::DecodingResult decode(ByteView& from, NewBlockHash& to) noexcept {
-
         auto [rlp_head, err]{decode_header(from)};
         if (err != DecodingResult::kOk) {
             return err;
@@ -72,7 +69,8 @@ namespace rlp {
     }
 
     // size_t length(const NewBlockHashesPacket& from)           implemented by  rlp::length<T>(const std::vector<T>& v)
-    // void encode(Bytes& to, const NewBlockHashesPacket& from)  implemented by  rlp::encode<T>(Bytes& to, const std::vector<T>& v)
+    // void encode(Bytes& to, const NewBlockHashesPacket& from)  implemented by  rlp::encode<T>(Bytes& to, const
+    // std::vector<T>& v)
 
     void encode(Bytes& to, const NewBlockHashesPacket& from);
 
@@ -81,17 +79,16 @@ namespace rlp {
     template <>
     rlp::DecodingResult decode(ByteView& from, NewBlockHashesPacket& to) noexcept;
 
+}  // namespace rlp
+
+inline std::ostream& operator<<(std::ostream& os, const NewBlockHashesPacket& packet) {
+    if (packet.size() == 1)
+        os << "block num " << packet[0].number /* << " hash " << to_hex(packet[0].hash) */;
+    else
+        os << packet.size() << " new block hashes/nums";
+    return os;
 }
 
-    inline std::ostream& operator<<(std::ostream& os, const NewBlockHashesPacket& packet)
-    {
-        if (packet.size() == 1)
-            os << "block num " << packet[0].number /* << " hash " << to_hex(packet[0].hash) */;
-        else
-            os << packet.size() << " new block hashes/nums";
-        return os;
-    }
-
-} // silkworm namespace
+}  // namespace silkworm
 
 #endif  // SILKWORM_NEWBLOCKHASHPACKET_HPP

--- a/node/silkworm/downloader/packets/NewBlockPacket.hpp
+++ b/node/silkworm/downloader/packets/NewBlockPacket.hpp
@@ -21,15 +21,14 @@
 
 namespace silkworm {
 
-    struct NewBlockPacket {
-        Block block;
-        BigInt td; // total difficulty
-    };
+struct NewBlockPacket {
+    Block block;
+    BigInt td;  // total difficulty
+};
 
 namespace rlp {
     inline void encode(Bytes& to, const NewBlockPacket& from) noexcept {
-        rlp::Header rlp_head{true,
-                             rlp::length(from.block) + rlp::length(from.td)};
+        rlp::Header rlp_head{true, rlp::length(from.block) + rlp::length(from.td)};
 
         rlp::encode_header(to, rlp_head);
 
@@ -38,8 +37,7 @@ namespace rlp {
     }
 
     inline size_t length(const NewBlockPacket& from) noexcept {
-        rlp::Header rlp_head{true,
-                             rlp::length(from.block) + rlp::length(from.td)};
+        rlp::Header rlp_head{true, rlp::length(from.block) + rlp::length(from.td)};
 
         size_t rlp_head_len = rlp::length_of_length(rlp_head.payload_length);
         return rlp_head_len + rlp_head.payload_length;
@@ -47,7 +45,6 @@ namespace rlp {
 
     template <>
     inline rlp::DecodingResult decode(ByteView& from, NewBlockPacket& to) noexcept {
-
         auto [rlp_head, err]{decode_header(from)};
         if (err != DecodingResult::kOk) {
             return err;
@@ -68,14 +65,13 @@ namespace rlp {
         return from.length() == leftover ? DecodingResult::kOk : DecodingResult::kListLengthMismatch;
     }
 
+}  // namespace rlp
+
+inline std::ostream& operator<<(std::ostream& os, const NewBlockPacket& packet) {
+    os << "block num " << packet.block.header.number;
+    return os;
 }
 
-    inline std::ostream& operator<<(std::ostream& os, const NewBlockPacket& packet)
-    {
-        os << "block num " << packet.block.header.number;
-        return os;
-    }
-
-}
+}  // namespace silkworm
 
 #endif  // SILKWORM_NEWBLOCKPACKET_HPP

--- a/node/silkworm/downloader/packets/RLPDecoding.cpp
+++ b/node/silkworm/downloader/packets/RLPDecoding.cpp
@@ -16,62 +16,65 @@
 
 // types
 #include <silkworm/downloader/Types.hpp>
+
 #include "BlockBodiesPacket.hpp"
 #include "BlockHeadersPacket.hpp"
-#include "GetBlockHeadersPacket.hpp"
 #include "GetBlockBodiesPacket.hpp"
+#include "GetBlockHeadersPacket.hpp"
 #include "NewBlockHashesPacket.hpp"
 
 // generic implementations (must follow types)
 #include <silkworm/rlp/decode.hpp>
+
 #include "RLPVectorCoding.hpp"
 
 // specific implementations
 namespace silkworm::rlp {
 
-    rlp::DecodingResult decode(ByteView& from, Hash& to) noexcept {
-        return rlp::decode(from, dynamic_cast<evmc::bytes32&>(to));
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, BlockBodiesPacket& to) noexcept {
-        return rlp::decode_vec(from, to);  // decode_vec
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, BlockHeadersPacket& to) noexcept {
-        return rlp::decode_vec(from, to); //decode_vec
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, GetBlockBodiesPacket& to) noexcept {
-        return rlp::decode_vec(from, to); //decode_vec
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, NewBlockHashesPacket& to) noexcept {
-        return rlp::decode_vec(from, to); // decode_vec
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, GetBlockHeadersPacket66& to) noexcept {
-        return rlp::decode_eth66(from, to);
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, BlockBodiesPacket66& to) noexcept {
-        return rlp::decode_eth66(from, to);
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, BlockHeadersPacket66& to) noexcept {
-        return rlp::decode_eth66(from, to);
-    }
-
-    template <>
-    rlp::DecodingResult decode(ByteView& from, GetBlockBodiesPacket66& to) noexcept {
-        return rlp::decode_eth66(from, to);
-    }
+rlp::DecodingResult decode(ByteView& from, Hash& to) noexcept {
+    return rlp::decode(from, dynamic_cast<evmc::bytes32&>(to));
 }
+
+template <>
+rlp::DecodingResult decode(ByteView& from, BlockBodiesPacket& to) noexcept {
+    return rlp::decode_vec(from, to);  // decode_vec
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, BlockHeadersPacket& to) noexcept {
+    return rlp::decode_vec(from, to);  // decode_vec
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, GetBlockBodiesPacket& to) noexcept {
+    return rlp::decode_vec(from, to);  // decode_vec
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, NewBlockHashesPacket& to) noexcept {
+    return rlp::decode_vec(from, to);  // decode_vec
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, GetBlockHeadersPacket66& to) noexcept {
+    return rlp::decode_eth66(from, to);
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, BlockBodiesPacket66& to) noexcept {
+    return rlp::decode_eth66(from, to);
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, BlockHeadersPacket66& to) noexcept {
+    return rlp::decode_eth66(from, to);
+}
+
+template <>
+rlp::DecodingResult decode(ByteView& from, GetBlockBodiesPacket66& to) noexcept {
+    return rlp::decode_eth66(from, to);
+}
+
+}  // namespace silkworm::rlp
 
 #include "RLPEth66PacketCoding.hpp"

--- a/node/silkworm/downloader/packets/RLPEncoding.cpp
+++ b/node/silkworm/downloader/packets/RLPEncoding.cpp
@@ -14,10 +14,9 @@
    limitations under the License.
 */
 
-
-
 // types
 #include <silkworm/downloader/Types.hpp>
+
 #include "BlockBodiesPacket.hpp"
 #include "BlockHeadersPacket.hpp"
 #include "GetBlockBodiesPacket.hpp"
@@ -25,22 +24,16 @@
 
 // generic implementations (must follow types)
 #include <silkworm/rlp/encode.hpp>
+
 #include "RLPEth66PacketCoding.hpp"
 #include "RLPVectorCoding.hpp"
 
 namespace silkworm::rlp {
 
-    void encode(Bytes& to, const Hash& h) {
-        rlp::encode(to, dynamic_cast<const evmc::bytes32&>(h));
-    }
+void encode(Bytes& to, const Hash& h) { rlp::encode(to, dynamic_cast<const evmc::bytes32&>(h)); }
 
-    void encode(Bytes& to, const NewBlockHashesPacket& from) {
-        rlp::encode_vec(to, from);
-    }
+void encode(Bytes& to, const NewBlockHashesPacket& from) { rlp::encode_vec(to, from); }
 
-    size_t length(const NewBlockHashesPacket& from) {
-        return rlp::length_vec(from);
-    }
+size_t length(const NewBlockHashesPacket& from) { return rlp::length_vec(from); }
 
-}
-
+}  // namespace silkworm::rlp

--- a/node/silkworm/downloader/packets/RLPError.hpp
+++ b/node/silkworm/downloader/packets/RLPError.hpp
@@ -19,12 +19,12 @@
 
 namespace silkworm::rlp {
 
-    class rlp_error : public std::runtime_error {
-      public:
-        rlp_error() : std::runtime_error("rlp encoding/decoding error") {}
-        rlp_error(const std::string& description) : std::runtime_error(description) {}
-    };
+class rlp_error : public std::runtime_error {
+  public:
+    rlp_error() : std::runtime_error("rlp encoding/decoding error") {}
+    rlp_error(const std::string& description) : std::runtime_error(description) {}
+};
 
-}
+}  // namespace silkworm::rlp
 
 #endif  // SILKWORM_RLPERROR_HPP

--- a/node/silkworm/downloader/packets/RLPEth66PacketCoding.hpp
+++ b/node/silkworm/downloader/packets/RLPEth66PacketCoding.hpp
@@ -17,24 +17,26 @@
 #ifndef SILKWORM_RLPETH66PACKETS_HPP
 #define SILKWORM_RLPETH66PACKETS_HPP
 
-#include <silkworm/downloader/Types.hpp>
 #include <type_traits>
+
+#include <silkworm/downloader/Types.hpp>
 
 namespace silkworm::rlp {
 
 /*
- * This concepts recognizes an eth66 packet and enable us to write generic encode/decode functions but require a c++20 compiler
+ * This concepts recognizes an eth66 packet and enable us to write generic encode/decode functions but require a c++20
+ * compiler
  */
-//template <class T>
-//concept Eth66Packet = requires(T p) {
+// template <class T>
+// concept Eth66Packet = requires(T p) {
 //    p.requestId;
 //    p.request;
 //};
 
-
-//template <Eth66Packet T> // we will use this definition when we will have a c++20 compiler
-template<typename T, typename std::enable_if_t<std::is_integral<decltype(T::requestId)>::value &&
-                                               std::is_class<decltype(T::request)>::value, bool> = true >
+// template <Eth66Packet T> // we will use this definition when we will have a c++20 compiler
+template <typename T, typename std::enable_if_t<std::is_integral<decltype(T::requestId)>::value &&
+                                                    std::is_class<decltype(T::request)>::value,
+                                                bool> = true>
 inline void encode(Bytes& to, const T& from) noexcept {
     rlp::Header rlp_head{true, 0};
 
@@ -47,9 +49,10 @@ inline void encode(Bytes& to, const T& from) noexcept {
     rlp::encode(to, from.request);
 }
 
-//template <Eth66Packet T> // we will use this definition when we will have a c++20 compiler
-template<typename T, typename std::enable_if_t<std::is_integral<decltype(T::requestId)>::value &&
-                                               std::is_class<decltype(T::request)>::value, bool> = true >
+// template <Eth66Packet T> // we will use this definition when we will have a c++20 compiler
+template <typename T, typename std::enable_if_t<std::is_integral<decltype(T::requestId)>::value &&
+                                                    std::is_class<decltype(T::request)>::value,
+                                                bool> = true>
 inline size_t length(const T& from) noexcept {
     rlp::Header rlp_head{true, 0};
 
@@ -63,13 +66,15 @@ inline size_t length(const T& from) noexcept {
 
 /*
  * The constrained generic decode function below clashes with decode<T> defined in silkworm/core/rlp packet:
- *  - using concepts template<Eth66Packet T> decode(...) compiler resolves ambiguity because the concept version is more constrained of template<typename T> decode(...)
- *  - using enable_if doesn't work because the compiler doesn't resolve the clash with decode<T> defined in silkworm/core/rlp packet
+ *  - using concepts template<Eth66Packet T> decode(...) compiler resolves ambiguity because the concept version is more
+ * constrained of template<typename T> decode(...)
+ *  - using enable_if doesn't work because the compiler doesn't resolve the clash with decode<T> defined in
+ * silkworm/core/rlp packet
  */
-//template <Eth66Packet T>
-//template<typename T, typename std::enable_if_t<std::is_integral<decltype(T::requestId)>::value &&
+// template <Eth66Packet T>
+// template<typename T, typename std::enable_if_t<std::is_integral<decltype(T::requestId)>::value &&
 //                                               std::is_class<decltype(T::request)>::value, bool> = true >
-//inline rlp::DecodingResult decode(ByteView& from, T& to) noexcept;
+// inline rlp::DecodingResult decode(ByteView& from, T& to) noexcept;
 
 template <typename T>
 inline rlp::DecodingResult decode_eth66(ByteView& from, T& to) noexcept {
@@ -95,6 +100,6 @@ inline rlp::DecodingResult decode_eth66(ByteView& from, T& to) noexcept {
     return from.length() == leftover ? DecodingResult::kOk : DecodingResult::kListLengthMismatch;
 }
 
-}
+}  // namespace silkworm::rlp
 
 #endif  // SILKWORM_RLPETH66PACKETS_HPP

--- a/node/silkworm/downloader/packets/RLPVectorCoding.hpp
+++ b/node/silkworm/downloader/packets/RLPVectorCoding.hpp
@@ -22,57 +22,56 @@
 /*
  * decode a generic vector
  *
- * Please note that the implementation need to know how to decode concrete T elements, so headers organization is critical.
- * For this reason it is hard to use the decode_vector() func defined in silkworm/core/rlp module because it is in a header
- * with other decode(concrete-type) functions so it is not possible to insert other decode(concrete-type) in the middle.
- * So we use this file in this module.
+ * Please note that the implementation need to know how to decode concrete T elements, so headers organization is
+ * critical. For this reason it is hard to use the decode_vector() func defined in silkworm/core/rlp module because it
+ * is in a header with other decode(concrete-type) functions so it is not possible to insert other decode(concrete-type)
+ * in the middle. So we use this file in this module.
  */
 namespace silkworm::rlp {
-    template <class T>
-    inline void encode_vec(Bytes& to, const std::vector<T>& v) {
-        Header h{true, 0};
-        for (const T& x : v) {
-            h.payload_length += length(x);
-        }
-        encode_header(to, h);
-        for (const T& x : v) {
-            encode(to, x);
-        }
+template <class T>
+inline void encode_vec(Bytes& to, const std::vector<T>& v) {
+    Header h{true, 0};
+    for (const T& x : v) {
+        h.payload_length += length(x);
     }
-
-    template <class T>
-    inline size_t length_vec(const std::vector<T>& v) {
-        size_t payload_length{0};
-        for (const T& x : v) {
-            payload_length += length(x);
-        }
-        return length_of_length(payload_length) + payload_length;
-    }
-
-    template <class T>
-    inline DecodingResult decode_vec(ByteView& from, std::vector<T>& to) {
-        auto [h, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
-        }
-        if (!h.list) {
-            return DecodingResult::kUnexpectedString;
-        }
-
-        to.clear();
-
-        ByteView payload_view{from.substr(0, h.payload_length)};
-        while (!payload_view.empty()) {
-            to.emplace_back();
-            if (err = decode(payload_view, to.back()); err != DecodingResult::kOk) {
-                return err;
-            }
-        }
-
-        from.remove_prefix(h.payload_length);
-        return DecodingResult::kOk;
+    encode_header(to, h);
+    for (const T& x : v) {
+        encode(to, x);
     }
 }
 
+template <class T>
+inline size_t length_vec(const std::vector<T>& v) {
+    size_t payload_length{0};
+    for (const T& x : v) {
+        payload_length += length(x);
+    }
+    return length_of_length(payload_length) + payload_length;
+}
+
+template <class T>
+inline DecodingResult decode_vec(ByteView& from, std::vector<T>& to) {
+    auto [h, err]{decode_header(from)};
+    if (err != DecodingResult::kOk) {
+        return err;
+    }
+    if (!h.list) {
+        return DecodingResult::kUnexpectedString;
+    }
+
+    to.clear();
+
+    ByteView payload_view{from.substr(0, h.payload_length)};
+    while (!payload_view.empty()) {
+        to.emplace_back();
+        if (err = decode(payload_view, to.back()); err != DecodingResult::kOk) {
+            return err;
+        }
+    }
+
+    from.remove_prefix(h.payload_length);
+    return DecodingResult::kOk;
+}
+}  // namespace silkworm::rlp
 
 #endif  // SILKWORM_RLPVECTOR_HPP

--- a/node/silkworm/downloader/rpc/PeerMinBlock.cpp
+++ b/node/silkworm/downloader/rpc/PeerMinBlock.cpp
@@ -18,11 +18,10 @@
 
 namespace silkworm::rpc {
 
-PeerMinBlock::PeerMinBlock(const std::string& peerId, BlockNum minBlock):
-    AsyncUnaryCall("PeerMinBlock", &sentry::Sentry::Stub::PrepareAsyncPeerMinBlock, {})
-{
+PeerMinBlock::PeerMinBlock(const std::string& peerId, BlockNum minBlock)
+    : AsyncUnaryCall("PeerMinBlock", &sentry::Sentry::Stub::PrepareAsyncPeerMinBlock, {}) {
     request_.set_allocated_peer_id(to_H512(peerId).release());
     request_.set_min_block(minBlock);  // take ownership
 }
 
-}
+}  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/PeerMinBlock.hpp
+++ b/node/silkworm/downloader/rpc/PeerMinBlock.hpp
@@ -21,16 +21,17 @@
 
 namespace silkworm::rpc {
 
-class PeerMinBlock: public rpc::AsyncUnaryCall<sentry::Sentry, sentry::PeerMinBlockRequest, google::protobuf::Empty> {
+class PeerMinBlock : public rpc::AsyncUnaryCall<sentry::Sentry, sentry::PeerMinBlockRequest, google::protobuf::Empty> {
   public:
     PeerMinBlock(const std::string& peerId, BlockNum minBlock);
 
     using SentryRpc::on_receive_reply;
 
-    static auto make(const std::string& peerId, BlockNum minBlock)
-    {return std::make_shared<PeerMinBlock>(peerId, minBlock);}
+    static auto make(const std::string& peerId, BlockNum minBlock) {
+        return std::make_shared<PeerMinBlock>(peerId, minBlock);
+    }
 };
 
-}
+}  // namespace silkworm::rpc
 
 #endif  // SILKWORM_PEERMINBLOCK_HPP

--- a/node/silkworm/downloader/rpc/ReceiveMessages.cpp
+++ b/node/silkworm/downloader/rpc/ReceiveMessages.cpp
@@ -18,18 +18,17 @@
 
 namespace silkworm::rpc {
 
-ReceiveMessages::ReceiveMessages():
-    AsyncOutStreamingCall("ReceiveMessages", &sentry::Sentry::Stub::PrepareAsyncMessages, {}) {
-
+ReceiveMessages::ReceiveMessages()
+    : AsyncOutStreamingCall("ReceiveMessages", &sentry::Sentry::Stub::PrepareAsyncMessages, {}) {
     // previous RecvMessages
-    //request_.add_ids(sentry::MessageId::BLOCK_HEADERS_66);
-    //request_.add_ids(sentry::MessageId::BLOCK_BODIES_66);
+    // request_.add_ids(sentry::MessageId::BLOCK_HEADERS_66);
+    // request_.add_ids(sentry::MessageId::BLOCK_BODIES_66);
     request_.add_ids(sentry::MessageId::NEW_BLOCK_HASHES_66);
-    //request_.add_ids(sentry::MessageId::NEW_BLOCK_66);
+    // request_.add_ids(sentry::MessageId::NEW_BLOCK_66);
 
     // previous RecvUploadMessages
     request_.add_ids(sentry::MessageId::GET_BLOCK_HEADERS_66);
-    request_.add_ids(sentry::MessageId::GET_BLOCK_BODIES_66);
+     request_.add_ids(sentry::MessageId::GET_BLOCK_BODIES_66);
+}
 
-}
-}
+}  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/ReceiveMessages.hpp
+++ b/node/silkworm/downloader/rpc/ReceiveMessages.hpp
@@ -21,16 +21,16 @@
 
 namespace silkworm::rpc {
 
-class ReceiveMessages: public rpc::AsyncOutStreamingCall<sentry::Sentry, sentry::MessagesRequest, sentry::InboundMessage> {
+class ReceiveMessages
+    : public rpc::AsyncOutStreamingCall<sentry::Sentry, sentry::MessagesRequest, sentry::InboundMessage> {
   public:
     ReceiveMessages();
 
     using SentryRpc::on_receive_reply;
 
-    static std::shared_ptr<ReceiveMessages> make() {return std::make_shared<ReceiveMessages>();}
+    static std::shared_ptr<ReceiveMessages> make() { return std::make_shared<ReceiveMessages>(); }
 };
 
-}
-
+}  // namespace silkworm::rpc
 
 #endif  // SILKWORM_RECEIVEMESSAGES_HPP

--- a/node/silkworm/downloader/rpc/SendMessageById.cpp
+++ b/node/silkworm/downloader/rpc/SendMessageById.cpp
@@ -18,11 +18,10 @@
 
 namespace silkworm::rpc {
 
-SendMessageById::SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message):
-    AsyncUnaryCall("SendMessageById", &sentry::Sentry::Stub::PrepareAsyncSendMessageById, {})
-{
+SendMessageById::SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
+    : AsyncUnaryCall("SendMessageById", &sentry::Sentry::Stub::PrepareAsyncSendMessageById, {}) {
     request_.set_allocated_peer_id(to_H512(peerId).release());
     request_.set_allocated_data(message.release());  // take ownership
 }
 
-}
+}  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/SendMessageById.hpp
+++ b/node/silkworm/downloader/rpc/SendMessageById.hpp
@@ -21,15 +21,17 @@
 
 namespace silkworm::rpc {
 
-class SendMessageById: public rpc::AsyncUnaryCall<sentry::Sentry, sentry::SendMessageByIdRequest, sentry::SentPeers> {
+class SendMessageById : public rpc::AsyncUnaryCall<sentry::Sentry, sentry::SendMessageByIdRequest, sentry::SentPeers> {
   public:
     SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message);
 
     using SentryRpc::on_receive_reply;
 
-    static auto make(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
-        {return std::make_shared<SendMessageById>(peerId, std::move(message));}
+    static auto make(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message) {
+        return std::make_shared<SendMessageById>(peerId, std::move(message));
+    }
 };
 
-}
+}  // namespace silkworm::rpc
+
 #endif  // SILKWORM_SENDMESSAGEBYID_HPP

--- a/node/silkworm/downloader/rpc/SendMessageByMinBlock.cpp
+++ b/node/silkworm/downloader/rpc/SendMessageByMinBlock.cpp
@@ -18,11 +18,10 @@
 
 namespace silkworm::rpc {
 
-SendMessageByMinBlock::SendMessageByMinBlock(BlockNum min_block, std::unique_ptr<sentry::OutboundMessageData> message):
-    AsyncUnaryCall("SendMessageByMinBlock", &sentry::Sentry::Stub::PrepareAsyncSendMessageByMinBlock, {})
-{
+SendMessageByMinBlock::SendMessageByMinBlock(BlockNum min_block, std::unique_ptr<sentry::OutboundMessageData> message)
+    : AsyncUnaryCall("SendMessageByMinBlock", &sentry::Sentry::Stub::PrepareAsyncSendMessageByMinBlock, {}) {
     request_.set_min_block(min_block);
     request_.set_allocated_data(message.release());  // take ownership
 }
 
-}
+}  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/SendMessageByMinBlock.hpp
+++ b/node/silkworm/downloader/rpc/SendMessageByMinBlock.hpp
@@ -21,16 +21,18 @@
 
 namespace silkworm::rpc {
 
-class SendMessageByMinBlock: public rpc::AsyncUnaryCall<sentry::Sentry, sentry::SendMessageByMinBlockRequest, sentry::SentPeers> {
+class SendMessageByMinBlock
+    : public rpc::AsyncUnaryCall<sentry::Sentry, sentry::SendMessageByMinBlockRequest, sentry::SentPeers> {
   public:
     SendMessageByMinBlock(BlockNum min_block, std::unique_ptr<sentry::OutboundMessageData> message);
 
     using SentryRpc::on_receive_reply;
 
-    static auto make(BlockNum min_block, std::unique_ptr<sentry::OutboundMessageData> message)
-    {return std::make_shared<SendMessageByMinBlock>(min_block, std::move(message));}
+    static auto make(BlockNum min_block, std::unique_ptr<sentry::OutboundMessageData> message) {
+        return std::make_shared<SendMessageByMinBlock>(min_block, std::move(message));
+    }
 };
 
-}
+}  // namespace silkworm::rpc
 
 #endif  // SILKWORM_SENDMESSAGEBYMINBLOCK_HPP

--- a/node/silkworm/downloader/rpc/SetStatus.cpp
+++ b/node/silkworm/downloader/rpc/SetStatus.cpp
@@ -18,20 +18,21 @@
 
 namespace silkworm::rpc {
 
-SetStatus::SetStatus(ChainConfig chain, Hash genesis, std::vector<BlockNum> hard_forks, Hash best_hash, BigInt total_difficulty):
-    AsyncUnaryCall("SetStatus", &sentry::Sentry::Stub::PrepareAsyncSetStatus, {})
-{
+SetStatus::SetStatus(ChainConfig chain, Hash genesis, std::vector<BlockNum> hard_forks, Hash best_hash,
+                     BigInt total_difficulty)
+    : AsyncUnaryCall("SetStatus", &sentry::Sentry::Stub::PrepareAsyncSetStatus, {}) {
     request_.set_network_id(chain.chain_id);
 
-    request_.set_allocated_total_difficulty(to_H256(total_difficulty).release()); // remove trailing zeros???
+    request_.set_allocated_total_difficulty(to_H256(total_difficulty).release());  // remove trailing zeros???
 
     request_.set_allocated_best_hash(to_H256(best_hash).release());
 
     auto* forks = new sentry::Forks{};
     forks->set_allocated_genesis(to_H256(genesis).release());
-    for(uint64_t block: hard_forks)
+    for (uint64_t block : hard_forks) {
         forks->add_forks(block);
-    request_.set_allocated_fork_data(forks); // take ownership
+    }
+    request_.set_allocated_fork_data(forks);  // take ownership
 }
 
-}
+}  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/SetStatus.hpp
+++ b/node/silkworm/downloader/rpc/SetStatus.hpp
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+
 #include <silkworm/chain/config.hpp>
 #include <silkworm/downloader/SentryClient.hpp>
 #include <silkworm/downloader/Types.hpp>
@@ -27,14 +28,17 @@ namespace silkworm::rpc {
 
 class SetStatus : public rpc::AsyncUnaryCall<sentry::Sentry, sentry::StatusData, sentry::SetStatusReply> {
   public:
-    SetStatus(ChainConfig chain, Hash genesis, std::vector<BlockNum> hard_forks, Hash best_hash, BigInt total_difficulty);
+    SetStatus(ChainConfig chain, Hash genesis, std::vector<BlockNum> hard_forks, Hash best_hash,
+              BigInt total_difficulty);
 
     using SentryRpc::on_receive_reply;
 
-    static std::shared_ptr<SetStatus> make(ChainConfig chain, Hash genesis, std::vector<BlockNum> hard_forks, Hash best_hash, BigInt total_difficulty) {
-        return std::make_shared<SetStatus>(chain, genesis, hard_forks, best_hash, total_difficulty);}
+    static std::shared_ptr<SetStatus> make(ChainConfig chain, Hash genesis, std::vector<BlockNum> hard_forks,
+                                           Hash best_hash, BigInt total_difficulty) {
+        return std::make_shared<SetStatus>(chain, genesis, hard_forks, best_hash, total_difficulty);
+    }
 };
 
-}
+}  // namespace silkworm::rpc
 
 #endif  // SILKWORM_SETSTATUS_HPP

--- a/node/silkworm/etl/buffer.hpp
+++ b/node/silkworm/etl/buffer.hpp
@@ -36,9 +36,7 @@ class Buffer {
     Buffer(const Buffer&) = delete;
     Buffer& operator=(const Buffer&) = delete;
 
-    explicit Buffer(size_t optimal_size) : optimal_size_(optimal_size) {
-        buffer_.reserve(kInitialBufferCapacity);
-    }
+    explicit Buffer(size_t optimal_size) : optimal_size_(optimal_size) { buffer_.reserve(kInitialBufferCapacity); }
 
     void put(const Entry& entry) {
         // Add a new entry to the buffer
@@ -52,7 +50,7 @@ class Buffer {
         buffer_.push_back(std::move(entry));
     }
 
-    void clear() noexcept { 
+    void clear() noexcept {
         // Set the buffer to contain 0 entries
         buffer_.resize(0);
         size_ = 0;
@@ -60,22 +58,20 @@ class Buffer {
 
     bool overflows() const noexcept {
         // Whether or not accounted size overflows optimal_size_ (i.e. time to flush)
-        return size_ >= optimal_size_; 
+        return size_ >= optimal_size_;
     }
 
     void sort() {
         // Sort buffer in increasing order by key comparison
-        std::sort(buffer_.begin(), buffer_.end()); 
+        std::sort(buffer_.begin(), buffer_.end());
     }
 
     size_t size() const noexcept {
         // Actual size of accounted data
-        return size_; 
+        return size_;
     }
 
-    const std::vector<Entry>& entries() const noexcept {
-        return buffer_; 
-    }
+    const std::vector<Entry>& entries() const noexcept { return buffer_; }
 
   private:
     size_t optimal_size_;

--- a/node/silkworm/etl/collector.hpp
+++ b/node/silkworm/etl/collector.hpp
@@ -32,7 +32,6 @@ typedef void (*LoadFunc)(Entry, mdbx::cursor&, MDBX_put_flags_t);
 // Collects data Extracted from db
 class Collector {
   public:
-
     // Not copyable nor movable
     Collector(const Collector&) = delete;
     Collector& operator=(const Collector&) = delete;
@@ -58,9 +57,7 @@ class Collector {
               MDBX_put_flags_t flags = MDBX_put_flags_t::MDBX_UPSERT, uint32_t log_every_percent = 100u);
 
     //! \brief Returns the number of actually collected items
-    size_t size() const {
-        return size_;
-    }
+    size_t size() const { return size_; }
 
     //! \brief Clears contents of collector and reset
     void clear() {

--- a/node/silkworm/etl/collector_test.cpp
+++ b/node/silkworm/etl/collector_test.cpp
@@ -18,8 +18,8 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/common/endian.hpp>
 #include <silkworm/common/directories.hpp>
+#include <silkworm/common/endian.hpp>
 #include <silkworm/db/tables.hpp>
 
 namespace silkworm::etl {
@@ -47,7 +47,7 @@ static std::vector<Entry> generate_entry_set(size_t size) {
     return pairs;
 }
 
-    void run_collector_test(LoadFunc load_func, bool do_copy = true) {
+void run_collector_test(LoadFunc load_func, bool do_copy = true) {
     TemporaryDirectory db_tmp_dir;
     TemporaryDirectory etl_tmp_dir;
     // Initialize random seed
@@ -67,7 +67,7 @@ static std::vector<Entry> generate_entry_set(size_t size) {
     // Collection
     for (auto&& entry : set) {
         if (do_copy)
-            collector.collect(entry); // copy is slower... do only if entry is reused afterwards
+            collector.collect(entry);  // copy is slower... do only if entry is reused afterwards
         else
             collector.collect(std::move(entry));
     }

--- a/node/silkworm/stagedsync/history_index_test.cpp
+++ b/node/silkworm/stagedsync/history_index_test.cpp
@@ -150,7 +150,7 @@ TEST_CASE("Stage History") {
     auto bitmap_storage_contract_bytes{storage_history_table.lower_bound(db::to_slice(composite)).value};
     // Bitmaps computing for storage
     auto bitmap_storage_contract{roaring::Roaring64Map::readSafe(
-    byte_ptr_cast(db::from_slice(bitmap_storage_contract_bytes).data()), bitmap_storage_contract_bytes.size())};
+        byte_ptr_cast(db::from_slice(bitmap_storage_contract_bytes).data()), bitmap_storage_contract_bytes.size())};
     // Checks on storage's bitmaps
     CHECK(bitmap_storage_contract.cardinality() == 3);
     CHECK(bitmap_storage_contract.toString() == "{1,2,3}");

--- a/node/silkworm/stagedsync/recovery/recovery_farm.cpp
+++ b/node/silkworm/stagedsync/recovery/recovery_farm.cpp
@@ -123,11 +123,10 @@ StageResult RecoveryFarm::recover(uint64_t height_from, uint64_t height_to) {
         // Get the body and its transactions
         auto body_rlp{db::from_slice(block_data.value)};
         auto block_body{db::detail::decode_stored_block_body(body_rlp)};
- 
 
         std::vector<Transaction> transactions{
             db::read_transactions(transactions_table, block_body.base_txn_id, block_body.txn_count)};
-       
+
         if (transactions.size()) {
             if (((*batch_).size() + transactions.size()) > max_batch_size_) {
                 dispatch_batch(true);
@@ -174,11 +173,11 @@ StageResult RecoveryFarm::recover(uint64_t height_from, uint64_t height_to) {
 StageResult RecoveryFarm::unwind(uint64_t new_height) {
     SILKWORM_LOG(LogLevel::Info) << "Unwinding Senders' table to height " << new_height << std::endl;
     auto unwind_table{db::open_cursor(db_transaction_, db::table::kSenders)};
-    auto unwind_bytes_point{db::block_key(new_height+1)};
+    auto unwind_bytes_point{db::block_key(new_height + 1)};
     truncate_table_from(unwind_table, unwind_bytes_point);
     // Eventually update new stage height
     db::stages::set_stage_progress(db_transaction_, db::stages::kSendersKey, new_height);
-    
+
     return StageResult::kSuccess;
 }
 

--- a/node/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.cpp
@@ -66,8 +66,9 @@ StageResult stage_blockhashes(TransactionManager& txn, const std::filesystem::pa
             return StageResult::kBadBlockHash;
         }
 
-        collector.collect(etl::Entry{Bytes(static_cast<uint8_t*>(header_data.value.iov_base), header_data.value.iov_len),
-                                     Bytes(static_cast<uint8_t*>(header_data.key.iov_base), header_data.key.iov_len)});
+        collector.collect(
+            etl::Entry{Bytes(static_cast<uint8_t*>(header_data.value.iov_base), header_data.value.iov_len),
+                       Bytes(static_cast<uint8_t*>(header_data.key.iov_base), header_data.key.iov_len)});
 
         // Save last processed block_number and expect next in sequence
         ++blocks_processed_count;

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -90,7 +90,8 @@ static StageResult execute_batch_of_blocks(mdbx::txn& txn, const ChainConfig& co
     }
 }
 
-StageResult stage_execution(TransactionManager& txn, const std::filesystem::path&, size_t batch_size, uint64_t prune_from) {
+StageResult stage_execution(TransactionManager& txn, const std::filesystem::path&, size_t batch_size,
+                            uint64_t prune_from) {
     StageResult res{StageResult::kSuccess};
 
     try {
@@ -121,7 +122,8 @@ StageResult stage_execution(TransactionManager& txn, const std::filesystem::path
         (void)sw.start();
 
         for (; block_num <= max_block; ++block_num) {
-            res = execute_batch_of_blocks(*txn, chain_config.value(), max_block, storage_mode, batch_size, block_num, prune_from);
+            res = execute_batch_of_blocks(*txn, chain_config.value(), max_block, storage_mode, batch_size, block_num,
+                                          prune_from);
             if (res != StageResult::kSuccess) {
                 return res;
             }

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -256,7 +256,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
     auto contract_code_table{db::open_cursor(txn, db::table::kPlainContractCode)};
 
     Bytes start_key{db::block_key(unwind_to + 1)};
-    auto changeset_data{changeset_table.lower_bound(db::to_slice(start_key), /*throw_notfound=*/ false)};
+    auto changeset_data{changeset_table.lower_bound(db::to_slice(start_key), /*throw_notfound=*/false)};
     if (!changeset_data) {
         return;
     }
@@ -266,7 +266,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
         case silkworm::stagedsync::HashstateOperation::HashAccount:
             unwind_func = [&target_table, &code_table](::mdbx::cursor::move_result data) -> bool {
                 auto [db_key, db_value]{convert_to_db_format(db::from_slice(data.key), db::from_slice(data.value))};
-                
+
                 auto hash{keccak256(db_key)};
                 auto new_key{mdbx::slice{hash.bytes, kHashLength}};
                 if (db_value.size() == 0) {
@@ -315,7 +315,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
                 std::memcpy(&hashed_key[kHashLength], &db_key[kAddressLength], db::kIncarnationLength);
                 std::memcpy(&hashed_key[kHashLength + db::kIncarnationLength],
                             keccak256(db_key.substr(kAddressLength + db::kIncarnationLength)).bytes, kHashLength);
-                
+
                 if (target_table.seek(db::to_slice(hashed_key))) {
                     target_table.erase();
                 }
@@ -347,7 +347,7 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
                 if (target_table.seek(db::to_slice(hashed_key))) {
                     target_table.erase();
                 }
-                
+
                 target_table.upsert(db::to_slice(hashed_key), code_hash_data.value);
                 return true;
             };

--- a/node/silkworm/stagedsync/stagedsync.hpp
+++ b/node/silkworm/stagedsync/stagedsync.hpp
@@ -31,24 +31,26 @@ namespace silkworm::stagedsync {
 constexpr size_t kDefaultBatchSize = 512_Mebi;
 constexpr size_t kDefaultRecoverySenderBatch = 50'000;  // This a number of transactions not number of bytes
 
-typedef StageResult (*StageFunc)(TransactionManager&, const std::filesystem::path& etl_path,  uint64_t prune_from);
-typedef StageResult (*UnwindFunc)(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to );
-typedef StageResult (*PruneFunc)(TransactionManager&, const std::filesystem::path& etl_path,  uint64_t prune_from);
+typedef StageResult (*StageFunc)(TransactionManager&, const std::filesystem::path& etl_path, uint64_t prune_from);
+typedef StageResult (*UnwindFunc)(TransactionManager&, const std::filesystem::path& etl_path, uint64_t unwind_to);
+typedef StageResult (*PruneFunc)(TransactionManager&, const std::filesystem::path& etl_path, uint64_t prune_from);
 
 struct Stage {
-    StageFunc   stage_func;
+    StageFunc stage_func;
     UnwindFunc unwind_func;
-    PruneFunc   prune_func;
-    uint64_t            id;
+    PruneFunc prune_func;
+    uint64_t id;
 };
 
 // Stage functions
-StageResult stage_headers    (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_headers(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
 StageResult stage_blockhashes(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_bodies     (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_senders    (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_execution  (TransactionManager& txn, const std::filesystem::path& etl_path, size_t batch_size, uint64_t prune_from);
-inline StageResult stage_execution(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0) {
+StageResult stage_bodies(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_senders(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_execution(TransactionManager& txn, const std::filesystem::path& etl_path, size_t batch_size,
+                            uint64_t prune_from);
+inline StageResult stage_execution(TransactionManager& txn, const std::filesystem::path& etl_path,
+                                   uint64_t prune_from = 0) {
     return stage_execution(txn, etl_path, kDefaultBatchSize, prune_from);
 }
 
@@ -72,36 +74,38 @@ void hashstate_promote_clean_code(mdbx::txn& txn, const std::filesystem::path& e
 void hashstate_promote_clean_state(mdbx::txn& txn, const std::filesystem::path& etl_path);
 
 /* **************************** */
-StageResult stage_hashstate      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_interhashes    (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_account_history(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_storage_history(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_log_index      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
-StageResult stage_tx_lookup      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_hashstate(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_interhashes(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_account_history(TransactionManager& txn, const std::filesystem::path& etl_path,
+                                  uint64_t prune_from = 0);
+StageResult stage_storage_history(TransactionManager& txn, const std::filesystem::path& etl_path,
+                                  uint64_t prune_from = 0);
+StageResult stage_log_index(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
+StageResult stage_tx_lookup(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from = 0);
 
 // Unwind functions
-StageResult no_unwind             (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_blockhashes    (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_senders        (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_execution      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_hashstate      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_interhashes    (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult no_unwind(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_blockhashes(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_senders(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_execution(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_hashstate(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_interhashes(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
 StageResult unwind_account_history(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
 StageResult unwind_storage_history(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_log_index      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
-StageResult unwind_tx_lookup      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_log_index(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
+StageResult unwind_tx_lookup(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t unwind_to);
 // Prune functions
-StageResult no_prune             (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
-StageResult prune_senders        (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
-StageResult prune_execution      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
+StageResult no_prune(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
+StageResult prune_senders(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
+StageResult prune_execution(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
 StageResult prune_account_history(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
 StageResult prune_storage_history(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
-StageResult prune_log_index      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
-StageResult prune_tx_lookup      (TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
+StageResult prune_log_index(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
+StageResult prune_tx_lookup(TransactionManager& txn, const std::filesystem::path& etl_path, uint64_t prune_from);
 
 std::vector<Stage> get_archive_node_stages();
-std::vector<Stage> get_pruned_node_stages ();
-std::vector<Stage> get_miner_mode_stages  ();
+std::vector<Stage> get_pruned_node_stages();
+std::vector<Stage> get_miner_mode_stages();
 
 }  // namespace silkworm::stagedsync
 

--- a/node/silkworm/stagedsync/stages.cpp
+++ b/node/silkworm/stagedsync/stages.cpp
@@ -19,49 +19,49 @@
 namespace silkworm::stagedsync {
 
 StageResult no_unwind(TransactionManager&, const std::filesystem::path&, uint64_t) { return StageResult::kSuccess; }
-StageResult no_prune(TransactionManager&, const std::filesystem::path&, uint64_t)  { return StageResult::kSuccess; }
+StageResult no_prune(TransactionManager&, const std::filesystem::path&, uint64_t) { return StageResult::kSuccess; }
 
 std::vector<Stage> get_archive_node_stages() {
     return {
-        {stage_headers,         no_unwind,              no_prune, 1},
-        {stage_blockhashes,     unwind_blockhashes,     no_prune, 2},
-        {stage_bodies,          no_unwind,              no_prune, 3},
-        {stage_senders,         unwind_senders,         no_prune, 4},
-        {stage_execution,       unwind_execution,       no_prune, 5},
-        {stage_hashstate,       unwind_hashstate,       no_prune, 6},
-        {stage_interhashes,     unwind_interhashes,     no_prune, 7},
+        {stage_headers, no_unwind, no_prune, 1},
+        {stage_blockhashes, unwind_blockhashes, no_prune, 2},
+        {stage_bodies, no_unwind, no_prune, 3},
+        {stage_senders, unwind_senders, no_prune, 4},
+        {stage_execution, unwind_execution, no_prune, 5},
+        {stage_hashstate, unwind_hashstate, no_prune, 6},
+        {stage_interhashes, unwind_interhashes, no_prune, 7},
         {stage_account_history, unwind_account_history, no_prune, 8},
         {stage_storage_history, unwind_storage_history, no_prune, 9},
-        {stage_log_index,       unwind_log_index,       no_prune, 10},
-        {stage_tx_lookup,       unwind_tx_lookup,       no_prune, 11},
+        {stage_log_index, unwind_log_index, no_prune, 10},
+        {stage_tx_lookup, unwind_tx_lookup, no_prune, 11},
     };
 }
 
 std::vector<Stage> get_pruned_node_stages() {
     return {
-        {stage_headers,         no_unwind,              no_prune,              1},
-        {stage_blockhashes,     unwind_blockhashes,     no_prune,              2},
-        {stage_bodies,          no_unwind,              no_prune,              3},
-        {stage_senders,         unwind_senders,         prune_senders,         4},
-        {stage_execution,       unwind_execution,       prune_execution,       5},
-        {stage_hashstate,       unwind_hashstate,       no_prune,              6},
-        {stage_interhashes,     unwind_interhashes,     no_prune,              7},
+        {stage_headers, no_unwind, no_prune, 1},
+        {stage_blockhashes, unwind_blockhashes, no_prune, 2},
+        {stage_bodies, no_unwind, no_prune, 3},
+        {stage_senders, unwind_senders, prune_senders, 4},
+        {stage_execution, unwind_execution, prune_execution, 5},
+        {stage_hashstate, unwind_hashstate, no_prune, 6},
+        {stage_interhashes, unwind_interhashes, no_prune, 7},
         {stage_account_history, unwind_account_history, prune_account_history, 8},
         {stage_storage_history, unwind_storage_history, prune_storage_history, 9},
-        {stage_log_index,       unwind_log_index,       prune_log_index,      10},
-        {stage_tx_lookup,       unwind_tx_lookup,       prune_tx_lookup,      11},
+        {stage_log_index, unwind_log_index, prune_log_index, 10},
+        {stage_tx_lookup, unwind_tx_lookup, prune_tx_lookup, 11},
     };
 }
 
 std::vector<Stage> get_miner_mode_stages() {
     return {
-        {stage_headers,         no_unwind,              no_prune,        1},
-        {stage_blockhashes,     unwind_blockhashes,     no_prune,        2},
-        {stage_bodies,          no_unwind,              no_prune,        3},
-        {stage_senders,         unwind_senders,         prune_senders,   4},
-        {stage_execution,       unwind_execution,       prune_execution, 5},
-        {stage_hashstate,       unwind_hashstate,       no_prune,        6},
-        {stage_interhashes,     unwind_interhashes,     no_prune,        7},
+        {stage_headers, no_unwind, no_prune, 1},
+        {stage_blockhashes, unwind_blockhashes, no_prune, 2},
+        {stage_bodies, no_unwind, no_prune, 3},
+        {stage_senders, unwind_senders, prune_senders, 4},
+        {stage_execution, unwind_execution, prune_execution, 5},
+        {stage_hashstate, unwind_hashstate, no_prune, 6},
+        {stage_interhashes, unwind_interhashes, no_prune, 7},
     };
 }
 

--- a/node/silkworm/stagedsync/util.cpp
+++ b/node/silkworm/stagedsync/util.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 - 2021 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
 #include "util.hpp"
 
 #include <memory>
@@ -47,7 +48,7 @@ std::pair<Bytes, Bytes> convert_to_db_format(const ByteView& key, const ByteView
  * Truncate a table by starting from a certain key, either up or down.
  * If reverse is set to false, then every key either higher or equal than starting key will be erased.
  * If reverse is set to true, then every key either lower(not equal) than starting key will be erased.
-*/
+ */
 void truncate_table_from(mdbx::cursor& table, Bytes& starting_key, bool reverse) {
     auto current{table.lower_bound(db::to_slice(starting_key), false)};
     if (reverse) {
@@ -55,7 +56,7 @@ void truncate_table_from(mdbx::cursor& table, Bytes& starting_key, bool reverse)
     }
     if (current) {
         table.erase();
-        while (reverse? table.to_previous(false) : table.to_next(false)) {
+        while (reverse ? table.to_previous(false) : table.to_next(false)) {
             table.erase();
         }
     }

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -17,8 +17,9 @@
 #ifndef SILKWORM_STAGEDSYNC_UTIL_HPP_
 #define SILKWORM_STAGEDSYNC_UTIL_HPP_
 
-#include <silkworm/common/base.hpp>
 #include <mdbx.h++>
+
+#include <silkworm/common/base.hpp>
 
 /*
 Part of the compatibility layer with the Erigon DB format;
@@ -27,19 +28,9 @@ see its package dbutils.
 
 namespace silkworm::stagedsync {
 
-enum class [[nodiscard]] StageResult {
-    kSuccess,
-    kUnknownChainId,
-    kBadBlockHash,
-    kBadChainSequence,
-    kInvalidRange,
-    kInvalidBlock,
-    kMissingSenders,
-    kDecodingError,
-    kUnexpectedError,
-    kUnknownError,
-    kDbError,
-    kAborted
+enum class [[nodiscard]] StageResult{
+    kSuccess,        kUnknownChainId, kBadBlockHash,    kBadChainSequence, kInvalidRange, kInvalidBlock,
+    kMissingSenders, kDecodingError,  kUnexpectedError, kUnknownError,     kDbError,      kAborted,
 };
 
 void check_stagedsync_error(StageResult code);


### PR DESCRIPTION
In this change I formatted all files using our `.clang-format`. Rationale: https://google.github.io/styleguide/cppguide.html#Formatting