### PR TITLE
Enforce more compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,9 +185,10 @@ endif()
 
 # Compiler enforcements on Silkworm
 if(NOT MSVC)
-  add_compile_options(-Werror)
-  add_compile_options(-Wall -Wextra -Wshadow -Wimplicit-fallthrough -Wno-missing-field-initializers)
+  add_compile_options(-Werror -Wall -Wextra)
+  add_compile_options(-Wshadow -Wimplicit-fallthrough -Wsign-conversion)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
+  add_compile_options(-Wno-missing-field-initializers)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-attributes)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,10 +176,16 @@ else()
   target_compile_options(evmone PRIVATE -fno-exceptions)
 endif()
 
+# MDBX
+if(NOT SILKWORM_CORE_ONLY)
+  set(MDBX_ENABLE_TESTS OFF)
+  add_subdirectory(libmdbx)
+  target_include_directories(mdbx-static INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/libmdbx)
+endif()
 
 # Compiler enforcements on Silkworm
 if(NOT MSVC)
-  add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers)
+  add_compile_options(-Wall -Wextra -Wshadow -Werror -Wno-missing-field-initializers)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-attributes)
   endif()
@@ -194,10 +200,6 @@ add_subdirectory(core)
 
 if(NOT SILKWORM_CORE_ONLY)
   add_subdirectory(interfaces)
-
-  set(MDBX_ENABLE_TESTS OFF)
-  add_subdirectory(libmdbx)
-  target_include_directories(mdbx-static INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/libmdbx)
   add_subdirectory(node)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,9 @@ endif()
 
 # Compiler enforcements on Silkworm
 if(NOT MSVC)
-  add_compile_options(-Wall -Wextra -Wshadow -Werror -Wno-missing-field-initializers)
+  add_compile_options(-Werror)
+  add_compile_options(-Wall -Wextra -Wshadow -Wimplicit-fallthrough -Wno-missing-field-initializers)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-attributes)
   endif()

--- a/cmd/benchmark/buffer.cpp
+++ b/cmd/benchmark/buffer.cpp
@@ -83,12 +83,12 @@ int main(int argc, char* argv[]) {
         std::cout << " [Buffer-Default copy build] Done in " << sw.format(loop2_timings.second) << "\n" << std::endl;
     }
 
