### PR TITLE
convert_to_db_format -> change_set_to_plain_state_format

### DIFF
--- a/node/silkworm/db/util.cpp
+++ b/node/silkworm/db/util.cpp
@@ -30,20 +30,20 @@ Bytes storage_prefix(ByteView address, uint64_t incarnation) {
     return res;
 }
 
-Bytes block_key(uint64_t block_number) {
+Bytes block_key(BlockNum block_number) {
     Bytes key(8, '\0');
     endian::store_big_u64(&key[0], block_number);
     return key;
 }
 
-Bytes block_key(uint64_t block_number, const uint8_t (&hash)[kHashLength]) {
+Bytes block_key(BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
     Bytes key(8 + kHashLength, '\0');
     endian::store_big_u64(&key[0], block_number);
     std::memcpy(&key[8], hash, kHashLength);
     return key;
 }
 
-Bytes storage_change_key(uint64_t block_number, const evmc::address& address, uint64_t incarnation) {
+Bytes storage_change_key(BlockNum block_number, const evmc::address& address, uint64_t incarnation) {
     Bytes res(8 + kPlainStoragePrefixLength, '\0');
     endian::store_big_u64(&res[0], block_number);
     std::memcpy(&res[8], address.bytes, kAddressLength);
@@ -51,14 +51,14 @@ Bytes storage_change_key(uint64_t block_number, const evmc::address& address, ui
     return res;
 }
 
-Bytes account_history_key(const evmc::address& address, uint64_t block_number) {
+Bytes account_history_key(const evmc::address& address, BlockNum block_number) {
     Bytes res(kAddressLength + 8, '\0');
     std::memcpy(&res[0], address.bytes, kAddressLength);
     endian::store_big_u64(&res[kAddressLength], block_number);
     return res;
 }
 
-Bytes storage_history_key(const evmc::address& address, const evmc::bytes32& location, uint64_t block_number) {
+Bytes storage_history_key(const evmc::address& address, const evmc::bytes32& location, BlockNum block_number) {
     Bytes res(kAddressLength + kHashLength + 8, '\0');
     std::memcpy(&res[0], address.bytes, kAddressLength);
     std::memcpy(&res[kAddressLength], location.bytes, kHashLength);
@@ -66,7 +66,7 @@ Bytes storage_history_key(const evmc::address& address, const evmc::bytes32& loc
     return res;
 }
 
-Bytes log_key(uint64_t block_number, uint32_t transaction_id) {
+Bytes log_key(BlockNum block_number, uint32_t transaction_id) {
     Bytes key(8 + 4, '\0');
     endian::store_big_u64(&key[0], block_number);
     endian::store_big_u32(&key[8], transaction_id);

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -153,21 +153,21 @@ using StorageChanges = absl::btree_map<evmc::address, absl::btree_map<uint64_t, 
 Bytes storage_prefix(ByteView address, uint64_t incarnation);
 
 // Erigon EncodeBlockNumber
-Bytes block_key(uint64_t block_number);
+Bytes block_key(BlockNum block_number);
 
 // Erigon HeaderKey & BlockBodyKey
-Bytes block_key(uint64_t block_number, const uint8_t (&hash)[kHashLength]);
+Bytes block_key(BlockNum block_number, const uint8_t (&hash)[kHashLength]);
 
-Bytes storage_change_key(uint64_t block_number, const evmc::address& address, uint64_t incarnation);
+Bytes storage_change_key(BlockNum block_number, const evmc::address& address, uint64_t incarnation);
 
 // Erigon IndexChunkKey for account
-Bytes account_history_key(const evmc::address& address, uint64_t block_number);
+Bytes account_history_key(const evmc::address& address, BlockNum block_number);
 
 // Erigon IndexChunkKey for storage
-Bytes storage_history_key(const evmc::address& address, const evmc::bytes32& location, uint64_t block_number);
+Bytes storage_history_key(const evmc::address& address, const evmc::bytes32& location, BlockNum block_number);
 
 // Erigon LogKey
-Bytes log_key(uint64_t block_number, uint32_t transaction_id);
+Bytes log_key(BlockNum block_number, uint32_t transaction_id);
 
 //! \brief Converts change set (AccountChangeSet/StorageChangeSet) entry to plain state format.
 //! \param [in] key : Change set key.

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -39,7 +39,7 @@ struct VersionBase {
     uint32_t Major;
     uint32_t Minor;
     uint32_t Patch;
-    std::string to_string() const {
+    [[nodiscard]] std::string to_string() const {
         std::string ret{std::to_string(Major)};
         ret.append("." + std::to_string(Minor));
         ret.append("." + std::to_string(Patch));
@@ -83,13 +83,14 @@ struct VersionBase {
 
 // Holds the storage mode set
 struct StorageMode {
-    bool Initialized;  // Whether or not db storage has been initialized
-    bool History;      // Whether or not History index is stored
-    bool Receipts;     // Whether or not Receipts are stored
-    bool TxIndex;      // Whether or not TxIndex is stored
-    bool CallTraces;   // Whether or not Call Traces are stored
+    bool Initialized;  // Whether db storage has been initialized
+    bool History;      // Whether History index is stored
+    bool Receipts;     // Whether Receipts are stored
+    bool TxIndex;      // Whether TxIndex is stored
+    bool CallTraces;   // Whether Call Traces are stored
     bool TEVM;         // TODO - not yet supported in Silkworm
-    std::string to_string() const {
+
+    [[nodiscard]] std::string to_string() const {
         if (!Initialized) {
             return "default";
         }
@@ -168,17 +169,19 @@ Bytes storage_history_key(const evmc::address& address, const evmc::bytes32& loc
 // Erigon LogKey
 Bytes log_key(uint64_t block_number, uint32_t transaction_id);
 
-inline mdbx::slice to_slice(ByteView value) {
-    return mdbx::slice(static_cast<const void*>(value.data()), value.length());
-}
+//! \brief Converts change set (AccountChangeSet/StorageChangeSet) entry to plain state format.
+//! \param [in] key : Change set key.
+//! \param [in] value : Change set value.
+//! \return Plain state key + previous value of the account or storage.
+//! \remarks For storage location is returned as the last part of the key,
+//! while technically in PlainState it's the first part of the value.
+std::pair<Bytes, Bytes> change_set_to_plain_state_format(ByteView key, ByteView value);
 
-inline mdbx::slice to_slice(const evmc::address& value) {
-    return mdbx::slice(static_cast<const void*>(value.bytes), sizeof(evmc::address));
-}
+inline mdbx::slice to_slice(ByteView value) { return {value.data(), value.length()}; }
 
-inline mdbx::slice to_slice(const evmc::bytes32& value) {
-    return mdbx::slice(static_cast<const void*>(value.bytes), sizeof(evmc::bytes32));
-}
+inline mdbx::slice to_slice(const evmc::address& value) { return {value.bytes, sizeof(evmc::address)}; }
+
+inline mdbx::slice to_slice(const evmc::bytes32& value) { return {value.bytes, sizeof(evmc::bytes32)}; }
 
 inline ByteView from_slice(const mdbx::slice slice) { return {static_cast<uint8_t*>(slice.iov_base), slice.iov_len}; }
 
@@ -198,7 +201,7 @@ namespace detail {
         uint64_t txn_count{0};
         std::vector<BlockHeader> ommers;
 
-        Bytes encode() const;
+        [[nodiscard]] Bytes encode() const;
     };
 
     BlockBodyForStorage decode_stored_block_body(ByteView& from);

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -215,7 +215,7 @@ static void unwind_state_from_changeset(mdbx::cursor& source, mdbx::cursor& plai
         if (block_number == unwind_to) {
             break;
         }
-        auto [new_key, new_value]{change_set_to_plain_state_format(key, value)};
+        auto [new_key, new_value]{db::change_set_to_plain_state_format(key, value)};
         revert_state(new_key, new_value, plain_state_table, plain_code_table);
         src_data = source.to_previous(/*throw_notfound*/ false);
     }

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -170,7 +170,7 @@ void hashstate_promote(mdbx::txn& txn, HashstateOperation operation) {
     while (changeset_data) {
         Bytes mdb_key_as_bytes{db::from_slice(changeset_data.key)};
         Bytes mdb_value_as_bytes{db::from_slice(changeset_data.value)};
-        auto [db_key, _]{change_set_to_plain_state_format(mdb_key_as_bytes, mdb_value_as_bytes)};
+        auto [db_key, _]{db::change_set_to_plain_state_format(mdb_key_as_bytes, mdb_value_as_bytes)};
 
         if (operation == HashstateOperation::HashAccount) {
             // We get account and hash its key.
@@ -289,8 +289,8 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
     switch (operation) {
         case silkworm::stagedsync::HashstateOperation::HashAccount:
             unwind_func = [&target_table, &code_table](::mdbx::cursor, ::mdbx::cursor::move_result data) -> bool {
-                auto [db_key,
-                      db_value]{change_set_to_plain_state_format(db::from_slice(data.key), db::from_slice(data.value))};
+                auto [db_key, db_value]{
+                    db::change_set_to_plain_state_format(db::from_slice(data.key), db::from_slice(data.value))};
 
                 auto hash{keccak256(db_key)};
                 auto new_key{mdbx::slice{hash.bytes, kHashLength}};
@@ -332,8 +332,8 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
             break;
         case silkworm::stagedsync::HashstateOperation::HashStorage:
             unwind_func = [&target_table](::mdbx::cursor, ::mdbx::cursor::move_result data) -> bool {
-                auto [db_key,
-                      db_value]{change_set_to_plain_state_format(db::from_slice(data.key), db::from_slice(data.value))};
+                auto [db_key, db_value]{
+                    db::change_set_to_plain_state_format(db::from_slice(data.key), db::from_slice(data.value))};
 
                 Bytes hashed_key(db::kHashedStoragePrefixLength, '\0');
                 std::memcpy(&hashed_key[0], keccak256(db_key.substr(0, kAddressLength)).bytes, kHashLength);
@@ -350,8 +350,8 @@ void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation ope
         case silkworm::stagedsync::HashstateOperation::Code:
             unwind_func = [&target_table, &contract_code_table](::mdbx::cursor,
                                                                 ::mdbx::cursor::move_result data) -> bool {
-                auto [db_key,
-                      db_value]{change_set_to_plain_state_format(db::from_slice(data.key), db::from_slice(data.value))};
+                auto [db_key, db_value]{
+                    db::change_set_to_plain_state_format(db::from_slice(data.key), db::from_slice(data.value))};
                 if (db_value.empty()) {
                     return true;
                 }

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -271,7 +271,7 @@ StageResult stage_hashstate(TransactionManager& txn, const fs::path& etl_path, u
  *  We need to use changeset because we can use the progress system.
  *  Note: Standard Promotion is way slower than Clean Promotion
  */
-void hashstate_unwind(mdbx::txn& txn, uint64_t unwind_to, HashstateOperation operation) {
+static void hashstate_unwind(mdbx::txn& txn, BlockNum unwind_to, HashstateOperation operation) {
     auto [changeset_config, target_config] = get_tables_for_promote(operation);
 
     auto changeset_table{db::open_cursor(txn, changeset_config)};

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -67,7 +67,7 @@ static StageResult history_index_stage(TransactionManager& txn, const std::files
         std::string composite_key;
         auto key{db::from_slice(data.key)};
         auto value{db::from_slice(data.value)};
-        auto [db_key, _]{change_set_to_plain_state_format(key, value)};
+        auto [db_key, _]{db::change_set_to_plain_state_format(key, value)};
         // Make the composite key accordingly whether we are dealing with storages or accounts
         if (storage) {
             // Storage: Address + Location

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -14,13 +14,11 @@
    limitations under the License.
 */
 
-#include <string>
 #include <unordered_map>
 
 #include <silkworm/common/cast.hpp>
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/log.hpp>
-#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/bitmap.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/etl/collector.hpp>
@@ -69,7 +67,7 @@ static StageResult history_index_stage(TransactionManager& txn, const std::files
         std::string composite_key;
         auto key{db::from_slice(data.key)};
         auto value{db::from_slice(data.value)};
-        auto [db_key, _]{convert_to_db_format(key, value)};
+        auto [db_key, _]{change_set_to_plain_state_format(key, value)};
         // Make the composite key accordingly whether we are dealing with storages or accounts
         if (storage) {
             // Storage: Address + Location
@@ -104,7 +102,7 @@ static StageResult history_index_stage(TransactionManager& txn, const std::files
     SILKWORM_LOG(LogLevel::Info) << "Latest Block: " << block_number << std::endl;
 
     // Proceed only if we've done something
-    if (collector.size()) {
+    if (!collector.empty()) {
         SILKWORM_LOG(LogLevel::Info) << "Started Loading" << std::endl;
 
         MDBX_put_flags_t db_flags{last_processed_block_number ? MDBX_put_flags_t::MDBX_UPSERT
@@ -178,7 +176,7 @@ StageResult history_index_unwind(TransactionManager& txn, const std::filesystem:
             auto key{db::from_slice(data.key)};
             auto bitmap_data{db::from_slice(data.value)};
             auto bm{roaring::Roaring64Map::readSafe(byte_ptr_cast(bitmap_data.data()), bitmap_data.size())};
-            // Check wheter we should skip the current bitmap
+            // Check whether we should skip the current bitmap
             if (bm.maximum() <= unwind_to) {
                 data = index_table.to_next(/*throw_notfound*/ false);
                 continue;

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -61,7 +61,7 @@ static StageResult history_index_stage(TransactionManager& txn, const std::files
                                  << " Index Extraction. From: " << (last_processed_block_number + 1) << std::endl;
 
     size_t allocated_space{0};
-    uint64_t block_number{0};
+    BlockNum block_number{0};
     auto data{changeset_table.lower_bound(db::to_slice(start))};
     while (data) {
         std::string composite_key;
@@ -133,7 +133,7 @@ static StageResult history_index_stage(TransactionManager& txn, const std::files
                     Bytes chunk_index(entry.key.size() + 8, '\0');
                     std::memcpy(&chunk_index[0], &entry.key[0], entry.key.size());
                     // Suffix is either the maximum Block Number of the bitmap or if it's the last chunk: UINT64_MAX
-                    uint64_t suffix{bm.cardinality() == 0 ? UINT64_MAX : current_chunk.maximum()};
+                    BlockNum suffix{bm.cardinality() == 0 ? UINT64_MAX : current_chunk.maximum()};
                     endian::store_big_u64(&chunk_index[entry.key.size()], suffix);
                     // Push chunk to database
                     Bytes current_chunk_bytes(current_chunk.getSizeInBytes(), '\0');

--- a/node/silkworm/stagedsync/util.cpp
+++ b/node/silkworm/stagedsync/util.cpp
@@ -16,13 +16,9 @@
 
 #include "util.hpp"
 
-#include <cassert>
-#include <memory>
 #include <stdexcept>
 
 #include <magic_enum.hpp>
-
-#include <silkworm/db/util.hpp>
 
 namespace silkworm::stagedsync {
 
@@ -30,23 +26,6 @@ void check_stagedsync_error(StageResult code) {
     if (code != StageResult::kSuccess) {
         std::string error{magic_enum::enum_name<StageResult>(code)};
         throw std::runtime_error(error);
-    }
-}
-
-std::pair<Bytes, Bytes> change_set_to_plain_state_format(const ByteView key, const ByteView value) {
-    if (key.size() == 8) {  // AccountChangeSet
-        const Bytes address{value.substr(0, kAddressLength)};
-        const Bytes previous_value{value.substr(kAddressLength)};
-        return {address, previous_value};
-    } else {  // StorageChangeSet
-        assert(key.length() == 8 + db::kPlainStoragePrefixLength);
-        // See db::storage_change_key
-        const ByteView address_with_incarnation{key.substr(8)};
-        const ByteView location{value.substr(0, kHashLength)};
-        Bytes full_key{address_with_incarnation};
-        full_key.append(location);
-        const Bytes previous_value{value.substr(kHashLength)};
-        return {full_key, previous_value};
     }
 }
 

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -49,14 +49,6 @@ enum class [[nodiscard]] StageResult {
 
 void check_stagedsync_error(StageResult code);
 
-//! \brief Converts change set (AccountChangeSet/StorageChangeSet) entry to plain state format.
-//! \param [in] key : Change set key.
-//! \param [in] value : Change set value.
-//! \return Plain state key + previous value of the account or storage.
-//! \remarks For storage location is returned as the last part of the key,
-//! while technically in PlainState it's the first part of the value.
-std::pair<Bytes, Bytes> change_set_to_plain_state_format(ByteView key, ByteView value);
-
 }  // namespace silkworm::stagedsync
 
 #endif  // SILKWORM_STAGEDSYNC_UTIL_HPP_

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -49,8 +49,13 @@ enum class [[nodiscard]] StageResult {
 
 void check_stagedsync_error(StageResult code);
 
-// Convert changesets key and value pair to plain state format
-std::pair<Bytes, Bytes> convert_to_db_format(const ByteView& key, const ByteView& value);
+//! \brief Converts change set (AccountChangeSet/StorageChangeSet) entry to plain state format.
+//! \param [in] key : Change set key.
+//! \param [in] value : Change set value.
+//! \return Plain state key + previous value of the account or storage.
+//! \remarks For storage location is returned as the last part of the key,
+//! while technically in PlainState it's the first part of the value.
+std::pair<Bytes, Bytes> change_set_to_plain_state_format(ByteView key, ByteView value);
 
 }  // namespace silkworm::stagedsync
 


### PR DESCRIPTION
`convert_to_db_format` was a bad name because it converts from one DB format (AccountChangeSet or StorageChangeSet) into another DB format (PlainState).