### PR TITLE
Update tests to 10.2. EIP-2681

### DIFF
--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -59,11 +59,6 @@ static const std::vector<fs::path> kSlowTests{
 };
 
 static const std::vector<fs::path> kFailingTests{
-    // Nonce >= 2^64 is not supported.
-    // Geth excludes this test as well:
-    // https://github.com/ethereum/go-ethereum/blob/v1.9.25/tests/transaction_test.go#L40
-    kTransactionDir / "ttNonce" / "TransactionWithHighNonce256.json",
-
     // Gas limit >= 2^64 is not supported; see EIP-1985.
     // Geth excludes this test as well:
     // https://github.com/ethereum/go-ethereum/blob/v1.9.25/tests/transaction_test.go#L31

--- a/core/silkworm/common/test_util.hpp
+++ b/core/silkworm/common/test_util.hpp
@@ -27,6 +27,8 @@ inline constexpr ChainConfig kLondonConfig{
     1,  // chain_id
     SealEngineType::kNoProof,
     {0, 0, 0, 0, 0, 0, 0, 0, 0},
+    std::nullopt,  // dao_block
+    0,             // muir_glacier_block
 };
 
 static_assert(kLondonConfig.revision(0) == EVMC_LONDON);

--- a/core/silkworm/consensus/engine.cpp
+++ b/core/silkworm/consensus/engine.cpp
@@ -26,7 +26,7 @@ namespace silkworm::consensus {
 void IConsensusEngine::finalize(IntraBlockState&, const Block&, const evmc_revision&) {}
 
 ValidationResult pre_validate_transaction(const Transaction& txn, uint64_t block_number, const ChainConfig& config,
-                                      const std::optional<intx::uint256>& base_fee_per_gas) {
+                                          const std::optional<intx::uint256>& base_fee_per_gas) {
     const evmc_revision rev{config.revision(block_number)};
 
     if (txn.chain_id.has_value()) {
@@ -66,6 +66,11 @@ ValidationResult pre_validate_transaction(const Transaction& txn, uint64_t block
     const intx::uint128 g0{intrinsic_gas(txn, rev >= EVMC_HOMESTEAD, rev >= EVMC_ISTANBUL)};
     if (txn.gas_limit < g0) {
         return ValidationResult::kIntrinsicGas;
+    }
+
+    // EIP-2681: Limit account nonce to 2^64-1
+    if (txn.nonce >= UINT64_MAX) {
+        return ValidationResult::kNonceTooHigh;
     }
 
     return ValidationResult::kOk;

--- a/core/silkworm/consensus/validation.hpp
+++ b/core/silkworm/consensus/validation.hpp
@@ -43,6 +43,7 @@ enum class [[nodiscard]] ValidationResult{
     kWrongBaseFee,       // see EIP-1559
     kInvalidSeal,        // Nonce or mix_hash (invalid Proof of Work)
     kInvalidMixHash,     // Invalid mix_hash (Clique, EIP-225)
+    kNonceTooHigh,       // Tn ≥ 2^64 - 1 (EIP-2681)
 
     // See [YP] Section 6.2 "Execution", Eq (58)
     kMissingSender,          // S(T) = ∅

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -81,6 +81,12 @@ evmc::result EVM::create(const evmc_message& message) noexcept {
     }
 
     const uint64_t nonce{state_.get_nonce(message.sender)};
+    if (nonce + 1 < nonce) {
+        // EIP-2681: Limit account nonce to 2^64-1
+        // See also https://github.com/ethereum/go-ethereum/blob/v1.10.13/core/vm/evm.go#L426
+        res.status_code = EVMC_ARGUMENT_OUT_OF_RANGE;
+        return res;
+    }
     state_.set_nonce(message.sender, nonce + 1);
 
     evmc::address contract_addr{};


### PR DESCRIPTION
Update consensus tests to [v10.2](https://github.com/ethereum/tests/releases/tag/v10.2). Difficulty tests were refactored in that release.

Implement [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681): Limit account nonce to 2^64-1.