### PR TITLE
Move kLondonTestConfig into test_util

### DIFF
--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -16,7 +16,6 @@
 
 #include <exception>
 #include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <map>
 #include <string>
@@ -28,15 +27,14 @@
 #include <magic_enum.hpp>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/consensus/blockchain.hpp>
 #include <silkworm/chain/difficulty.hpp>
-#include <silkworm/consensus/ethash/ethash.hpp>
 #include <silkworm/common/cast.hpp>
 #include <silkworm/common/endian.hpp>
+#include <silkworm/common/test_util.hpp>
 #include <silkworm/common/util.hpp>
+#include <silkworm/consensus/blockchain.hpp>
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/state/in_memory_state.hpp>
-#include <silkworm/state/intra_block_state.hpp>
 #include <silkworm/types/block.hpp>
 
 // See https://ethereum-tests.readthedocs.io
@@ -168,7 +166,7 @@ static const std::map<std::string, silkworm::ChainConfig> kNetworkConfig{
          },
          0,  // muir_glacier_block
      }},
-    {"London", kLondonTestConfig},
+    {"London", test::kLondonConfig},
     {"FrontierToHomesteadAt5",
      {
          1,  // chain_id
@@ -436,7 +434,7 @@ Status blockchain_test(const nlohmann::json& json_test, std::optional<ChainConfi
     }
 
     init_pre_state(json_test["pre"], state);
-    
+
     auto engine{consensus::get_consensus_engine(config.seal_engine)};
     Blockchain blockchain{state, *engine, config, genesis_block};
     blockchain.state_pool = &state_pool;

--- a/core/silkworm/chain/config.cpp
+++ b/core/silkworm/chain/config.cpp
@@ -87,15 +87,6 @@ std::optional<ChainConfig> ChainConfig::from_json(const nlohmann::json& json) no
     return config;
 }
 
-evmc_revision ChainConfig::revision(uint64_t block_number) const noexcept {
-    for (size_t i{EVMC_MAX_REVISION}; i > 0; --i) {
-        if (fork_blocks[i - 1].has_value() && block_number >= fork_blocks[i - 1].value()) {
-            return static_cast<evmc_revision>(i);
-        }
-    }
-    return EVMC_FRONTIER;
-}
-
 std::optional<uint64_t> ChainConfig::revision_block(evmc_revision rev) const noexcept {
     if (rev == EVMC_FRONTIER) {
         return 0;

--- a/core/silkworm/chain/config_test.cpp
+++ b/core/silkworm/chain/config_test.cpp
@@ -118,6 +118,4 @@ TEST_CASE("JSON serialization") {
     CHECK(config->to_json() == mainnet_json);
 }
 
-TEST_CASE("London Test Config") { CHECK(kLondonTestConfig.revision(0) == EVMC_LONDON); }
-
 }  // namespace silkworm

--- a/core/silkworm/common/test_util.cpp
+++ b/core/silkworm/common/test_util.cpp
@@ -1,6 +1,22 @@
+/*
+   Copyright 2021 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 #include "test_util.hpp"
 
-namespace silkworm::test_util {
+namespace silkworm::test {
 
 std::vector<Transaction> sample_transactions() {
     std::vector<Transaction> transactions;
@@ -36,4 +52,4 @@ std::vector<Transaction> sample_transactions() {
     return transactions;
 }
 
-}
+}  // namespace silkworm::test

--- a/core/silkworm/common/test_util.hpp
+++ b/core/silkworm/common/test_util.hpp
@@ -19,10 +19,19 @@
 
 #include <silkworm/types/block.hpp>
 
-namespace silkworm::test_util {
+namespace silkworm::test {
+
+/// Enables London from genesis.
+constexpr ChainConfig kLondonConfig{
+    1,  // chain_id
+    SealEngineType::kNoProof,
+    {0, 0, 0, 0, 0, 0, 0, 0, 0},
+};
+
+static_assert(kLondonConfig.revision(0) == EVMC_LONDON);
 
 std::vector<Transaction> sample_transactions();
 
-}  // namespace silkworm::test_util
+}  // namespace silkworm::test
 
 #endif  // SILKWORM_COMMON_TEST_UTIL_HPP_

--- a/core/silkworm/execution/execution_test.cpp
+++ b/core/silkworm/execution/execution_test.cpp
@@ -21,8 +21,8 @@
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
 
-#include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
+#include <silkworm/common/test_util.hpp>
 #include <silkworm/execution/address.hpp>
 #include <silkworm/rlp/encode.hpp>
 #include <silkworm/state/in_memory_state.hpp>
@@ -35,7 +35,6 @@ namespace silkworm {
 using namespace silkworm::consensus;
 
 TEST_CASE("Execute two blocks") {
-
     // ---------------------------------------
     // Prepare
     // ---------------------------------------
@@ -82,7 +81,7 @@ TEST_CASE("Execute two blocks") {
     // Execute first block
     // ---------------------------------------
 
-    REQUIRE(execute_block(block, state, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, state, test::kLondonConfig) == ValidationResult::kOk);
 
     auto contract_address{create_address(sender, /*nonce=*/0)};
     std::optional<Account> contract_account{state.read_account(contract_address)};
