### PR TITLE
Consistent naming for err handlers

### DIFF
--- a/cmd/blockhashes.cpp
+++ b/cmd/blockhashes.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
         auto result_code{stagedsync::stage_blockhashes(tm, data_dir.etl().path())};
-        check_stagedsync_error(result_code);
+        success_or_throw(result_code);
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;

--- a/cmd/history_index.cpp
+++ b/cmd/history_index.cpp
@@ -62,9 +62,9 @@ int main(int argc, char* argv[]) {
 
         stagedsync::TransactionManager tm{env};
         if (storage) {
-            stagedsync::check_stagedsync_error(stagedsync::stage_storage_history(tm, data_dir.etl().path()));
+            stagedsync::success_or_throw(stagedsync::stage_storage_history(tm, data_dir.etl().path()));
         } else {
-            stagedsync::check_stagedsync_error(stagedsync::stage_account_history(tm, data_dir.etl().path()));
+            stagedsync::success_or_throw(stagedsync::stage_account_history(tm, data_dir.etl().path()));
         }
 
     } catch (const std::exception& ex) {

--- a/cmd/log_index.cpp
+++ b/cmd/log_index.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
         }
 
         stagedsync::TransactionManager tm{env};
-        stagedsync::check_stagedsync_error(stagedsync::stage_log_index(tm, data_dir.etl().path()));
+        stagedsync::success_or_throw(stagedsync::stage_log_index(tm, data_dir.etl().path()));
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;

