### PR TITLE
Avoid potential numeric underflow in get_parent

### DIFF
--- a/core/silkworm/chain/validity.cpp
+++ b/core/silkworm/chain/validity.cpp
@@ -74,6 +74,9 @@ ValidationResult pre_validate_transaction(const Transaction& txn, uint64_t block
 }
 
 static std::optional<BlockHeader> get_parent(const State& state, const BlockHeader& header) {
+    if (header.number == 0) {
+        return std::nullopt;
+    }
     return state.read_header(header.number - 1, header.parent_hash);
 }
 


### PR DESCRIPTION
This is a small improvement when `get_parent` is called for 0th block: immediately return `std::nullopt` instead of looking up for block number UINT64_MAX in the state.