### PR TITLE
Break Appveyor cache dependency on .appveyor.yml, Hunter\config.cmake…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The Silkworm Authors
+#   Copyright 2020-2021 The Silkworm Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ install:
   - vcpkg install mpir:x64-windows
 
 cache:
-  - C:\Tools\vcpkg\installed -> .appveyor.yml
-  - C:\.hunter -> .appveyor.yml, cmake\toolchain.cmake, cmake\Hunter\config.cmake, cmake\Hunter\core_packages.cmake, cmake\Hunter\extra_packages.cmake
+  - C:\Tools\vcpkg\installed
+  - C:\.hunter
 
 before_build:
   - cd "%APPVEYOR_BUILD_FOLDER%"


### PR DESCRIPTION
A mitigation for the following problem with AppVeyor. It caches Hunter builds, but we invalidate the cache if our Hunter config changes. This is the right thing to do, of course. However, consequently if one branch has a change to Hunter dependencies (e.g. ethash) and others don't, Appveyor starts Hunter build from scratch when switching branches and builds take 2 hours. Circle CI doesn't have this problem because it supports multiple caches with different keys (and hunter dependencies are hashed into the key.)

See Issue #358.