--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -360,7 +360,7 @@ void do_stages(db::EnvConfig& config) {
             if (std::memcmp(result.key.iov_base, prune_prefix, 6) == 0) {
                 offset = 6;
             }
-            
+
             bool Known{db::stages::is_known_stage(result.key.char_ptr() + offset)};
             std::cout << (boost::format(fmt_row) % result.key.as_string() % height %
                           (Known ? std::string(8, ' ') : "Unknown"))
@@ -384,9 +384,8 @@ void do_prunes(db::EnvConfig& config, uint64_t prune_size) {
 
     std::cout << "\n Pruned start, block to be kept: " << prune_size << "\n" << std::endl;
     auto pruned_node_stages{stagedsync::get_pruned_node_stages()};
-    for (auto stage : pruned_node_stages) {
-        stagedsync::check_stagedsync_error(
-            stage.prune_func(txn, DataDirectory::from_chaindata(config.path).etl().path(), prune_from));
+    for(auto stage: pruned_node_stages) {
+        stagedsync::success_or_throw(stage.prune_func(txn, DataDirectory::from_chaindata(config.path).etl().path(), prune_from));
     }
 }
 
@@ -419,7 +418,7 @@ void do_migrations(db::EnvConfig& config) {
     }
 }
 
-void do_stage_set(db::EnvConfig& config, std::string stage_name, uint32_t new_height, bool dry) {
+void do_stage_set(db::EnvConfig& config, std::string& stage_name, uint32_t new_height, bool dry) {
     config.readonly = false;
     auto env{silkworm::db::open_env(config)};
     auto txn{env.start_write()};
@@ -518,7 +517,7 @@ void do_schema(db::EnvConfig& config) {
               << std::endl;
 }
 
-void do_compact(db::EnvConfig& config, std::string work_dir, bool replace, bool nobak) {
+void do_compact(db::EnvConfig& config, const std::string& work_dir, bool replace, bool nobak) {
     fs::path work_path{work_dir};
     if (work_path.has_filename()) {
         work_path += fs::path::preferred_separator;
@@ -584,7 +583,7 @@ void do_compact(db::EnvConfig& config, std::string work_dir, bool replace, bool 
     }
 }
 
-void do_copy(db::EnvConfig& src_config, std::string target_dir, bool create, bool noempty,
+void do_copy(db::EnvConfig& src_config, const std::string& target_dir, bool create, bool noempty,
              std::vector<std::string>& names, std::vector<std::string>& xnames, bool dry) {
     fs::path target_path{target_dir};
     if (target_path.has_filename()) {
@@ -776,7 +775,7 @@ void do_copy(db::EnvConfig& src_config, std::string target_dir, bool create, boo
  * \param bool dry : whether or not commit data or run in simulation
  *
  */
-void do_init_genesis(DataDirectory& data_dir, std::string json_file, uint32_t chain_id, bool dry) {
+void do_init_genesis(DataDirectory& data_dir, const std::string&& json_file, uint32_t chain_id, bool dry) {
     // Check datadir does not exist
     if (data_dir.exists()) {
         throw std::runtime_error("Provided data directory already exist");

--- a/cmd/tx_lookup.cpp
+++ b/cmd/tx_lookup.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
         }
 
         stagedsync::TransactionManager tm{env};
-        stagedsync::check_stagedsync_error(stagedsync::stage_tx_lookup(tm, data_dir.etl().path()));
+        stagedsync::success_or_throw(stagedsync::stage_tx_lookup(tm, data_dir.etl().path()));
 
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;

--- a/cmd/unwind_execution.cpp
+++ b/cmd/unwind_execution.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
         db::EnvConfig db_config{data_dir.chaindata().path().string()};
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
-        stagedsync::check_stagedsync_error(stagedsync::unwind_execution(tm, data_dir.etl().path(), unwind_to));
+        stagedsync::success_or_throw(stagedsync::unwind_execution(tm, data_dir.etl().path(), unwind_to));
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;

--- a/cmd/unwind_hashstate.cpp
+++ b/cmd/unwind_hashstate.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
         db::EnvConfig db_config{data_dir.chaindata().path().string()};
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
-        stagedsync::check_stagedsync_error(stagedsync::unwind_hashstate(tm, data_dir.etl().path(), unwind_to));
+        stagedsync::success_or_throw(stagedsync::unwind_hashstate(tm, data_dir.etl().path(), unwind_to));
 
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;

--- a/cmd/unwind_history_index.cpp
+++ b/cmd/unwind_history_index.cpp
@@ -48,10 +48,10 @@ int main(int argc, char* argv[]) {
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
         if (storage) {
-            stagedsync::check_stagedsync_error(
+            stagedsync::success_or_throw(
                 stagedsync::unwind_storage_history(tm, data_dir.etl().path(), unwind_to));
         } else {
-            stagedsync::check_stagedsync_error(
+            stagedsync::success_or_throw(
                 stagedsync::unwind_account_history(tm, data_dir.etl().path(), unwind_to));
         }
     } catch (const std::exception& ex) {

--- a/cmd/unwind_log_index.cpp
+++ b/cmd/unwind_log_index.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
     try {
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
-        stagedsync::check_stagedsync_error(stagedsync::unwind_log_index(tm, data_dir.etl().path(), unwind_to));
+        stagedsync::success_or_throw(stagedsync::unwind_log_index(tm, data_dir.etl().path(), unwind_to));
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;
         return -5;

--- a/cmd/unwind_tx_lookup.cpp
+++ b/cmd/unwind_tx_lookup.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
         db::EnvConfig db_config{data_dir.chaindata().path().string()};
         auto env{db::open_env(db_config)};
         stagedsync::TransactionManager tm{env};
-        stagedsync::check_stagedsync_error(stagedsync::unwind_tx_lookup(tm, data_dir.etl().path(), unwind_to));
+        stagedsync::success_or_throw(stagedsync::unwind_tx_lookup(tm, data_dir.etl().path(), unwind_to));
 
     } catch (const std::exception& ex) {
         SILKWORM_LOG(LogLevel::Error) << ex.what() << std::endl;

--- a/node/silkworm/common/rlp_err.hpp
+++ b/node/silkworm/common/rlp_err.hpp
@@ -28,18 +28,18 @@ class DecodingError : public std::exception {
     explicit DecodingError(DecodingResult err)
         : err_{magic_enum::enum_integer<DecodingResult>(err)},
           message_{"Decoding error : " + std::string(magic_enum::enum_name<DecodingResult>(err))} {};
-    explicit DecodingError(DecodingResult err, const std::string& message)
-        : err_{magic_enum::enum_integer<DecodingResult>(err)}, message_{message} {};
-    virtual ~DecodingError() noexcept = default;
-    const char* what() const noexcept override { return message_.c_str(); }
-    int err() const noexcept { return err_; }
+    [[maybe_unused]] explicit DecodingError(DecodingResult err, std::string  message)
+        : err_{magic_enum::enum_integer<DecodingResult>(err)}, message_{std::move(message)} {};
+    ~DecodingError() noexcept override = default;
+    [[nodiscard]] const char* what() const noexcept override { return message_.c_str(); }
+    [[nodiscard]] int err() const noexcept { return err_; }
 
   protected:
     int err_;
     std::string message_;
 };
 
-inline void err_handler(DecodingResult err) {
+inline void success_or_throw(DecodingResult err) {
     if (err != DecodingResult::kOk) {
         throw DecodingError(err);
     }

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -140,7 +140,7 @@ std::optional<BlockHeader> read_header(mdbx::txn& txn, uint64_t block_number, co
 
     BlockHeader header;
     ByteView data_view{from_slice(data.value)};
-    rlp::err_handler(rlp::decode(data_view, header));
+    rlp::success_or_throw(rlp::decode(data_view, header));
     return header;
 }
 
@@ -154,7 +154,7 @@ std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, uint64_t bloc
     }
     intx::uint256 td{0};
     ByteView data_view{from_slice(data.value)};
-    rlp::err_handler(rlp::decode(data_view, td));
+    rlp::success_or_throw(rlp::decode(data_view, td));
     return td;
 }
 
@@ -182,7 +182,7 @@ std::vector<Transaction> read_transactions(mdbx::cursor& txn_table, uint64_t bas
          data = txn_table.to_next(/*throw_notfound = */ false), ++i) {
         ByteView data_view{from_slice(data.value)};
         Transaction eth_txn;
-        rlp::err_handler(rlp::decode(data_view, eth_txn));
+        rlp::success_or_throw(rlp::decode(data_view, eth_txn));
         v.push_back(eth_txn);
     }
 
@@ -211,7 +211,7 @@ std::optional<BlockWithHash> read_block(mdbx::txn& txn, uint64_t block_number, b
     }
 
     ByteView data_view(from_slice(data.value));
-    rlp::err_handler(rlp::decode(data_view, bh.block.header));
+    rlp::success_or_throw(rlp::decode(data_view, bh.block.header));
 
     // Read body
     std::optional<BlockBody> body{read_body(txn, block_number, bh.hash.bytes, read_senders)};
@@ -339,7 +339,7 @@ std::optional<Account> read_account(mdbx::txn& txn, const evmc::address& address
     }
 
     auto [acc, err]{decode_account_from_storage(encoded.value())};
-    rlp::err_handler(err);
+    rlp::success_or_throw(err);
 
     if (acc.incarnation > 0 && acc.code_hash == kEmptyHash) {
         // restore code hash

--- a/node/silkworm/db/util.cpp
+++ b/node/silkworm/db/util.cpp
@@ -130,16 +130,16 @@ namespace detail {
 
     BlockBodyForStorage decode_stored_block_body(ByteView& from) {
         auto [header, err]{rlp::decode_header(from)};
-        rlp::err_handler(err);
+        rlp::success_or_throw(err);
         if (!header.list) {
-            rlp::err_handler(rlp::DecodingResult::kUnexpectedString);
+            rlp::success_or_throw(rlp::DecodingResult::kUnexpectedString);
         }
         uint64_t leftover{from.length() - header.payload_length};
 
         BlockBodyForStorage to;
-        rlp::err_handler(rlp::decode(from, to.base_txn_id));
-        rlp::err_handler(rlp::decode(from, to.txn_count));
-        rlp::err_handler(rlp::decode_vector(from, to.ommers));
+        rlp::success_or_throw(rlp::decode(from, to.base_txn_id));
+        rlp::success_or_throw(rlp::decode(from, to.txn_count));
+        rlp::success_or_throw(rlp::decode_vector(from, to.ommers));
 
         if (from.length() != leftover) {
             throw rlp::DecodingError{rlp::DecodingResult::kListLengthMismatch};

--- a/node/silkworm/stagedsync/prune_execution_test.cpp
+++ b/node/silkworm/stagedsync/prune_execution_test.cpp
@@ -135,8 +135,7 @@ TEST_CASE("Prune Execution") {
     SECTION("With prune function") {
         buffer.write_to_db();
         // We prune from block 2, thus we delete block 1
-        REQUIRE_NOTHROW(
-            stagedsync::check_stagedsync_error(stagedsync::prune_execution(txn, context.dir().etl().path(), 2)));
+        REQUIRE_NOTHROW(stagedsync::success_or_throw(stagedsync::prune_execution(txn, context.dir().etl().path(), 2)));
 
         auto account_changeset_table{db::open_cursor(*txn, db::table::kAccountChangeSet)};
         auto storage_changeset_table{db::open_cursor(*txn, db::table::kStorageChangeSet)};

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -157,7 +157,7 @@ static void revert_state(ByteView key, ByteView value, mdbx::cursor& plain_state
     if (key.size() == kAddressLength) {
         if (!value.empty()) {
             auto [account, err1]{decode_account_from_storage(value)};
-            rlp::err_handler(err1);
+            rlp::success_or_throw(err1);
             if (account.incarnation > 0 && account.code_hash == kEmptyHash) {
                 Bytes code_hash_key(kAddressLength + db::kIncarnationLength, '\0');
                 std::memcpy(&code_hash_key[0], &key[0], kAddressLength);
@@ -169,7 +169,7 @@ static void revert_state(ByteView key, ByteView value, mdbx::cursor& plain_state
             auto state_account_encoded{plain_state_table.find(db::to_slice(key), /*throw_notfound=*/false)};
             if (state_account_encoded) {
                 auto [state_incarnation, err2]{extract_incarnation(db::from_slice(state_account_encoded.value))};
-                rlp::err_handler(err2);
+                rlp::success_or_throw(err2);
                 // cleanup each code incarnation
                 for (uint64_t i = state_incarnation; i > account.incarnation && i > 0; --i) {
                     Bytes key_hash(kAddressLength + 8, '\0');

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -216,7 +216,7 @@ void hashstate_promote(mdbx::txn& txn, HashstateOperation operation) {
                 continue;
             }
             auto [incarnation, err]{extract_incarnation(db::from_slice(encoded_account.value))};
-            rlp::err_handler(err);
+            rlp::success_or_throw(err);
             if (incarnation == 0) {
                 changeset_data = changeset_table.to_next(/*throw_notfound=*/false);
                 continue;
@@ -301,7 +301,7 @@ static void hashstate_unwind(mdbx::txn& txn, BlockNum unwind_to, HashstateOperat
                     return true;
                 }
                 auto [acc, err]{decode_account_from_storage(db_value)};
-                rlp::err_handler(err);
+                rlp::success_or_throw(err);
 
                 if (acc.incarnation <= 0 || acc.code_hash != kEmptyHash) {
                     if (target_table.seek(new_key)) {
@@ -356,7 +356,7 @@ static void hashstate_unwind(mdbx::txn& txn, BlockNum unwind_to, HashstateOperat
                     return true;
                 }
                 auto [incarnation, err]{extract_incarnation(db_value)};
-                rlp::err_handler(err);
+                rlp::success_or_throw(err);
                 if (incarnation == 0) {
                     return true;
                 }

--- a/node/silkworm/stagedsync/stage_senders_test.cpp
+++ b/node/silkworm/stagedsync/stage_senders_test.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Stage Senders") {
     canonical_table.upsert(db::to_slice(db::block_key(3)), db::to_slice(hash_2));
     db::stages::write_stage_progress(*txn, db::stages::kBlockBodiesKey, 3);
 
-    stagedsync::check_stagedsync_error(stagedsync::stage_senders(txn, context.dir().etl().path()));
+    stagedsync::success_or_throw(stagedsync::stage_senders(txn, context.dir().etl().path()));
 
     auto sender_table{db::open_cursor(*txn, db::table::kSenders)};
     auto got_sender_0{db::from_slice(sender_table.lower_bound(db::to_slice(db::block_key(1))).value)};
@@ -163,8 +163,8 @@ TEST_CASE("Unwind Senders") {
     canonical_table.upsert(db::to_slice(db::block_key(3)), db::to_slice(hash_2));
     db::stages::write_stage_progress(*txn, db::stages::kBlockBodiesKey, 3);
 
-    stagedsync::check_stagedsync_error(stagedsync::stage_senders(txn, context.dir().path()));
-    stagedsync::check_stagedsync_error(stagedsync::unwind_senders(txn, context.dir().path(), 1));
+    stagedsync::success_or_throw(stagedsync::stage_senders(txn, context.dir().etl().path()));
+    stagedsync::success_or_throw(stagedsync::unwind_senders(txn, context.dir().etl().path(), 1));
 
     auto sender_table{db::open_cursor(*txn, db::table::kSenders)};
     auto got_sender_0{db::from_slice(sender_table.lower_bound(db::to_slice(db::block_key(1))).value)};
@@ -232,9 +232,9 @@ TEST_CASE("Prune Senders") {
     canonical_table.upsert(db::to_slice(db::block_key(3)), db::to_slice(hash_2));
     db::stages::write_stage_progress(*txn, db::stages::kBlockBodiesKey, 3);
 
-    stagedsync::check_stagedsync_error(stagedsync::stage_senders(txn, context.dir().path()));
+    stagedsync::success_or_throw(stagedsync::stage_senders(txn, context.dir().etl().path()));
     // We prune from Block 2, thus deleting block 1
-    stagedsync::check_stagedsync_error(stagedsync::prune_senders(txn, context.dir().path(), 2));
+    stagedsync::success_or_throw(stagedsync::prune_senders(txn, context.dir().etl().path(), 2));
 
     auto sender_table{db::open_cursor(*txn, db::table::kSenders)};
     auto got_sender_1{db::from_slice(sender_table.lower_bound(db::to_slice(db::block_key(2))).value)};

--- a/node/silkworm/stagedsync/unwind_execution_test.cpp
+++ b/node/silkworm/stagedsync/unwind_execution_test.cpp
@@ -127,8 +127,7 @@ TEST_CASE("Unwind Execution") {
     // ---------------------------------------
     // Unwind second block and checks if state is first block
     // ---------------------------------------
-    REQUIRE_NOTHROW(
-        stagedsync::check_stagedsync_error(stagedsync::unwind_execution(txn, context.dir().etl().path(), 1)));
+    REQUIRE_NOTHROW(stagedsync::success_or_throw(stagedsync::unwind_execution(txn, context.dir().etl().path(), 1)));
 
     db::Buffer buffer2{*txn, 0};
 

--- a/node/silkworm/stagedsync/util.cpp
+++ b/node/silkworm/stagedsync/util.cpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::stagedsync {
 
-void check_stagedsync_error(StageResult code) {
+void success_or_throw(StageResult code) {
     if (code != StageResult::kSuccess) {
         std::string error{magic_enum::enum_name<StageResult>(code)};
         throw std::runtime_error(error);

--- a/node/silkworm/stagedsync/util.hpp
+++ b/node/silkworm/stagedsync/util.hpp
@@ -47,7 +47,7 @@ enum class [[nodiscard]] StageResult {
 };
 // clang-format on
 
-void check_stagedsync_error(StageResult code);
+void success_or_throw(StageResult code);
 
 }  // namespace silkworm::stagedsync
 

--- a/node/silkworm/trie/intermediate_hashes.cpp
+++ b/node/silkworm/trie/intermediate_hashes.cpp
@@ -244,7 +244,7 @@ evmc::bytes32 DbTrieLoader::calculate_root(const PrefixSet& changed) {
                 break;
             }
             const auto [account, err]{decode_account_from_storage(db::from_slice(acc.value))};
-            rlp::err_handler(err);
+            rlp::success_or_throw(err);
 
             evmc::bytes32 storage_root{kEmptyRoot};
 


### PR DESCRIPTION
Borrowed from MDBX err handler

- rlp::err_handler -> rlp::success_or_throw
- stagedsync::check_stagedsync_error -> success_or_throw