### PR TITLE
Remove code duplication between rlp::decode(uint64_t) & decode(uint256)

### DIFF
--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -28,10 +28,10 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/chain/difficulty.hpp>
+#include <silkworm/common/as_range.hpp>
 #include <silkworm/common/cast.hpp>
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/test_util.hpp>
-#include <silkworm/common/as_range.hpp>
 #include <silkworm/consensus/blockchain.hpp>
 #include <silkworm/state/in_memory_state.hpp>
 
@@ -279,10 +279,10 @@ void init_pre_state(const nlohmann::json& pre, State& state) {
 
         Account account;
         const Bytes balance_str{from_hex(j["balance"].get<std::string>()).value()};
-        const auto balance{endian::from_big_compact_u256(balance_str, /*allow_leading_zeros=*/true)};
+        const auto balance{endian::from_big_compact<intx::uint256>(balance_str, /*allow_leading_zeros=*/true)};
         account.balance = *balance;
         const Bytes nonce_str{from_hex(j["nonce"].get<std::string>()).value()};
-        const auto nonce{endian::from_big_compact_u64(nonce_str, /*allow_leading_zeros=*/true)};
+        const auto nonce{endian::from_big_compact<uint64_t>(nonce_str, /*allow_leading_zeros=*/true)};
         account.nonce = *nonce;
 
         const Bytes code{from_hex(j["code"].get<std::string>()).value()};
@@ -363,7 +363,7 @@ bool post_check(const InMemoryState& state, const nlohmann::json& expected) {
         }
 
         const Bytes balance_str{from_hex(j["balance"].get<std::string>()).value()};
-        const auto expected_balance{endian::from_big_compact_u256(balance_str, /*allow_leading_zeros=*/true)};
+        const auto expected_balance{endian::from_big_compact<intx::uint256>(balance_str, /*allow_leading_zeros=*/true)};
         if (account->balance != expected_balance) {
             std::cout << "Balance mismatch for " << entry.key() << ":\n"
                       << to_string(account->balance, 16) << " != " << j["balance"] << std::endl;
@@ -371,7 +371,7 @@ bool post_check(const InMemoryState& state, const nlohmann::json& expected) {
         }
 
         const Bytes nonce_str{from_hex(j["nonce"].get<std::string>()).value()};
-        const auto expected_nonce{endian::from_big_compact_u64(nonce_str, /*allow_leading_zeros=*/true)};
+        const auto expected_nonce{endian::from_big_compact<uint64_t>(nonce_str, /*allow_leading_zeros=*/true)};
         if (account->nonce != expected_nonce) {
             std::cout << "Nonce mismatch for " << entry.key() << ":\n"
                       << account->nonce << " != " << *expected_nonce << std::endl;
@@ -634,7 +634,8 @@ Status difficulty_test(const nlohmann::json& j, const std::optional<ChainConfig>
 }
 
 bool exclude_test(const fs::path& p, const fs::path& root_dir) {
-    return as_range::any_of(kExcludedTests, [&p, &root_dir](const std::filesystem::path& e) -> bool { return root_dir / e == p; });
+    return as_range::any_of(kExcludedTests,
+                            [&p, &root_dir](const std::filesystem::path& e) -> bool { return root_dir / e == p; });
 }
 
 int main(int argc, char* argv[]) {

--- a/core/silkworm/common/endian.cpp
+++ b/core/silkworm/common/endian.cpp
@@ -38,38 +38,4 @@ Bytes to_big_compact(const intx::uint256& value) {
     return Bytes{zeroless_view(full_be)};
 }
 
-template <typename T>
-static std::optional<T> from_big_compact(const ByteView& data, bool allow_leading_zeros) {
-    if (data.length() > sizeof(T)) {
-        return std::nullopt;
-    }
-
-    T x{0};
-
-    if (data.empty()) {
-        return x;
-    }
-
-    if (data[0] == 0 && !allow_leading_zeros) {
-        return std::nullopt;
-    }
-
-    auto* ptr{reinterpret_cast<uint8_t*>(&x)};
-    std::memcpy(ptr + (sizeof(T) - data.length()), &data[0], data.length());
-
-#if SILKWORM_BYTE_ORDER == SILKWORM_LITTLE_ENDIAN
-    x = intx::bswap(x);
-#endif
-
-    return x;
-}
-
-std::optional<uint64_t> from_big_compact_u64(const ByteView& data, bool allow_leading_zeros) {
-    return from_big_compact<uint64_t>(data, allow_leading_zeros);
-}
-
-std::optional<intx::uint256> from_big_compact_u256(const ByteView& data, bool allow_leading_zeros) {
-    return from_big_compact<intx::uint256>(data, allow_leading_zeros);
-}
-
 }  // namespace silkworm::endian

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -72,26 +72,28 @@ as compiler intrinsics to swap bytes in 16-bit, 32-bit, and 64-bit integers resp
 namespace silkworm::endian {
 
 #if SILKWORM_BYTE_ORDER == SILKWORM_LITTLE_ENDIAN
-struct le {
-    static inline uint16_t uint16(uint16_t value) noexcept { return value; }
-    static inline uint32_t uint32(uint32_t value) noexcept { return value; }
-    static inline uint64_t uint64(uint64_t value) noexcept { return value; }
+struct LE {
+    static inline uint16_t load(uint16_t value) noexcept { return value; }
+    static inline uint32_t load(uint32_t value) noexcept { return value; }
+    static inline uint64_t load(uint64_t value) noexcept { return value; }
+    static inline intx::uint256 load(const intx::uint256& value) noexcept { return value; }
 };
-struct be {
-    static inline uint16_t uint16(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
-    static inline uint32_t uint32(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
-    static inline uint64_t uint64(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+struct BE {
+    static inline uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
+    static inline uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
+    static inline uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+    static inline intx::uint256 load(const intx::uint256& value) noexcept { return intx::bswap(value); }
 };
 #elif SILKWORM_BYTE_ORDER == SILKWORM_BIG_ENDIAN
-struct le {
-    static inline uint16_t uint16(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
-    static inline uint32_t uint32(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
-    static inline uint64_t uint64(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+struct LE {
+    static inline uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
+    static inline uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
+    static inline uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
 };
-struct be {
-    static inline uint16_t uint16(uint16_t value) noexcept { return value; }
-    static inline uint32_t uint32(uint32_t value) noexcept { return value; }
-    static inline uint64_t uint64(uint64_t value) noexcept { return value; }
+struct BE {
+    static inline uint16_t load(uint16_t value) noexcept { return value; }
+    static inline uint32_t load(uint32_t value) noexcept { return value; }
+    static inline uint64_t load(uint64_t value) noexcept { return value; }
 };
 #else
 #error "byte order not supported"
@@ -101,59 +103,59 @@ struct be {
 inline uint16_t load_big_u16(const uint8_t* bytes) noexcept {
     uint16_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return be::uint16(x);
+    return BE::load(x);
 }
 
 // Similar to boost::endian::load_big_u32
 inline uint32_t load_big_u32(const uint8_t* bytes) noexcept {
     uint32_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return be::uint32(x);
+    return BE::load(x);
 }
 
 // Similar to boost::endian::load_big_u64
 inline uint64_t load_big_u64(const uint8_t* bytes) noexcept {
     uint64_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return be::uint64(x);
+    return BE::load(x);
 }
 
 // Similar to boost::endian::load_little_u16
 inline uint16_t load_little_u16(const uint8_t* bytes) noexcept {
     uint16_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return le::uint16(x);
+    return LE::load(x);
 }
 
 // Similar to boost::endian::load_little_u32
 inline uint32_t load_little_u32(const uint8_t* bytes) noexcept {
     uint32_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return le::uint32(x);
+    return LE::load(x);
 }
 
 // Similar to boost::endian::load_little_u64
 inline uint64_t load_little_u64(const uint8_t* bytes) noexcept {
     uint64_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return le::uint64(x);
+    return LE::load(x);
 }
 
 // Similar to boost::endian::store_big_u16
 inline void store_big_u16(uint8_t* bytes, const uint16_t value) {
-    uint16_t x{be::uint16(value)};
+    uint16_t x{BE::load(value)};
     std::memcpy(bytes, &x, sizeof(x));
 }
 
 // Similar to boost::endian::store_big_u32
 inline void store_big_u32(uint8_t* bytes, const uint32_t value) {
-    uint32_t x{be::uint32(value)};
+    uint32_t x{BE::load(value)};
     std::memcpy(bytes, &x, sizeof(x));
 }
 
 // Similar to boost::endian::store_big_u64
 inline void store_big_u64(uint8_t* bytes, const uint64_t value) {
-    uint64_t x{be::uint64(value)};
+    uint64_t x{BE::load(value)};
     std::memcpy(bytes, &x, sizeof(x));
 }
 
@@ -195,11 +197,7 @@ static std::optional<UnsignedInteger> from_big_compact(ByteView data, bool allow
     auto* ptr{reinterpret_cast<uint8_t*>(&x)};
     std::memcpy(ptr + (sizeof(UnsignedInteger) - data.length()), &data[0], data.length());
 
-#if SILKWORM_BYTE_ORDER == SILKWORM_LITTLE_ENDIAN
-    x = intx::bswap(x);
-#endif
-
-    return x;
+    return BE::load(x);
 }
 
 }  // namespace silkworm::endian

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -72,36 +72,37 @@ as compiler intrinsics to swap bytes in 16-bit, 32-bit, and 64-bit integers resp
 namespace silkworm::endian {
 
 #if SILKWORM_BYTE_ORDER == SILKWORM_LITTLE_ENDIAN
-struct LE {
+namespace le {
     template <class UnsignedInteger>
-    static constexpr UnsignedInteger load(UnsignedInteger value) noexcept {
+    static inline UnsignedInteger load(UnsignedInteger value) noexcept {
         return value;
     }
-};
-struct BE {
-    static constexpr uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
-    static constexpr uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
-    static constexpr uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+}  // namespace le
+namespace be {
+    static inline uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
+    static inline uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
+    static inline uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
 
     template <unsigned N>
-    static constexpr intx::uint<N> load(const intx::uint<N>& value) noexcept {
+    static inline intx::uint<N> load(const intx::uint<N>& value) noexcept {
         return intx::bswap(value);
     }
-};
-#elif SILKWORM_BYTE_ORDER == SILKWORM_BIG_ENDIAN
-struct LE {
-    static constexpr uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
-    static constexpr uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
-    static constexpr uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+}  // namespace be
 
+#elif SILKWORM_BYTE_ORDER == SILKWORM_BIG_ENDIAN
+namespace le {
+    static inline uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
+    static inline uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
+    static inline uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
     // intx::uint not defined here since its words are little-endian.
     // In any case, Silkworm is currently untested on big-endian plaforms.
-};
-struct BE {
-    static constexpr uint16_t load(uint16_t value) noexcept { return value; }
-    static constexpr uint32_t load(uint32_t value) noexcept { return value; }
-    static constexpr uint64_t load(uint64_t value) noexcept { return value; }
-};
+}  // namespace le
+namespace be {
+    static inline uint16_t load(uint16_t value) noexcept { return value; }
+    static inline uint32_t load(uint32_t value) noexcept { return value; }
+    static inline uint64_t load(uint64_t value) noexcept { return value; }
+}  // namespace be
+
 #else
 #error "byte order not supported"
 #endif
@@ -110,59 +111,59 @@ struct BE {
 inline uint16_t load_big_u16(const uint8_t* bytes) noexcept {
     uint16_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return BE::load(x);
+    return be::load(x);
 }
 
 // Similar to boost::endian::load_big_u32
 inline uint32_t load_big_u32(const uint8_t* bytes) noexcept {
     uint32_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return BE::load(x);
+    return be::load(x);
 }
 
 // Similar to boost::endian::load_big_u64
 inline uint64_t load_big_u64(const uint8_t* bytes) noexcept {
     uint64_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return BE::load(x);
+    return be::load(x);
 }
 
 // Similar to boost::endian::load_little_u16
 inline uint16_t load_little_u16(const uint8_t* bytes) noexcept {
     uint16_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return LE::load(x);
+    return le::load(x);
 }
 
 // Similar to boost::endian::load_little_u32
 inline uint32_t load_little_u32(const uint8_t* bytes) noexcept {
     uint32_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return LE::load(x);
+    return le::load(x);
 }
 
 // Similar to boost::endian::load_little_u64
 inline uint64_t load_little_u64(const uint8_t* bytes) noexcept {
     uint64_t x;
     std::memcpy(&x, bytes, sizeof(x));
-    return LE::load(x);
+    return le::load(x);
 }
 
 // Similar to boost::endian::store_big_u16
 inline void store_big_u16(uint8_t* bytes, const uint16_t value) {
-    uint16_t x{BE::load(value)};
+    uint16_t x{be::load(value)};
     std::memcpy(bytes, &x, sizeof(x));
 }
 
 // Similar to boost::endian::store_big_u32
 inline void store_big_u32(uint8_t* bytes, const uint32_t value) {
-    uint32_t x{BE::load(value)};
+    uint32_t x{be::load(value)};
     std::memcpy(bytes, &x, sizeof(x));
 }
 
 // Similar to boost::endian::store_big_u64
 inline void store_big_u64(uint8_t* bytes, const uint64_t value) {
-    uint64_t x{BE::load(value)};
+    uint64_t x{be::load(value)};
     std::memcpy(bytes, &x, sizeof(x));
 }
 
@@ -204,7 +205,7 @@ static std::optional<UnsignedInteger> from_big_compact(ByteView data, bool allow
     auto* ptr{reinterpret_cast<uint8_t*>(&x)};
     std::memcpy(ptr + (sizeof(UnsignedInteger) - data.length()), &data[0], data.length());
 
-    return BE::load(x);
+    return be::load(x);
 }
 
 }  // namespace silkworm::endian

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -73,27 +73,34 @@ namespace silkworm::endian {
 
 #if SILKWORM_BYTE_ORDER == SILKWORM_LITTLE_ENDIAN
 struct LE {
-    static inline uint16_t load(uint16_t value) noexcept { return value; }
-    static inline uint32_t load(uint32_t value) noexcept { return value; }
-    static inline uint64_t load(uint64_t value) noexcept { return value; }
-    static inline intx::uint256 load(const intx::uint256& value) noexcept { return value; }
+    template <class UnsignedInteger>
+    static constexpr UnsignedInteger load(UnsignedInteger value) noexcept {
+        return value;
+    }
 };
 struct BE {
-    static inline uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
-    static inline uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
-    static inline uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
-    static inline intx::uint256 load(const intx::uint256& value) noexcept { return intx::bswap(value); }
+    static constexpr uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
+    static constexpr uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
+    static constexpr uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+
+    template <unsigned N>
+    static constexpr intx::uint<N> load(const intx::uint<N>& value) noexcept {
+        return intx::bswap(value);
+    }
 };
 #elif SILKWORM_BYTE_ORDER == SILKWORM_BIG_ENDIAN
 struct LE {
-    static inline uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
-    static inline uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
-    static inline uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+    static constexpr uint16_t load(uint16_t value) noexcept { return SILKWORM_BSWAP16(value); }
+    static constexpr uint32_t load(uint32_t value) noexcept { return SILKWORM_BSWAP32(value); }
+    static constexpr uint64_t load(uint64_t value) noexcept { return SILKWORM_BSWAP64(value); }
+
+    // intx::uint not defined here since its words are little-endian.
+    // In any case, Silkworm is currently untested on big-endian plaforms.
 };
 struct BE {
-    static inline uint16_t load(uint16_t value) noexcept { return value; }
-    static inline uint32_t load(uint32_t value) noexcept { return value; }
-    static inline uint64_t load(uint64_t value) noexcept { return value; }
+    static constexpr uint16_t load(uint16_t value) noexcept { return value; }
+    static constexpr uint32_t load(uint32_t value) noexcept { return value; }
+    static constexpr uint64_t load(uint64_t value) noexcept { return value; }
 };
 #else
 #error "byte order not supported"

--- a/core/silkworm/common/endian_test.cpp
+++ b/core/silkworm/common/endian_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Block as key and compact form") {
 #else
         CHECK(block_number_from_key == block_number);
 #endif
-        CHECK(endian::be::uint64(block_number_from_key) == block_number);
+        CHECK(endian::BE::load(block_number_from_key) == block_number);
     }
 
     SECTION("Block number as compact") {

--- a/core/silkworm/common/endian_test.cpp
+++ b/core/silkworm/common/endian_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Block as key and compact form") {
 #else
         CHECK(block_number_from_key == block_number);
 #endif
-        CHECK(endian::BE::load(block_number_from_key) == block_number);
+        CHECK(be::load(block_number_from_key) == block_number);
     }
 
     SECTION("Block number as compact") {

--- a/core/silkworm/common/endian_test.cpp
+++ b/core/silkworm/common/endian_test.cpp
@@ -139,4 +139,13 @@ TEST_CASE("Block as key and compact form") {
     }
 }
 
+TEST_CASE("from_big_compact with leading zeros") {
+    const Bytes non_compact_be{*from_hex("00AB")};
+    const auto x{from_big_compact<uint32_t>(non_compact_be, /*allow_leading_zeros=*/false)};
+    CHECK(x == std::nullopt);
+    const auto y{from_big_compact<uint32_t>(non_compact_be, /*allow_leading_zeros=*/true)};
+    REQUIRE(y != std::nullopt);
+    CHECK(y == 0xAB);
+}
+
 }  // namespace silkworm::endian

--- a/core/silkworm/common/endian_test.cpp
+++ b/core/silkworm/common/endian_test.cpp
@@ -121,21 +121,21 @@ TEST_CASE("Block as key and compact form") {
         auto block_number_compact_bytes{to_big_compact(block_number)};
         CHECK(to_hex(block_number_compact_bytes) == "5485ffde");
         // Convert back and check
-        auto block_number_from_compact{from_big_compact_u64(block_number_compact_bytes)};
+        auto block_number_from_compact{from_big_compact<uint64_t>(block_number_compact_bytes)};
         CHECK(block_number_from_compact == block_number);
         // Try compact empty bytes
         Bytes empty_bytes{};
-        CHECK(zeroless_view(empty_bytes).empty() == true);
+        CHECK(zeroless_view(empty_bytes).empty());
         // Try compact zeroed bytes
         Bytes zeroed_bytes(2, 0);
-        CHECK(zeroless_view(zeroed_bytes).empty() == true);
+        CHECK(zeroless_view(zeroed_bytes).empty());
         // Compact block == 0
-        CHECK(to_big_compact(0).empty() == true);
+        CHECK(to_big_compact(0).empty());
         // Try retrieve a compacted value from an empty Byte string
-        CHECK(from_big_compact_u64(Bytes()) == 0u);
+        CHECK(from_big_compact<uint64_t>(Bytes()) == 0u);
         // Try retrieve a compacted value from a too large Byte string
         Bytes extra_long_bytes(sizeof(uint64_t) + 1, 0);
-        CHECK(from_big_compact_u64(extra_long_bytes) == std::nullopt);
+        CHECK(from_big_compact<uint64_t>(extra_long_bytes) == std::nullopt);
     }
 }
 

--- a/core/silkworm/types/account.cpp
+++ b/core/silkworm/types/account.cpp
@@ -97,7 +97,7 @@ std::pair<uint64_t, rlp::DecodingResult> extract_incarnation(ByteView encoded) {
     if (field_set & 4) {
         // Incarnation has been found.
         uint8_t len = encoded[pos++];
-        const std::optional<uint64_t> incarnation{endian::from_big_compact_u64(encoded.substr(pos, len))};
+        const std::optional<uint64_t> incarnation{endian::from_big_compact<uint64_t>(encoded.substr(pos, len))};
         if (incarnation == std::nullopt) {
             return {0, rlp::DecodingResult::kOverflow};
         }
@@ -120,7 +120,7 @@ std::pair<Account, rlp::DecodingResult> decode_account_from_storage(ByteView enc
         if (encoded.length() < pos + len) {
             return {a, rlp::DecodingResult::kInputTooShort};
         }
-        const std::optional<uint64_t> nonce{endian::from_big_compact_u64(encoded.substr(pos, len))};
+        const std::optional<uint64_t> nonce{endian::from_big_compact<uint64_t>(encoded.substr(pos, len))};
         if (nonce == std::nullopt) {
             return {a, rlp::DecodingResult::kOverflow};
         }
@@ -143,7 +143,7 @@ std::pair<Account, rlp::DecodingResult> decode_account_from_storage(ByteView enc
         if (encoded.length() < pos + len) {
             return {a, rlp::DecodingResult::kInputTooShort};
         }
-        const std::optional<uint64_t> incarnation{endian::from_big_compact_u64(encoded.substr(pos, len))};
+        const std::optional<uint64_t> incarnation{endian::from_big_compact<uint64_t>(encoded.substr(pos, len))};
         if (incarnation == std::nullopt) {
             return {a, rlp::DecodingResult::kOverflow};
         }

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -18,7 +18,6 @@
 
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/log.hpp>
-#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/etl/collector.hpp>
 
@@ -91,7 +90,7 @@ StageResult stage_tx_lookup(TransactionManager& txn, const std::filesystem::path
     SILKWORM_LOG(LogLevel::Info) << "Entries Collected << " << collector.size() << std::endl;
 
     // Proceed only if we've done something
-    if (collector.size()) {
+    if (!collector.empty()) {
         SILKWORM_LOG(LogLevel::Info) << "Started tx Hashes Loading" << std::endl;
 
         /*
@@ -184,7 +183,7 @@ StageResult prune_tx_lookup(TransactionManager& txn, const std::filesystem::path
     while (lookup_data) {
         // Check current lookup block number
         auto block_number_view{db::from_slice(lookup_data.value)};
-        auto current_block{endian::from_big_compact_u64(block_number_view)};
+        auto current_block{endian::from_big_compact<uint64_t>(block_number_view)};
         // Filter out all of the lookups with invalid block numbers
         if (current_block < prune_from) {
             lookup_table.erase(/*whole_multivalue*/ false);


### PR DESCRIPTION
As a prerequisite, `from_big_compact_u64` & `from_big_compact_u256` are unified into template `from_big_compact`.