### PR TITLE
Signals - Don't inline initialization of static memeber

### DIFF
--- a/node/silkworm/common/signal_handler.cpp
+++ b/node/silkworm/common/signal_handler.cpp
@@ -100,6 +100,9 @@ inline constexpr int kHandleableCodes[] {
         SIGTERM  // Termination request (kill/killall default)
 };
 
+std::atomic_uint32_t SignalHandler::sig_count_{0};
+std::atomic_bool SignalHandler::signalled_{false};
+
 void SignalHandler::init() {
     for (const int sig_code : kHandleableCodes) {
         signal(sig_code, &SignalHandler::handle);

--- a/node/silkworm/common/signal_handler.hpp
+++ b/node/silkworm/common/signal_handler.hpp
@@ -32,8 +32,8 @@ class SignalHandler {
     static void reset();                                          // Reset to un-signalled (see tests coverage)
 
   private:
-    inline static std::atomic_uint32_t sig_count_{0};
-    inline static std::atomic_bool signalled_{false};
+    static std::atomic_uint32_t sig_count_;
+    static std::atomic_bool signalled_;
 };
 
 }  // namespace silkworm


### PR DESCRIPTION
The inline initialization of static members causes warnings like 

```
LINK : warning C4744: 'static struct std::atomic<bool> silkworm::SignalHandler::signalled_' has different type in 'd:\github\silkworm\node\silkworm\stagedsync\stage_senders.cpp' and 'd:\github\silkworm\cmd\toolbox.cpp': '__declspec(align(1)) struct (1 bytes)' and 'struct (1 bytes)' [C:\Users\Andrea\CMakeBuilds\silkworm\Debug\cmd\toolbox.vcxproj]
```

Revert to initialization in own compile unit