### PR TITLE
SIGSTOP & SIGKILL cannot be caught

### DIFF
--- a/node/silkworm/common/signal_handler.cpp
+++ b/node/silkworm/common/signal_handler.cpp
@@ -93,8 +93,6 @@ inline constexpr int kHandleableCodes[] {
 #if defined(__linux__) || defined(__APPLE__)
         SIGQUIT,  // CTRL+\ (like CTRL+C but also generates a coredump)
         SIGTSTP,  // CTRL+Z to interrupt a process
-        SIGSTOP,  // interrupt a process (not ignoreable)
-        SIGKILL,  // kill (not catchable nor ignorable)
 #endif
         SIGINT,  // Keyboard CTRL+C
         SIGTERM  // Termination request (kill/killall default)


### PR DESCRIPTION
It's not possible to handle SIGSTOP & SIGKILL manually. From [macOS man](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/signal.3.html): "ERRORS: ... An attempt is made to ignore or supply a handler for SIGKILL or SIGSTOP.". And per [Linux man](https://man7.org/linux/man-pages/man2/signal.2.html): "The signals SIGKILL and SIGSTOP cannot be caught or ignored."