-    // Push all items in buffer default (nove)
+    // Push all items in buffer default (move)
     {
         etl::Buffer buffer(kDataSetSize);
         std::cout << "\n [Buffer-Default] First loop ..." << std::endl;
         sw.start();
-        for (auto&& item : (std::vector<etl::Entry>&)base_buffer.entries()) {
+        for (auto&& item : base_buffer.entries()) {
             buffer.put(std::move(item));
         }
         // buffer.sort();
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
         buffer.clear();
         std::cout << "\n [Buffer-Default] Second loop ..." << std::endl;
         sw.start();
-        for (auto&& item : (std::vector<etl::Entry>&)base_buffer2.entries()) {
+        for (auto&& item : base_buffer2.entries()) {
             buffer.put(std::move(item));
         }
         // buffer.sort();

--- a/cmd/check_pow.cpp
+++ b/cmd/check_pow.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
         // Initialize epoch
         auto epoch_num{options.block_from / ethash::epoch_length};
         SILKWORM_LOG(LogLevel::Info) << "Initializing Light Cache for DAG epoch " << epoch_num << std::endl;
-        auto epoch_context{ethash::create_epoch_context(epoch_num)};
+        auto epoch_context{ethash::create_epoch_context(static_cast<int>(epoch_num))};
 
         auto canonical_hashes{db::open_cursor(txn, db::table::kCanonicalHashes)};
 
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
             if (epoch_context->epoch_number != static_cast<int>(block_num / ethash::epoch_length)) {
                 epoch_num = (block_num / ethash::epoch_length);
                 SILKWORM_LOG(LogLevel::Info) << "Initializing Light Cache for DAG epoch " << epoch_num << std::endl;
-                epoch_context = ethash::create_epoch_context(epoch_num);
+                epoch_context = ethash::create_epoch_context(static_cast<int>(epoch_num));
             }
 
             auto block_key{db::block_key(block_num)};

--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -617,10 +617,10 @@ Status transaction_test(const nlohmann::json& j, std::optional<ChainConfig>) {
 
 // https://ethereum-tests.readthedocs.io/en/latest/test_types/difficulty_tests.html
 Status difficulty_test(const nlohmann::json& j, std::optional<ChainConfig> config) {
-    auto parent_timestamp{std::stoll(j["parentTimestamp"].get<std::string>(), 0, 0)};
+    auto parent_timestamp{std::stoull(j["parentTimestamp"].get<std::string>(), 0, 0)};
     auto parent_difficulty{intx::from_string<intx::uint256>(j["parentDifficulty"].get<std::string>())};
-    auto current_timestamp{std::stoll(j["currentTimestamp"].get<std::string>(), 0, 0)};
-    auto block_number{std::stoll(j["currentBlockNumber"].get<std::string>(), 0, 0)};
+    auto current_timestamp{std::stoull(j["currentTimestamp"].get<std::string>(), 0, 0)};
+    auto block_number{std::stoull(j["currentBlockNumber"].get<std::string>(), 0, 0)};
     auto current_difficulty{intx::from_string<intx::uint256>(j["currentDifficulty"].get<std::string>())};
 
     bool parent_has_uncles{false};

--- a/cmd/unwind_execution.cpp
+++ b/cmd/unwind_execution.cpp
@@ -32,15 +32,11 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Unwind Execution Stage"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    int64_t unwind_to{-1};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Turbo-Geth", true)
+    BlockNum unwind_to{0};
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Turbo-Geth", /*defaulted=*/true)
         ->check(CLI::ExistingDirectory);
-    app.add_option("--unwind-to", unwind_to, "Specify unwinding point", false);
+    app.add_option("--unwind-to", unwind_to, "Specify unwinding point", /*defaulted=*/false)->required();
     CLI11_PARSE(app, argc, argv);
-    if (unwind_to < 0) {
-        SILKWORM_LOG(LogLevel::Error) << "Specify valid unwinding point with --unwind-to" << std::endl;
-        return -1;
-    }
 
     try {
         auto data_dir{DataDirectory::from_chaindata(chaindata)};

--- a/core/silkworm/chain/config.cpp
+++ b/core/silkworm/chain/config.cpp
@@ -106,7 +106,7 @@ std::optional<uint64_t> ChainConfig::revision_block(evmc_revision rev) const noe
 
 void ChainConfig::set_revision_block(evmc_revision rev, std::optional<uint64_t> block) {
     if (rev > 0) {  // Frontier block is always 0
-        fork_blocks[rev - 1] = block;
+        fork_blocks[static_cast<size_t>(rev) - 1] = block;
     }
 }
 

--- a/core/silkworm/chain/config.cpp
+++ b/core/silkworm/chain/config.cpp
@@ -51,7 +51,7 @@ nlohmann::json ChainConfig::to_json() const noexcept {
             break;
     }
 
-    for (int i{0}; i < EVMC_MAX_REVISION; ++i) {
+    for (size_t i{0}; i < EVMC_MAX_REVISION; ++i) {
         member_to_json(ret, kJsonForkNames[i], fork_blocks[i]);
     }
 
@@ -77,7 +77,7 @@ std::optional<ChainConfig> ChainConfig::from_json(const nlohmann::json& json) no
         config.seal_engine = SealEngineType::kAuRA;
     }
 
-    for (int i{0}; i < EVMC_MAX_REVISION; ++i) {
+    for (size_t i{0}; i < EVMC_MAX_REVISION; ++i) {
         read_json_config_member(json, kJsonForkNames[i], config.fork_blocks[i]);
     }
 
@@ -88,9 +88,9 @@ std::optional<ChainConfig> ChainConfig::from_json(const nlohmann::json& json) no
 }
 
 evmc_revision ChainConfig::revision(uint64_t block_number) const noexcept {
-    for (int i{EVMC_MAX_REVISION - 1}; i >= 0; --i) {
-        if (fork_blocks[i].has_value() && block_number >= fork_blocks[i].value()) {
-            return static_cast<evmc_revision>(i + 1);
+    for (size_t i{EVMC_MAX_REVISION}; i > 0; --i) {
+        if (fork_blocks[i - 1].has_value() && block_number >= fork_blocks[i - 1].value()) {
+            return static_cast<evmc_revision>(i);
         }
     }
     return EVMC_FRONTIER;

--- a/core/silkworm/chain/validity.cpp
+++ b/core/silkworm/chain/validity.cpp
@@ -128,7 +128,7 @@ ValidationResult validate_block_header(const BlockHeader& header, const State& s
 
     // https://github.com/ethereum/go-ethereum/blob/v1.9.25/consensus/ethash/consensus.go#L267
     // https://eips.ethereum.org/EIPS/eip-1985
-    if (header.gas_limit > 0x7fffffffffffffff) {
+    if (header.gas_limit > INT64_MAX) {
         return ValidationResult::kInvalidGasLimit;
     }
 

--- a/core/silkworm/crypto/sha-256.c
+++ b/core/silkworm/crypto/sha-256.c
@@ -247,6 +247,9 @@ __attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(uint32_t h[8], c
     sha_256_implementation(h, input, len);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+
 // The following function was adapted from https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-x86.c
 /*   Intel SHA extensions using C intrinsics               */
 /*   Written and place in public domain by Jeffrey Walton  */
@@ -445,6 +448,8 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
     _mm_storeu_si128((__m128i*)&h[0], STATE0);
     _mm_storeu_si128((__m128i*)&h[4], STATE1);
 }
+
+#pragma GCC diagnostic pop
 
 // https://stackoverflow.com/questions/6121792/how-to-check-if-a-cpu-supports-the-sse3-instruction-set
 void cpuid(int info[4], int InfoType) { __cpuid_count(InfoType, 0, info[0], info[1], info[2], info[3]); }

--- a/core/silkworm/crypto/snark.hpp
+++ b/core/silkworm/crypto/snark.hpp
@@ -21,6 +21,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
 #pragma GCC diagnostic pop

--- a/core/silkworm/crypto/snark.hpp
+++ b/core/silkworm/crypto/snark.hpp
@@ -22,6 +22,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
 #pragma GCC diagnostic pop

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -131,7 +131,7 @@ evmc::result EVM::create(const evmc_message& message) noexcept {
             // https://eips.ethereum.org/EIPS/eip-170
             res.status_code = EVMC_OUT_OF_GAS;
         } else if (res.gas_left >= 0 && static_cast<uint64_t>(res.gas_left) >= code_deploy_gas) {
-            res.gas_left -= code_deploy_gas;
+            res.gas_left -= static_cast<int64_t>(code_deploy_gas);
             state_.set_code(contract_addr, {res.output_data, res.output_size});
         } else if (rev >= EVMC_HOMESTEAD) {
             res.status_code = EVMC_OUT_OF_GAS;

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -189,7 +189,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
         const uint8_t num{code_address.bytes[kAddressLength - 1]};
         precompiled::Contract contract{precompiled::kContracts[num - 1]};
         const ByteView input{message.input_data, message.input_size};
-        const int64_t gas = contract.gas(input, revision());
+        const int64_t gas{static_cast<int64_t>(contract.gas(input, revision()))};
         if (gas < 0 || gas > message.gas) {
             res.status_code = EVMC_OUT_OF_GAS;
         } else {
@@ -500,9 +500,12 @@ evmc_tx_context EvmHost::get_tx_context() const noexcept {
     intx::be::store(context.tx_gas_price.bytes, effective_gas_price);
     context.tx_origin = *evm_.txn_->from;
     context.block_coinbase = header.beneficiary;
-    context.block_number = header.number;
-    context.block_timestamp = header.timestamp;
-    context.block_gas_limit = header.gas_limit;
+    assert(header.number <= INT64_MAX);  // EIP-1985
+    context.block_number = static_cast<int64_t>(header.number);
+    assert(header.timestamp <= INT64_MAX);  // EIP-1985
+    context.block_timestamp = static_cast<int64_t>(header.timestamp);
+    assert(header.gas_limit <= INT64_MAX);  // EIP-1985
+    context.block_gas_limit = static_cast<int64_t>(header.gas_limit);
     intx::be::store(context.block_difficulty.bytes, header.difficulty);
     intx::be::store(context.chain_id.bytes, intx::uint256{evm_.config().chain_id});
     intx::be::store(context.block_base_fee.bytes, base_fee_per_gas);
@@ -510,8 +513,8 @@ evmc_tx_context EvmHost::get_tx_context() const noexcept {
 }
 
 evmc::bytes32 EvmHost::get_block_hash(int64_t n) const noexcept {
-    uint64_t base_number{evm_.block_.header.number};
-    uint64_t new_size{base_number - n};
+    const uint64_t base_number{evm_.block_.header.number};
+    const uint64_t new_size{base_number - static_cast<uint64_t>(n)};
     assert(new_size <= 256);
 
     std::vector<evmc::bytes32>& hashes{evm_.block_hashes_};
@@ -519,7 +522,7 @@ evmc::bytes32 EvmHost::get_block_hash(int64_t n) const noexcept {
         hashes.push_back(evm_.block_.header.parent_hash);
     }
 
-    uint64_t old_size{hashes.size()};
+    const uint64_t old_size{hashes.size()};
     if (old_size < new_size) {
         hashes.resize(new_size);
     }

--- a/core/silkworm/execution/precompiled.cpp
+++ b/core/silkworm/execution/precompiled.cpp
@@ -28,6 +28,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp>
 #pragma GCC diagnostic pop
 

--- a/core/silkworm/execution/precompiled.cpp
+++ b/core/silkworm/execution/precompiled.cpp
@@ -27,6 +27,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp>
 #pragma GCC diagnostic pop
 

--- a/core/silkworm/rlp/decode.cpp
+++ b/core/silkworm/rlp/decode.cpp
@@ -87,7 +87,7 @@ std::pair<Header, DecodingResult> decode_header(ByteView& from) noexcept {
         h.payload_length = 1;
     } else if (b < 0xB8) {
         from.remove_prefix(1);
-        h.payload_length = b - 0x80;
+        h.payload_length = b - 0x80u;
         if (h.payload_length == 1) {
             if (from.empty()) {
                 return {h, DecodingResult::kInputTooShort};
@@ -114,7 +114,7 @@ std::pair<Header, DecodingResult> decode_header(ByteView& from) noexcept {
     } else if (b < 0xF8) {
         from.remove_prefix(1);
         h.list = true;
-        h.payload_length = b - 0xC0;
+        h.payload_length = b - 0xC0u;
     } else {
         from.remove_prefix(1);
         h.list = true;

--- a/core/silkworm/rlp/encode.cpp
+++ b/core/silkworm/rlp/encode.cpp
@@ -23,11 +23,11 @@ namespace silkworm::rlp {
 
 void encode_header(Bytes& to, Header header) {
     if (header.payload_length < 56) {
-        uint8_t code{header.list ? kEmptyListCode : kEmptyStringCode};
+        const uint8_t code{header.list ? kEmptyListCode : kEmptyStringCode};
         to.push_back(static_cast<uint8_t>(code + header.payload_length));
     } else {
-        ByteView len_be{big_endian(header.payload_length)};
-        uint8_t code = header.list ? '\xF7' : '\xB7';
+        const ByteView len_be{big_endian(header.payload_length)};
+        const uint8_t code = header.list ? 0xF7 : 0xB7;
         to.push_back(static_cast<uint8_t>(code + len_be.length()));
         to.append(len_be);
     }

--- a/core/silkworm/rlp/encode_test.cpp
+++ b/core/silkworm/rlp/encode_test.cpp
@@ -38,17 +38,17 @@ TEST_CASE("RLP encoding") {
     }
 
     SECTION("uint64") {
-        CHECK(to_hex(encoded(0)) == "80");
-        CHECK(to_hex(encoded(1)) == "01");
-        CHECK(to_hex(encoded(0x7F)) == "7f");
-        CHECK(to_hex(encoded(0x80)) == "8180");
-        CHECK(to_hex(encoded(0x400)) == "820400");
-        CHECK(to_hex(encoded(0xFFCCB5)) == "83ffccb5");
-        CHECK(to_hex(encoded(0xFFCCB5DD)) == "84ffccb5dd");
-        CHECK(to_hex(encoded(0xFFCCB5DDFF)) == "85ffccb5ddff");
-        CHECK(to_hex(encoded(0xFFCCB5DDFFEE)) == "86ffccb5ddffee");
-        CHECK(to_hex(encoded(0xFFCCB5DDFFEE14)) == "87ffccb5ddffee14");
-        CHECK(to_hex(encoded(0xFFCCB5DDFFEE1483)) == "88ffccb5ddffee1483");
+        CHECK(to_hex(encoded(0u)) == "80");
+        CHECK(to_hex(encoded(1u)) == "01");
+        CHECK(to_hex(encoded(0x7Fu)) == "7f");
+        CHECK(to_hex(encoded(0x80u)) == "8180");
+        CHECK(to_hex(encoded(0x400u)) == "820400");
+        CHECK(to_hex(encoded(0xFFCCB5u)) == "83ffccb5");
+        CHECK(to_hex(encoded(0xFFCCB5DDu)) == "84ffccb5dd");
+        CHECK(to_hex(encoded(0xFFCCB5DDFFu)) == "85ffccb5ddff");
+        CHECK(to_hex(encoded(0xFFCCB5DDFFEEu)) == "86ffccb5ddffee");
+        CHECK(to_hex(encoded(0xFFCCB5DDFFEE14u)) == "87ffccb5ddffee14");
+        CHECK(to_hex(encoded(0xFFCCB5DDFFEE1483u)) == "88ffccb5ddffee1483");
     }
 
     SECTION("uint256") {

--- a/core/silkworm/state/in_memory_state.cpp
+++ b/core/silkworm/state/in_memory_state.cpp
@@ -243,12 +243,12 @@ evmc::bytes32 InMemoryState::account_storage_root(const evmc::address& address, 
     }
 
     std::map<evmc::bytes32, Bytes> storage_rlp;
-    Bytes rlp;
+    Bytes buffer;
     for (const auto& [location, value] : storage) {
         ethash::hash256 hash{keccak256(full_view(location))};
-        rlp.clear();
-        rlp::encode(rlp, zeroless_view(value));
-        storage_rlp[to_bytes32(full_view(hash.bytes))] = rlp;
+        buffer.clear();
+        rlp::encode(buffer, zeroless_view(value));
+        storage_rlp[to_bytes32(full_view(hash.bytes))] = buffer;
     }
 
     trie::HashBuilder hb;

--- a/core/silkworm/types/bloom.cpp
+++ b/core/silkworm/types/bloom.cpp
@@ -26,7 +26,7 @@ namespace silkworm {
 static void m3_2048(Bloom& bloom, ByteView x) {
     ethash::hash256 hash{keccak256(x)};
     for (unsigned i{0}; i < 6; i += 2) {
-        unsigned bit{(hash.bytes[i + 1] + (hash.bytes[i] << 8)) & 0x7FFu};
+        unsigned bit{static_cast<unsigned>(hash.bytes[i + 1] + (hash.bytes[i] << 8)) & 0x7FFu};
         bloom[kBloomByteLength - 1 - bit / 8] |= 1 << (bit % 8);
     }
 }

--- a/core/silkworm/types/transaction.cpp
+++ b/core/silkworm/types/transaction.cpp
@@ -74,9 +74,9 @@ namespace rlp {
 
     template <>
     DecodingResult decode(ByteView& from, AccessListEntry& to) noexcept {
-        auto [rlp_head, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
+        auto [rlp_head, err0]{decode_header(from)};
+        if (err0 != DecodingResult::kOk) {
+            return err0;
         }
         if (!rlp_head.list) {
             return DecodingResult::kUnexpectedString;
@@ -268,9 +268,9 @@ namespace rlp {
     static DecodingResult eip2718_decode(ByteView& from, Transaction& to) noexcept {
         assert(to.type == Transaction::Type::kEip2930 || to.type == Transaction::Type::kEip1559);
 
-        auto [h, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
+        auto [h, err0]{decode_header(from)};
+        if (err0 != DecodingResult::kOk) {
+            return err0;
         }
         if (!h.list) {
             return DecodingResult::kUnexpectedString;
@@ -333,9 +333,9 @@ namespace rlp {
 
     template <>
     DecodingResult decode(ByteView& from, Transaction& to) noexcept {
-        auto [h, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
+        auto [h, err0]{decode_header(from)};
+        if (err0 != DecodingResult::kOk) {
+            return err0;
         }
 
         if (h.list) {

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(silkworm_node ${SILKWORM_NODE_SRC} ${SILKWORM_INTERFACE_SRC})
 add_dependencies(silkworm_node generate_sentry_grpc)
 
 set_source_files_properties(${SILKWORM_INTERFACE_SRC} PROPERTIES GENERATED TRUE)
+set_source_files_properties(${SILKWORM_INTERFACE_SRC} PROPERTIES COMPILE_FLAGS -Wno-sign-conversion)
 
 target_include_directories(silkworm_node PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -37,7 +37,9 @@ add_library(silkworm_node ${SILKWORM_NODE_SRC} ${SILKWORM_INTERFACE_SRC})
 add_dependencies(silkworm_node generate_sentry_grpc)
 
 set_source_files_properties(${SILKWORM_INTERFACE_SRC} PROPERTIES GENERATED TRUE)
-set_source_files_properties(${SILKWORM_INTERFACE_SRC} PROPERTIES COMPILE_FLAGS -Wno-sign-conversion)
+if(NOT MSVC)
+  set_source_files_properties(${SILKWORM_INTERFACE_SRC} PROPERTIES COMPILE_FLAGS -Wno-sign-conversion)
+endif(MSVC)
 
 target_include_directories(silkworm_node PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/node/silkworm/common/log.hpp
+++ b/node/silkworm/common/log.hpp
@@ -58,7 +58,7 @@ extern bool log_thread_enabled_;
 void log_set_streams_(std::ostream& o1, std::ostream& o2);
 class log_ {
   public:
-    log_(LogLevel level_) : level_(level_) { log_mtx_.lock(); }
+    log_(LogLevel level) : level_(level) { log_mtx_.lock(); }
     ~log_() { log_mtx_.unlock(); }
     std::ostream& header_(LogLevel);
     template <class T>

--- a/node/silkworm/concurrency/worker.cpp
+++ b/node/silkworm/concurrency/worker.cpp
@@ -27,14 +27,14 @@ Worker::~Worker() {
 }
 
 void Worker::start(bool wait) {
-    WorkerState expected_state{WorkerState::kStopped};
-    if (!state_.compare_exchange_strong(expected_state, WorkerState::kStarting)) {
+    WorkerState expected_state1{WorkerState::kStopped};
+    if (!state_.compare_exchange_strong(expected_state1, WorkerState::kStarting)) {
         return;
     }
 
     thread_.reset(new std::thread([&]() {
-        WorkerState expected_state{WorkerState::kStarting};
-        if (state_.compare_exchange_strong(expected_state, WorkerState::kStarted)) {
+        WorkerState expected_state2{WorkerState::kStarting};
+        if (state_.compare_exchange_strong(expected_state2, WorkerState::kStarted)) {
             try {
                 kicked_.store(false);
                 work();

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -252,7 +252,7 @@ std::optional<BlockBody> read_body(mdbx::txn& txn, uint64_t block_number, const 
     return out;
 }
 
-std::vector<evmc::address> read_senders(mdbx::txn& txn, int64_t block_number, const uint8_t (&hash)[kHashLength]) {
+std::vector<evmc::address> read_senders(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
     std::vector<evmc::address> senders{};
 
     auto src{db::open_cursor(txn, table::kSenders)};

--- a/node/silkworm/db/access_layer.hpp
+++ b/node/silkworm/db/access_layer.hpp
@@ -66,7 +66,7 @@ std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, uint64_t bloc
 std::optional<BlockWithHash> read_block(mdbx::txn& txn, uint64_t block_number, bool read_senders);
 
 // See Erigon ReadSenders
-std::vector<evmc::address> read_senders(mdbx::txn& txn, int64_t block_number, const uint8_t (&hash)[kHashLength]);
+std::vector<evmc::address> read_senders(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
 
 // Overload
 std::vector<Transaction> read_transactions(mdbx::cursor& txn_table, uint64_t base_id, uint64_t count);

--- a/node/silkworm/db/bitmap.hpp
+++ b/node/silkworm/db/bitmap.hpp
@@ -21,6 +21,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <roaring64map.hh>
 #pragma GCC diagnostic pop
 

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -73,8 +73,8 @@ namespace silkworm::db {
 
     ::mdbx::env_managed::create_parameters cp{};  // Default create parameters
     if (!(config.shared)) {
-        size_t max_map_size{config.inmemory ? 64_Mebi : 2_Tebi};
-        size_t growth_size{config.inmemory ? 2_Mebi : 2_Gibi};
+        const intptr_t max_map_size = config.inmemory ? 64_Mebi : 2_Tebi;
+        const intptr_t growth_size = config.inmemory ? 2_Mebi : 2_Gibi;
         cp.geometry.make_dynamic(::mdbx::env::geometry::default_value, max_map_size);
         cp.geometry.growth_step = growth_size;
         cp.geometry.pagesize = 4_Kibi;

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -22,7 +22,11 @@
 #include <filesystem>
 #include <string>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <mdbx.h++>
+#pragma GCC diagnostic pop
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/util.hpp>

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -25,6 +25,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <mdbx.h++>
 #pragma GCC diagnostic pop
 

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -26,6 +26,7 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <mdbx.h++>
 #pragma GCC diagnostic pop
 

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -26,14 +26,8 @@ see its package dbutils.
 
 #include <absl/container/btree_map.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#include <mdbx.h++>
-#pragma GCC diagnostic pop
-
 #include <silkworm/common/base.hpp>
+#include <silkworm/db/mdbx.hpp>
 #include <silkworm/types/block.hpp>
 
 namespace silkworm::db {

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -29,6 +29,7 @@ see its package dbutils.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <mdbx.h++>
 #pragma GCC diagnostic pop
 

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -25,7 +25,12 @@ see its package dbutils.
 #include <string>
 
 #include <absl/container/btree_map.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <mdbx.h++>
+#pragma GCC diagnostic pop
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/types/block.hpp>

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -56,6 +56,8 @@ using BigInt = intx::uint256;  // use intx::to_string, from_string, ...
 using time_point_t = std::chrono::time_point<std::chrono::system_clock>;
 using time_dur_t = std::chrono::duration<std::chrono::system_clock>;
 
+inline Bytes bytes_of_string(const std::string& s) { return Bytes(s.begin(), s.end()); }
+
 inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& bytes) {
     for (const auto& b : bytes) {
         out << std::hex << std::setw(2) << std::setfill('0') << int(b);

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -56,8 +56,6 @@ using BigInt = intx::uint256;  // use intx::to_string, from_string, ...
 using time_point_t = std::chrono::time_point<std::chrono::system_clock>;
 using time_dur_t = std::chrono::duration<std::chrono::system_clock>;
 
-inline Bytes bytes_of_string(const std::string& s) { return Bytes(s.begin(), s.end()); }
-
 inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& bytes) {
     for (const auto& b : bytes) {
         out << std::hex << std::setw(2) << std::setfill('0') << int(b);

--- a/node/silkworm/downloader/internals/types_for_grpc_test.cpp
+++ b/node/silkworm/downloader/internals/types_for_grpc_test.cpp
@@ -14,40 +14,40 @@
    limitations under the License.
 */
 
-#include <catch2/catch.hpp>
-
 #include "types_for_grpc.hpp"
+
+#include <catch2/catch.hpp>
 
 namespace silkworm {
 
 TEST_CASE("H256/512 to/from conversions") {
     using namespace std;
 
-    SECTION( "H256 to/from Hash" ) {
+    SECTION("H256 to/from Hash") {
         Hash orig_hash = Hash::from_hex("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
         Hash transf_hash = hash_from_H256(*to_H256(orig_hash));
 
         REQUIRE(orig_hash == transf_hash);
     }
 
-    SECTION( "H256 to/from number" ) {
+    SECTION("H256 to/from number") {
         intx::uint256 orig_big{int64_t{789}, int64_t{567}, int64_t{345}, int64_t{123}};
         intx::uint256 transf_big = uint256_from_H256(*to_H256(orig_big));
 
         REQUIRE(orig_big == transf_big);
     }
 
-    for(auto len: {64,64,64,64,64,60,70}) {
-        SECTION( "H512 to/from string, len="+to_string(len) ) {
+    for (size_t len : {64u, 64u, 64u, 64u, 64u, 60u, 70u}) {
+        SECTION("H512 to/from string, len=" + to_string(len)) {
             string orig_string(len, 0);
             generate_n(orig_string.begin(), len, [] { return static_cast<char>(rand() % 255); });
 
             string transf_string = string_from_H512(*to_H512(orig_string));
 
-            orig_string.resize(64,0);   // transf_string is always of 64 bytes with trailing zeros if needed
+            orig_string.resize(64, 0);  // transf_string is always of 64 bytes with trailing zeros if needed
             REQUIRE(orig_string == transf_string);
         }
     }
 }
 
-}
+}  // namespace silkworm

--- a/node/silkworm/downloader/packets/GetBlockHeadersPacket.hpp
+++ b/node/silkworm/downloader/packets/GetBlockHeadersPacket.hpp
@@ -68,9 +68,9 @@ namespace rlp {
     inline rlp::DecodingResult decode(ByteView& from, GetBlockHeadersPacket& to) noexcept {
         using namespace rlp;
 
-        auto [rlp_head, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
+        auto [rlp_head, err0]{decode_header(from)};
+        if (err0 != DecodingResult::kOk) {
+            return err0;
         }
         if (!rlp_head.list) {
             return DecodingResult::kUnexpectedString;

--- a/node/silkworm/downloader/packets/NewBlockHashesPacket.hpp
+++ b/node/silkworm/downloader/packets/NewBlockHashesPacket.hpp
@@ -51,9 +51,9 @@ namespace rlp {
     template <>
     inline rlp::DecodingResult decode(ByteView& from, NewBlockHash& to) noexcept {
 
-        auto [rlp_head, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
+        auto [rlp_head, err0]{decode_header(from)};
+        if (err0 != DecodingResult::kOk) {
+            return err0;
         }
         if (!rlp_head.list) {
             return DecodingResult::kUnexpectedString;

--- a/node/silkworm/downloader/packets/NewBlockPacket.hpp
+++ b/node/silkworm/downloader/packets/NewBlockPacket.hpp
@@ -48,9 +48,9 @@ namespace rlp {
     template <>
     inline rlp::DecodingResult decode(ByteView& from, NewBlockPacket& to) noexcept {
 
-        auto [rlp_head, err]{decode_header(from)};
-        if (err != DecodingResult::kOk) {
-            return err;
+        auto [rlp_head, err0]{decode_header(from)};
+        if (err0 != DecodingResult::kOk) {
+            return err0;
         }
         if (!rlp_head.list) {
             return DecodingResult::kUnexpectedString;

--- a/node/silkworm/downloader/packets/RLPEth66PacketCoding.hpp
+++ b/node/silkworm/downloader/packets/RLPEth66PacketCoding.hpp
@@ -76,9 +76,9 @@ template <typename T>
 inline rlp::DecodingResult decode_eth66(ByteView& from, T& to) noexcept {
     using namespace rlp;
 
-    auto [rlp_head, err]{decode_header(from)};
-    if (err != DecodingResult::kOk) {
-        return err;
+    auto [rlp_head, err0]{decode_header(from)};
+    if (err0 != DecodingResult::kOk) {
+        return err0;
     }
     if (!rlp_head.list) {
         return DecodingResult::kUnexpectedString;

--- a/node/silkworm/etl/collector.cpp
+++ b/node/silkworm/etl/collector.cpp
@@ -104,10 +104,10 @@ void Collector::load(mdbx::cursor& target, LoadFunc load_func, MDBX_put_flags_t 
     flush_buffer();
 
     // Define a priority queue based on smallest available key
-    auto key_comparer = [](const std::pair<Entry, int>& left, const std::pair<Entry, int>& right) {
+    auto key_comparer = [](const std::pair<Entry, size_t>& left, const std::pair<Entry, size_t>& right) {
         return right.first < left.first;
     };
-    std::priority_queue<std::pair<Entry, int>, std::vector<std::pair<Entry, int>>, decltype(key_comparer)> queue(
+    std::priority_queue<std::pair<Entry, size_t>, std::vector<std::pair<Entry, size_t>>, decltype(key_comparer)> queue(
         key_comparer);
 
     // Read one "record" from each data_provider and let the queue

--- a/node/silkworm/etl/collector_test.cpp
+++ b/node/silkworm/etl/collector_test.cpp
@@ -18,8 +18,8 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/common/endian.hpp>
 #include <silkworm/common/directories.hpp>
+#include <silkworm/common/endian.hpp>
 #include <silkworm/db/tables.hpp>
 
 namespace silkworm::etl {
@@ -32,8 +32,8 @@ static std::vector<Entry> generate_entry_set(size_t size) {
     while (pairs.size() < size) {
         Bytes key(8, '\0');
         Bytes value(8, '\0');
-        endian::store_big_u64(&key[0], rand() % 200000000u);
-        endian::store_big_u64(&value[0], rand() % 200000000u);
+        endian::store_big_u64(&key[0], static_cast<unsigned>(rand()) % 200000000u);
+        endian::store_big_u64(&value[0], static_cast<unsigned>(rand()) % 200000000u);
 
         if (keys.count(key)) {
             // we want unique keys
@@ -47,7 +47,7 @@ static std::vector<Entry> generate_entry_set(size_t size) {
     return pairs;
 }
 
-    void run_collector_test(LoadFunc load_func, bool do_copy = true) {
+void run_collector_test(LoadFunc load_func, bool do_copy = true) {
     TemporaryDirectory db_tmp_dir;
     TemporaryDirectory etl_tmp_dir;
     // Initialize random seed
@@ -67,7 +67,7 @@ static std::vector<Entry> generate_entry_set(size_t size) {
     // Collection
     for (auto&& entry : set) {
         if (do_copy)
-            collector.collect(entry); // copy is slower... do only if entry is reused afterwards
+            collector.collect(entry);  // copy is slower... do only if entry is reused afterwards
         else
             collector.collect(std::move(entry));
     }

--- a/node/silkworm/etl/file_provider.cpp
+++ b/node/silkworm/etl/file_provider.cpp
@@ -52,8 +52,8 @@ void FileProvider::flush(Buffer& buffer) {
         head.lengths[0] = entry.key.size();
         head.lengths[1] = entry.value.size();
         if (!file_.write(byte_ptr_cast(head.bytes), 8) ||
-            !file_.write(byte_ptr_cast(entry.key.data()), entry.key.size()) ||
-            !file_.write(byte_ptr_cast(entry.value.data()), entry.value.size())) {
+            !file_.write(byte_ptr_cast(entry.key.data()), static_cast<std::streamsize>(entry.key.size())) ||
+            !file_.write(byte_ptr_cast(entry.value.data()), static_cast<std::streamsize>(entry.value.size()))) {
             auto err{errno};
             reset();
             throw etl_error(strerror(err));
@@ -73,7 +73,7 @@ void FileProvider::flush(Buffer& buffer) {
     };
 }
 
-std::optional<std::pair<Entry, int>> FileProvider::read_entry() {
+std::optional<std::pair<Entry, size_t>> FileProvider::read_entry() {
     head_t head{};
 
     if (!file_.is_open() || !file_size_) {

--- a/node/silkworm/etl/file_provider.hpp
+++ b/node/silkworm/etl/file_provider.hpp
@@ -34,9 +34,9 @@ class FileProvider {
   public:
     FileProvider(std::string file_name, size_t id);
     ~FileProvider(void);
-    void flush(Buffer& buffer);                         // Write buffer's contents to disk
-    std::optional<std::pair<Entry, int>> read_entry();  // Read next data element from file starting from position 0
-    void reset();                                       // Remove the file when eof is met
+    void flush(Buffer& buffer);                            // Write buffer's contents to disk
+    std::optional<std::pair<Entry, size_t>> read_entry();  // Read next data element from file starting from position 0
+    void reset();                                          // Remove the file when eof is met
 
     std::string get_file_name(void) const;
     size_t get_file_size(void) const;

--- a/node/silkworm/stagedsync/listener_log_index.hpp
+++ b/node/silkworm/stagedsync/listener_log_index.hpp
@@ -41,7 +41,7 @@ class listener_log_index : public cbor::listener {
     void on_integer(int) override{};
 
     void on_bytes(unsigned char* data, int size) override {
-        std::string key(byte_ptr_cast(data), size);
+        std::string key(byte_ptr_cast(data), static_cast<size_t>(size));
         if (size == kHashLength) {
             if (topics_map_->find(key) == topics_map_->end()) {
                 topics_map_->emplace(key, roaring::Roaring());

--- a/node/silkworm/stagedsync/listener_log_index.hpp
+++ b/node/silkworm/stagedsync/listener_log_index.hpp
@@ -31,14 +31,14 @@ class listener_log_index : public cbor::listener {
   public:
     listener_log_index(uint64_t block_number, std::unordered_map<std::string, roaring::Roaring>* topics_map,
                        std::unordered_map<std::string, roaring::Roaring>* addrs_map, uint64_t* allocated_topics,
-                       uint64_t* allocated_addrs_)
+                       uint64_t* allocated_addrs)
         : block_number_(block_number),
           topics_map_(topics_map),
           addrs_map_(addrs_map),
           allocated_topics_(allocated_topics),
-          allocated_addrs_(allocated_addrs_){};
+          allocated_addrs_(allocated_addrs) {}
 
-    void on_integer(int) override{};
+    void on_integer(int) override {}
 
     void on_bytes(unsigned char* data, int size) override {
         std::string key(byte_ptr_cast(data), static_cast<size_t>(size));
@@ -57,33 +57,33 @@ class listener_log_index : public cbor::listener {
         }
     }
 
-    void on_string(std::string&) override{};
+    void on_string(std::string&) override {}
 
     void on_array(int) override {}
 
-    void on_map(int) override{};
+    void on_map(int) override {}
 
-    void on_tag(unsigned int) override{};
+    void on_tag(unsigned int) override {}
 
-    void on_special(unsigned int) override{};
+    void on_special(unsigned int) override {}
 
-    void on_bool(bool) override{};
+    void on_bool(bool) override {}
 
-    void on_null() override{};
+    void on_null() override {}
 
-    void on_undefined() override{};
+    void on_undefined() override {}
 
-    void on_error(const char*) override{};
+    void on_error(const char*) override {}
 
-    void on_extra_integer(unsigned long long, int) override{};
+    void on_extra_integer(unsigned long long, int) override {}
 
-    void on_extra_tag(unsigned long long) override{};
+    void on_extra_tag(unsigned long long) override {}
 
-    void on_extra_special(unsigned long long) override{};
+    void on_extra_special(unsigned long long) override {}
 
-    void on_double(double) override{};
+    void on_double(double) override {}
 
-    void on_float32(float) override{};
+    void on_float32(float) override {}
 
     void set_block_number(uint64_t block_number) { block_number_ = block_number; }
 

--- a/node/silkworm/stagedsync/recovery/recovery_farm.cpp
+++ b/node/silkworm/stagedsync/recovery/recovery_farm.cpp
@@ -292,7 +292,7 @@ void RecoveryFarm::fill_batch(ChainConfig config, uint64_t block_num, std::vecto
         rlp::encode(rlp, transaction, /*for_signing=*/true, /*wrap_eip2718_into_array=*/false);
 
         auto hash{keccak256(rlp)};
-        RecoveryWorker::package package{block_num, hash, transaction.odd_y_parity};
+        RecoveryWorker::Package package{block_num, hash, transaction.odd_y_parity};
         intx::be::unsafe::store(package.signature, transaction.r);
         intx::be::unsafe::store(package.signature + 32, transaction.s);
         (*batch_).push_back(package);
@@ -434,7 +434,7 @@ void RecoveryFarm::worker_completed_handler(RecoveryWorker* sender, uint32_t bat
 }
 
 void RecoveryFarm::init_batch() {
-    batch_ = std::make_unique<std::vector<RecoveryWorker::package>>();
+    batch_ = std::make_unique<std::vector<RecoveryWorker::Package>>();
     (*batch_).reserve(max_batch_size_);
 }
 

--- a/node/silkworm/stagedsync/recovery/recovery_farm.hpp
+++ b/node/silkworm/stagedsync/recovery/recovery_farm.hpp
@@ -127,7 +127,7 @@ class RecoveryFarm {
 
     /* Batches */
     const size_t max_batch_size_;  // Max number of transaction to be sent a worker for recovery
-    std::unique_ptr<std::vector<RecoveryWorker::package>>
+    std::unique_ptr<std::vector<RecoveryWorker::Package>>
         batch_;                                  // Collection of transactions to be sent a worker for recovery
     uint32_t batch_id_{0};                       // Incremental id of launched batches
     std::atomic_uint32_t completed_batch_id{0};  // Incremental id of completed batches

--- a/node/silkworm/stagedsync/recovery/recovery_worker.cpp
+++ b/node/silkworm/stagedsync/recovery/recovery_worker.cpp
@@ -27,7 +27,7 @@ RecoveryWorker::RecoveryWorker(uint32_t id, size_t data_size) : id_(id), data_si
     }
 }
 
-void RecoveryWorker::set_work(uint32_t batch_id, std::unique_ptr<std::vector<package>> batch) {
+void RecoveryWorker::set_work(uint32_t batch_id, std::unique_ptr<std::vector<Package>> batch) {
     batch_ = std::move(batch);
     batch_id_ = batch_id;
     status_.store(Status::Working);

--- a/node/silkworm/stagedsync/recovery/recovery_worker.hpp
+++ b/node/silkworm/stagedsync/recovery/recovery_worker.hpp
@@ -48,7 +48,7 @@ class RecoveryWorker final : public silkworm::Worker {
     RecoveryWorker(uint32_t id, size_t data_size);
 
     // Recovery package
-    struct package {
+    struct Package {
         uint64_t block_num;
         ethash::hash256 hash;
         bool odd_y_parity;
@@ -64,7 +64,7 @@ class RecoveryWorker final : public silkworm::Worker {
     };
 
     // Provides a container of packages to process
-    void set_work(uint32_t batch_id, std::unique_ptr<std::vector<package>> batch);
+    void set_work(uint32_t batch_id, std::unique_ptr<std::vector<Package>> batch);
 
     uint32_t get_id() const;
     uint32_t get_batch_id() const;
@@ -80,7 +80,7 @@ class RecoveryWorker final : public silkworm::Worker {
   private:
     const uint32_t id_;                                  // Current worker identifier
     uint32_t batch_id_{0};                               // Running batch identifier
-    std::unique_ptr<std::vector<package>> batch_;        // Batch to process
+    std::unique_ptr<std::vector<Package>> batch_;        // Batch to process
     size_t data_size_;                                   // Size of the recovery data buffer
     uint8_t* data_{nullptr};                             // Pointer to data where rsults are stored
     std::vector<std::pair<uint64_t, iovec>> results_{};  // Results per block pointing to data area

--- a/node/silkworm/stagedsync/stage_blockhashes_test.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes_test.cpp
@@ -16,25 +16,23 @@
 
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
-#include <evmc/evmc.hpp>
 
 #include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
+#include <silkworm/common/base.hpp>
 #include <silkworm/common/directories.hpp>
 #include <silkworm/db/buffer.hpp>
 #include <silkworm/db/stages.hpp>
 
 #include "stagedsync.hpp"
 
-using namespace evmc::literals;
+namespace silkworm {
 
 constexpr evmc::bytes32 hash_0{0x3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb_bytes32};
 constexpr evmc::bytes32 hash_1{0xb5553de315e0edf504d9150af82dafa5c4667fa618ed0a6f19c69b41166c5510_bytes32};
 constexpr evmc::bytes32 hash_2{0x0b42b6393c1f53060fe3ddbfcd7aadcca894465a5a438f69c87d790b2299b9b2_bytes32};
 
 TEST_CASE("Stage Block Hashes") {
-    using namespace silkworm;
-
     TemporaryDirectory tmp_dir;
     DataDirectory data_dir{tmp_dir.path()};
     CHECK_NOTHROW(data_dir.deploy());
@@ -73,8 +71,6 @@ TEST_CASE("Stage Block Hashes") {
 }
 
 TEST_CASE("Unwind Block Hashes") {
-    using namespace silkworm;
-
     TemporaryDirectory tmp_dir;
     DataDirectory data_dir{tmp_dir.path()};
     CHECK_NOTHROW(data_dir.deploy());
@@ -110,3 +106,5 @@ TEST_CASE("Unwind Block Hashes") {
     REQUIRE(!blockhashes_table.seek(db::to_slice(hash_1)));
     REQUIRE(!blockhashes_table.seek(db::to_slice(hash_2)));
 }
+
+}  // namespace silkworm

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -150,8 +150,8 @@ StageResult stage_execution(TransactionManager& txn, const std::filesystem::path
 static void revert_state(Bytes key, Bytes value, mdbx::cursor& plain_state_table, mdbx::cursor& plain_code_table) {
     if (key.size() == kAddressLength) {
         if (value.size() > 0) {
-            auto [account, err]{decode_account_from_storage(value)};
-            rlp::err_handler(err);
+            auto [account, err1]{decode_account_from_storage(value)};
+            rlp::err_handler(err1);
             if (account.incarnation > 0 && account.code_hash == kEmptyHash) {
                 Bytes code_hash_key(kAddressLength + db::kIncarnationLength, '\0');
                 std::memcpy(&code_hash_key[0], &key[0], kAddressLength);
@@ -162,8 +162,8 @@ static void revert_state(Bytes key, Bytes value, mdbx::cursor& plain_state_table
             // cleaning up contract codes
             auto state_account_encoded{plain_state_table.find(db::to_slice(key), /*throw_notfound=*/false)};
             if (state_account_encoded) {
-                auto [state_incarnation, err]{extract_incarnation(db::from_slice(state_account_encoded.value))};
-                rlp::err_handler(err);
+                auto [state_incarnation, err2]{extract_incarnation(db::from_slice(state_account_encoded.value))};
+                rlp::err_handler(err2);
                 // cleanup each code incarnation
                 for (uint64_t i = state_incarnation; i > account.incarnation && i > 0; --i) {
                     Bytes key_hash(kAddressLength + 8, '\0');

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -58,9 +58,7 @@ StageResult stage_tx_lookup(TransactionManager& txn, const std::filesystem::path
 
     auto bodies_data{bodies_table.lower_bound(db::to_slice(start), /*throw_notfound*/ false)};
 
-    auto body_rlp{db::from_slice(bodies_data.value)};
-    auto body{db::detail::decode_stored_block_body(body_rlp)};
-    auto block_number{0};
+    BlockNum block_number{0};
 
     while (bodies_data) {
         auto body_rlp{db::from_slice(bodies_data.value)};
@@ -220,6 +218,5 @@ StageResult prune_tx_lookup(TransactionManager& txn, const std::filesystem::path
 
     return StageResult::kSuccess;
 }
-
 
 }  // namespace silkworm::stagedsync

--- a/node/silkworm/stagedsync/transaction_manager.hpp
+++ b/node/silkworm/stagedsync/transaction_manager.hpp
@@ -17,12 +17,7 @@
 #ifndef SILKWORM_STAGEDSYNC_TRANSACTION_MANAGER_HPP_
 #define SILKWORM_STAGEDSYNC_TRANSACTION_MANAGER_HPP_
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#include <mdbx.h++>
-#pragma GCC diagnostic pop
+#include <silkworm/db/mdbx.hpp>
 
 namespace silkworm::stagedsync {
 

--- a/node/silkworm/stagedsync/transaction_manager.hpp
+++ b/node/silkworm/stagedsync/transaction_manager.hpp
@@ -17,7 +17,11 @@
 #ifndef SILKWORM_STAGEDSYNC_TRANSACTION_MANAGER_HPP_
 #define SILKWORM_STAGEDSYNC_TRANSACTION_MANAGER_HPP_
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <mdbx.h++>
+#pragma GCC diagnostic pop
 
 namespace silkworm::stagedsync {
 

--- a/node/silkworm/stagedsync/transaction_manager.hpp
+++ b/node/silkworm/stagedsync/transaction_manager.hpp
@@ -20,6 +20,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <mdbx.h++>
 #pragma GCC diagnostic pop
 

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -17,14 +17,8 @@
 #ifndef SILKWORM_STAGEDSYNC_UTIL_HPP_
 #define SILKWORM_STAGEDSYNC_UTIL_HPP_
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#include <mdbx.h++>
-#pragma GCC diagnostic pop
-
 #include <silkworm/common/base.hpp>
+#include <silkworm/db/mdbx.hpp>
 
 /*
 Part of the compatibility layer with the Erigon DB format;

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -17,8 +17,13 @@
 #ifndef SILKWORM_STAGEDSYNC_UTIL_HPP_
 #define SILKWORM_STAGEDSYNC_UTIL_HPP_
 
-#include <silkworm/common/base.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <mdbx.h++>
+#pragma GCC diagnostic pop
+
+#include <silkworm/common/base.hpp>
 
 /*
 Part of the compatibility layer with the Erigon DB format;
@@ -27,6 +32,7 @@ see its package dbutils.
 
 namespace silkworm::stagedsync {
 
+// clang-format off
 enum class [[nodiscard]] StageResult {
     kSuccess,
     kUnknownChainId,
@@ -39,8 +45,9 @@ enum class [[nodiscard]] StageResult {
     kUnexpectedError,
     kUnknownError,
     kDbError,
-    kAborted
+    kAborted,
 };
+// clang-format on
 
 void check_stagedsync_error(StageResult code);
 

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -20,6 +20,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <mdbx.h++>
 #pragma GCC diagnostic pop
 

--- a/node/silkworm/stagedsync/util_test.cpp
+++ b/node/silkworm/stagedsync/util_test.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Check Truncate tables, reverse = true") {
     // Cursor to be opened does not matter
     auto account_history_table{db::open_cursor(*txn, db::table::kAccountHistory)};
 
-    for (int i = 100; i >= 0; i--) {
+    for (BlockNum i = 100; i > 0; --i) {
         account_history_table.upsert(db::to_slice(db::block_key(i)), db::to_slice(value));
     }
     // Check if works when cut in half
@@ -70,7 +70,7 @@ TEST_CASE("Check Truncate tables, reverse = false") {
     // Cursor to be opened does not matter
     auto account_history_table{db::open_cursor(*txn, db::table::kAccountHistory)};
 
-    for (int i = 100; i >= 0; i--) {
+    for (BlockNum i = 100; i > 0; --i) {
         account_history_table.upsert(db::to_slice(db::block_key(i)), db::to_slice(value));
     }
     // Check if works when cut in half

--- a/node/silkworm/trie/intermediate_hashes.cpp
+++ b/node/silkworm/trie/intermediate_hashes.cpp
@@ -132,9 +132,9 @@ evmc::bytes32 DbTrieLoader::calculate_root() {
             if (account.incarnation) {
                 const Bytes acc_with_inc{db::storage_prefix(db::from_slice(a.key), account.incarnation)};
                 HashBuilder storage_hb;
-                storage_hb.node_collector = [&](ByteView unpacked_key, const Node& node) {
+                storage_hb.node_collector = [&](ByteView unpacked_storage_key, const Node& node) {
                     etl::Entry e{acc_with_inc, marshal_node(node)};
-                    e.key.append(unpacked_key);
+                    e.key.append(unpacked_storage_key);
                     storage_collector_.collect(std::move(e));
                 };
 

--- a/node/silkworm/types/log_cbor.cpp
+++ b/node/silkworm/types/log_cbor.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -29,12 +29,12 @@ Bytes cbor_encode(const std::vector<Log>& v) {
 
     for (const Log& l : v) {
         encoder.write_array(3);
-        encoder.write_bytes(l.address.bytes, static_cast<int>(kAddressLength));
+        encoder.write_bytes(l.address.bytes, kAddressLength);
         encoder.write_array(static_cast<int>(l.topics.size()));
         for (const evmc::bytes32& t : l.topics) {
-            encoder.write_bytes(t.bytes, static_cast<int>(kHashLength));
+            encoder.write_bytes(t.bytes, kHashLength);
         }
-        encoder.write_bytes(l.data.data(), static_cast<int>(l.data.size()));
+        encoder.write_bytes(l.data.data(), l.data.size());
     }
 
     return Bytes{output.data(), output.size()};


### PR DESCRIPTION
- `-Wshadow` a variable declaration shadows one from a parent context
- `-Wold-style-cast` c-style casts
- `-Wimplicit-fallthrough` fall through in a `switch` statement without an explicit `[[fallthrough]]`
- `-Wsign-conversion` implicit signed <-> unsigned conversions