@@ -120,7 +119,7 @@ TEST_CASE("Execute two blocks") {
     block.transactions[0].data = *from_hex(new_val);
     block.transactions[0].max_priority_fee_per_gas = 20 * kGiga;
 
-    REQUIRE(execute_block(block, state, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, state, test::kLondonConfig) == ValidationResult::kOk);
 
     storage0 = state.read_storage(contract_address, kDefaultIncarnation, storage_key0);
     CHECK(to_hex(storage0) == new_val);
@@ -130,4 +129,4 @@ TEST_CASE("Execute two blocks") {
     CHECK(miner_account->balance > 2 * param::kBlockRewardConstantinople);
     CHECK(miner_account->balance < 3 * param::kBlockRewardConstantinople);
 }
-}
+}  // namespace silkworm

--- a/core/silkworm/execution/processor_test.cpp
+++ b/core/silkworm/execution/processor_test.cpp
@@ -21,8 +21,8 @@
 
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/test_util.hpp>
-#include <silkworm/state/in_memory_state.hpp>
 #include <silkworm/consensus/ethash/ethash.hpp>
+#include <silkworm/state/in_memory_state.hpp>
 
 #include "address.hpp"
 
@@ -73,7 +73,7 @@ TEST_CASE("EIP-3607: Reject transactions from senders with deployed code") {
 
     const evmc::address sender{0x71562b71999873DB5b286dF957af199Ec94617F7_address};
 
-    Transaction txn{test_util::sample_transactions()[0]};
+    Transaction txn{test::sample_transactions()[0]};
     txn.nonce = 0;
     txn.from = sender;
 

--- a/node/silkworm/stagedsync/prune_execution_test.cpp
+++ b/node/silkworm/stagedsync/prune_execution_test.cpp
@@ -17,9 +17,9 @@
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
 
-#include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/directories.hpp>
+#include <silkworm/common/test_util.hpp>
 #include <silkworm/db/buffer.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/execution/address.hpp>
@@ -32,7 +32,6 @@ using namespace silkworm;
 using namespace silkworm::consensus;
 
 TEST_CASE("Prune Execution without prune function") {
-
     TemporaryDirectory tmp_dir;
     DataDirectory data_dir{tmp_dir.path()};
 
@@ -88,7 +87,7 @@ TEST_CASE("Prune Execution without prune function") {
     // ---------------------------------------
     // Execute first block
     // ---------------------------------------
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
     auto contract_address{create_address(sender, /*nonce=*/0)};
 
     // ---------------------------------------
@@ -110,7 +109,7 @@ TEST_CASE("Prune Execution without prune function") {
     block.transactions[0].data = *from_hex(new_val);
     block.transactions[0].max_priority_fee_per_gas = 20 * kGiga;
 
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
 
     // ---------------------------------------
     // Execute third block
@@ -124,7 +123,7 @@ TEST_CASE("Prune Execution without prune function") {
     block.transactions[0].nonce = 2;
     block.transactions[0].data = *from_hex(new_val);
 
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
 
     db::stages::set_stage_progress(*txn, db::stages::kExecutionKey, 3);
     // We keep chain from Block 2 onwards (Aka, we delete block 1 changesets and receipts)
@@ -198,7 +197,7 @@ TEST_CASE("Prune Execution with prune function") {
     // ---------------------------------------
     // Execute first block
     // ---------------------------------------
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
     auto contract_address{create_address(sender, /*nonce=*/0)};
 
     // ---------------------------------------
@@ -220,7 +219,7 @@ TEST_CASE("Prune Execution with prune function") {
     block.transactions[0].data = *from_hex(new_val);
     block.transactions[0].max_priority_fee_per_gas = 20 * kGiga;
 
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
 
     // ---------------------------------------
     // Execute third block
@@ -234,7 +233,7 @@ TEST_CASE("Prune Execution with prune function") {
     block.transactions[0].nonce = 2;
     block.transactions[0].data = *from_hex(new_val);
 
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
 
     db::stages::set_stage_progress(*txn, db::stages::kExecutionKey, 3);
     buffer.write_to_db();

--- a/node/silkworm/stagedsync/stage_senders_test.cpp
+++ b/node/silkworm/stagedsync/stage_senders_test.cpp
@@ -21,9 +21,9 @@
 #include <silkworm/chain/genesis.hpp>
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/directories.hpp>
+#include <silkworm/common/test_util.hpp>
 #include <silkworm/db/buffer.hpp>
 #include <silkworm/db/stages.hpp>
-#include <silkworm/common/test_util.hpp>
 
 using namespace evmc::literals;
 
@@ -49,7 +49,7 @@ TEST_CASE("Stage Senders") {
     auto transaction_table{db::open_cursor(*txn, db::table::kEthTx)};
 
     db::detail::BlockBodyForStorage block{};
-    auto transactions{test_util::sample_transactions()};
+    auto transactions{test::sample_transactions()};
     block.base_txn_id = 1;
     block.txn_count = 1;
 
@@ -126,7 +126,7 @@ TEST_CASE("Unwind Senders") {
     auto transaction_table{db::open_cursor(*txn, db::table::kEthTx)};
 
     db::detail::BlockBodyForStorage block{};
-    auto transactions{test_util::sample_transactions()};
+    auto transactions{test::sample_transactions()};
     block.base_txn_id = 1;
     block.txn_count = 1;
 
@@ -203,7 +203,7 @@ TEST_CASE("Prune Senders") {
     auto transaction_table{db::open_cursor(*txn, db::table::kEthTx)};
 
     db::detail::BlockBodyForStorage block{};
-    auto transactions{test_util::sample_transactions()};
+    auto transactions{test::sample_transactions()};
     block.base_txn_id = 1;
     block.txn_count = 1;
 

--- a/node/silkworm/stagedsync/tx_lookup_test.cpp
+++ b/node/silkworm/stagedsync/tx_lookup_test.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Stage Transaction Lookups") {
     auto transaction_table{db::open_cursor(*txn, db::table::kEthTx)};
 
     db::detail::BlockBodyForStorage block{};
-    auto transactions{test_util::sample_transactions()};
+    auto transactions{test::sample_transactions()};
     block.base_txn_id = 1;
     block.txn_count = 1;
     // ---------------------------------------
@@ -94,7 +94,7 @@ TEST_CASE("Unwind Transaction Lookups") {
     auto transaction_table{db::open_cursor(*txn, db::table::kEthTx)};
 
     db::detail::BlockBodyForStorage block{};
-    auto transactions{test_util::sample_transactions()};
+    auto transactions{test::sample_transactions()};
     block.base_txn_id = 1;
     block.txn_count = 1;
 
@@ -145,7 +145,7 @@ TEST_CASE("Prune Transaction Lookups") {
     auto transaction_table{db::open_cursor(*txn, db::table::kEthTx)};
 
     db::detail::BlockBodyForStorage block{};
-    auto transactions{test_util::sample_transactions()};
+    auto transactions{test::sample_transactions()};
     block.base_txn_id = 1;
     block.txn_count = 1;
 

--- a/node/silkworm/stagedsync/unwind_execution_test.cpp
+++ b/node/silkworm/stagedsync/unwind_execution_test.cpp
@@ -17,9 +17,9 @@
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
 
-#include <silkworm/chain/config.hpp>
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/directories.hpp>
+#include <silkworm/common/test_util.hpp>
 #include <silkworm/db/buffer.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/execution/address.hpp>
@@ -35,7 +35,6 @@ using namespace silkworm;
 using namespace silkworm::consensus;
 
 TEST_CASE("Unwind Execution") {
-
     TemporaryDirectory tmp_dir;
     DataDirectory data_dir{tmp_dir.path()};
 
@@ -91,7 +90,7 @@ TEST_CASE("Unwind Execution") {
     // ---------------------------------------
     // Execute first block
     // ---------------------------------------
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
     auto contract_address{create_address(sender, /*nonce=*/0)};
 
     // ---------------------------------------
@@ -113,7 +112,7 @@ TEST_CASE("Unwind Execution") {
     block.transactions[0].data = *from_hex(new_val);
     block.transactions[0].max_priority_fee_per_gas = 20 * kGiga;
 
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
 
     // ---------------------------------------
     // Execute third block
@@ -127,7 +126,7 @@ TEST_CASE("Unwind Execution") {
     block.transactions[0].nonce = 2;
     block.transactions[0].data = *from_hex(new_val);
 
-    REQUIRE(execute_block(block, buffer, kLondonTestConfig) == ValidationResult::kOk);
+    REQUIRE(execute_block(block, buffer, test::kLondonConfig) == ValidationResult::kOk);
 
     db::stages::set_stage_progress(*txn, db::stages::kExecutionKey, 3);
     buffer.write_to_db();


### PR DESCRIPTION
`kLondonTestConfig` is used only in tests, so moving it into `test_util.hpp`