### PR TITLE
Revert "Change sentry peer_id from H512 pubkey to H256 keccak256(pubkey)"

### DIFF
--- a/interfaces/sentry.pb.cc
+++ b/interfaces/sentry.pb.cc
@@ -17,6 +17,7 @@
 extern PROTOBUF_INTERNAL_EXPORT_sentry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_Forks_sentry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_sentry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_OutboundMessageData_sentry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H256_types_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_types_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H512_types_2eproto;
 namespace sentry {
 class OutboundMessageDataDefaultTypeInternal {
  public:
@@ -93,7 +94,7 @@ static void InitDefaultsscc_info_InboundMessage_sentry_2eproto() {
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_InboundMessage_sentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_InboundMessage_sentry_2eproto}, {
-      &scc_info_H256_types_2eproto.base,}};
+      &scc_info_H512_types_2eproto.base,}};
 
 static void InitDefaultsscc_info_MessagesRequest_sentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -133,7 +134,7 @@ static void InitDefaultsscc_info_PeerMinBlockRequest_sentry_2eproto() {
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PeerMinBlockRequest_sentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PeerMinBlockRequest_sentry_2eproto}, {
-      &scc_info_H256_types_2eproto.base,}};
+      &scc_info_H512_types_2eproto.base,}};
 
 static void InitDefaultsscc_info_PenalizePeerRequest_sentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -147,7 +148,7 @@ static void InitDefaultsscc_info_PenalizePeerRequest_sentry_2eproto() {
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PenalizePeerRequest_sentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PenalizePeerRequest_sentry_2eproto}, {
-      &scc_info_H256_types_2eproto.base,}};
+      &scc_info_H512_types_2eproto.base,}};
 
 static void InitDefaultsscc_info_SendMessageByIdRequest_sentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -162,7 +163,7 @@ static void InitDefaultsscc_info_SendMessageByIdRequest_sentry_2eproto() {
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_SendMessageByIdRequest_sentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_SendMessageByIdRequest_sentry_2eproto}, {
       &scc_info_OutboundMessageData_sentry_2eproto.base,
-      &scc_info_H256_types_2eproto.base,}};
+      &scc_info_H512_types_2eproto.base,}};
 
 static void InitDefaultsscc_info_SendMessageByMinBlockRequest_sentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -204,7 +205,7 @@ static void InitDefaultsscc_info_SentPeers_sentry_2eproto() {
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_SentPeers_sentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_SentPeers_sentry_2eproto}, {
-      &scc_info_H256_types_2eproto.base,}};
+      &scc_info_H512_types_2eproto.base,}};
 
 static void InitDefaultsscc_info_SetStatusReply_sentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -364,16 +365,16 @@ const char descriptor_table_protodef_sentry_2eproto[] PROTOBUF_SECTION_VARIABLE(
   "ageData\022\021\n\tmin_block\030\002 \001(\004\"a\n\026SendMessag"
   "eByIdRequest\022)\n\004data\030\001 \001(\0132\033.sentry.Outb"
   "oundMessageData\022\034\n\007peer_id\030\002 \001(\0132\013.types"
-  ".H256\"_\n\037SendMessageToRandomPeersRequest"
+  ".H512\"_\n\037SendMessageToRandomPeersRequest"
   "\022)\n\004data\030\001 \001(\0132\033.sentry.OutboundMessageD"
   "ata\022\021\n\tmax_peers\030\002 \001(\004\"\'\n\tSentPeers\022\032\n\005p"
-  "eers\030\001 \003(\0132\013.types.H256\"Y\n\023PenalizePeerR"
-  "equest\022\034\n\007peer_id\030\001 \001(\0132\013.types.H256\022$\n\007"
+  "eers\030\001 \003(\0132\013.types.H512\"Y\n\023PenalizePeerR"
+  "equest\022\034\n\007peer_id\030\001 \001(\0132\013.types.H512\022$\n\007"
   "penalty\030\002 \001(\0162\023.sentry.PenaltyKind\"F\n\023Pe"
   "erMinBlockRequest\022\034\n\007peer_id\030\001 \001(\0132\013.typ"
-  "es.H256\022\021\n\tmin_block\030\002 \001(\004\"[\n\016InboundMes"
+  "es.H512\022\021\n\tmin_block\030\002 \001(\004\"[\n\016InboundMes"
   "sage\022\035\n\002id\030\001 \001(\0162\021.sentry.MessageId\022\014\n\004d"
-  "ata\030\002 \001(\014\022\034\n\007peer_id\030\003 \001(\0132\013.types.H256\""
+  "ata\030\002 \001(\014\022\034\n\007peer_id\030\003 \001(\0132\013.types.H512\""
   "4\n\005Forks\022\034\n\007genesis\030\001 \001(\0132\013.types.H256\022\r"
   "\n\005forks\030\002 \003(\004\"\234\001\n\nStatusData\022\022\n\nnetwork_"
   "id\030\001 \001(\004\022%\n\020total_difficulty\030\002 \001(\0132\013.typ"
@@ -995,14 +996,14 @@ void SendMessageByMinBlockRequest::InternalSwap(SendMessageByMinBlockRequest* ot
 class SendMessageByIdRequest::_Internal {
  public:
   static const ::sentry::OutboundMessageData& data(const SendMessageByIdRequest* msg);
-  static const ::types::H256& peer_id(const SendMessageByIdRequest* msg);
+  static const ::types::H512& peer_id(const SendMessageByIdRequest* msg);
 };
 
 const ::sentry::OutboundMessageData&
 SendMessageByIdRequest::_Internal::data(const SendMessageByIdRequest* msg) {
   return *msg->data_;
 }
-const ::types::H256&
+const ::types::H512&
 SendMessageByIdRequest::_Internal::peer_id(const SendMessageByIdRequest* msg) {
   return *msg->peer_id_;
 }
@@ -1027,7 +1028,7 @@ SendMessageByIdRequest::SendMessageByIdRequest(const SendMessageByIdRequest& fro
     data_ = nullptr;
   }
   if (from._internal_has_peer_id()) {
-    peer_id_ = new ::types::H256(*from.peer_id_);
+    peer_id_ = new ::types::H512(*from.peer_id_);
   } else {
     peer_id_ = nullptr;
   }
@@ -1100,7 +1101,7 @@ const char* SendMessageByIdRequest::_InternalParse(const char* ptr, ::PROTOBUF_N
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
-      // .types.H256 peer_id = 2;
+      // .types.H512 peer_id = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
           ptr = ctx->ParseMessage(_internal_mutable_peer_id(), ptr);
@@ -1143,7 +1144,7 @@ failure:
         1, _Internal::data(this), target, stream);
   }
 
-  // .types.H256 peer_id = 2;
+  // .types.H512 peer_id = 2;
   if (this->has_peer_id()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
@@ -1174,7 +1175,7 @@ size_t SendMessageByIdRequest::ByteSizeLong() const {
         *data_);
   }
 
-  // .types.H256 peer_id = 2;
+  // .types.H512 peer_id = 2;
   if (this->has_peer_id()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -1216,7 +1217,7 @@ void SendMessageByIdRequest::MergeFrom(const SendMessageByIdRequest& from) {
     _internal_mutable_data()->::sentry::OutboundMessageData::MergeFrom(from._internal_data());
   }
   if (from.has_peer_id()) {
-    _internal_mutable_peer_id()->::types::H256::MergeFrom(from._internal_peer_id());
+    _internal_mutable_peer_id()->::types::H512::MergeFrom(from._internal_peer_id());
   }
 }
 
@@ -1566,7 +1567,7 @@ const char* SentPeers::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     CHK_(ptr);
     switch (tag >> 3) {
-      // repeated .types.H256 peers = 1;
+      // repeated .types.H512 peers = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
           ptr -= 1;
@@ -1606,7 +1607,7 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .types.H256 peers = 1;
+  // repeated .types.H512 peers = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->_internal_peers_size()); i < n; i++) {
     target = stream->EnsureSpace(target);
@@ -1630,7 +1631,7 @@ size_t SentPeers::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // repeated .types.H256 peers = 1;
+  // repeated .types.H512 peers = 1;
   total_size += 1UL * this->_internal_peers_size();
   for (const auto& msg : this->peers_) {
     total_size +=
@@ -1704,10 +1705,10 @@ void SentPeers::InternalSwap(SentPeers* other) {
 
 class PenalizePeerRequest::_Internal {
  public:
-  static const ::types::H256& peer_id(const PenalizePeerRequest* msg);
+  static const ::types::H512& peer_id(const PenalizePeerRequest* msg);
 };
 
-const ::types::H256&
+const ::types::H512&
 PenalizePeerRequest::_Internal::peer_id(const PenalizePeerRequest* msg) {
   return *msg->peer_id_;
 }
@@ -1727,7 +1728,7 @@ PenalizePeerRequest::PenalizePeerRequest(const PenalizePeerRequest& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_peer_id()) {
-    peer_id_ = new ::types::H256(*from.peer_id_);
+    peer_id_ = new ::types::H512(*from.peer_id_);
   } else {
     peer_id_ = nullptr;
   }
@@ -1790,7 +1791,7 @@ const char* PenalizePeerRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAME
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     CHK_(ptr);
     switch (tag >> 3) {
-      // .types.H256 peer_id = 1;
+      // .types.H512 peer_id = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
           ptr = ctx->ParseMessage(_internal_mutable_peer_id(), ptr);
@@ -1833,7 +1834,7 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .types.H256 peer_id = 1;
+  // .types.H512 peer_id = 1;
   if (this->has_peer_id()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
@@ -1864,7 +1865,7 @@ size_t PenalizePeerRequest::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .types.H256 peer_id = 1;
+  // .types.H512 peer_id = 1;
   if (this->has_peer_id()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -1909,7 +1910,7 @@ void PenalizePeerRequest::MergeFrom(const PenalizePeerRequest& from) {
   (void) cached_has_bits;
 
   if (from.has_peer_id()) {
-    _internal_mutable_peer_id()->::types::H256::MergeFrom(from._internal_peer_id());
+    _internal_mutable_peer_id()->::types::H512::MergeFrom(from._internal_peer_id());
   }
   if (from.penalty() != 0) {
     _internal_set_penalty(from._internal_penalty());
@@ -1954,10 +1955,10 @@ void PenalizePeerRequest::InternalSwap(PenalizePeerRequest* other) {
 
 class PeerMinBlockRequest::_Internal {
  public:
-  static const ::types::H256& peer_id(const PeerMinBlockRequest* msg);
+  static const ::types::H512& peer_id(const PeerMinBlockRequest* msg);
 };
 
-const ::types::H256&
+const ::types::H512&
 PeerMinBlockRequest::_Internal::peer_id(const PeerMinBlockRequest* msg) {
   return *msg->peer_id_;
 }
@@ -1977,7 +1978,7 @@ PeerMinBlockRequest::PeerMinBlockRequest(const PeerMinBlockRequest& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_peer_id()) {
-    peer_id_ = new ::types::H256(*from.peer_id_);
+    peer_id_ = new ::types::H512(*from.peer_id_);
   } else {
     peer_id_ = nullptr;
   }
@@ -2040,7 +2041,7 @@ const char* PeerMinBlockRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAME
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     CHK_(ptr);
     switch (tag >> 3) {
-      // .types.H256 peer_id = 1;
+      // .types.H512 peer_id = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
           ptr = ctx->ParseMessage(_internal_mutable_peer_id(), ptr);
@@ -2082,7 +2083,7 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .types.H256 peer_id = 1;
+  // .types.H512 peer_id = 1;
   if (this->has_peer_id()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
@@ -2112,7 +2113,7 @@ size_t PeerMinBlockRequest::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .types.H256 peer_id = 1;
+  // .types.H512 peer_id = 1;
   if (this->has_peer_id()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -2158,7 +2159,7 @@ void PeerMinBlockRequest::MergeFrom(const PeerMinBlockRequest& from) {
   (void) cached_has_bits;
 
   if (from.has_peer_id()) {
-    _internal_mutable_peer_id()->::types::H256::MergeFrom(from._internal_peer_id());
+    _internal_mutable_peer_id()->::types::H512::MergeFrom(from._internal_peer_id());
   }
   if (from.min_block() != 0) {
     _internal_set_min_block(from._internal_min_block());
@@ -2203,10 +2204,10 @@ void PeerMinBlockRequest::InternalSwap(PeerMinBlockRequest* other) {
 
 class InboundMessage::_Internal {
  public:
-  static const ::types::H256& peer_id(const InboundMessage* msg);
+  static const ::types::H512& peer_id(const InboundMessage* msg);
 };
 
-const ::types::H256&
+const ::types::H512&
 InboundMessage::_Internal::peer_id(const InboundMessage* msg) {
   return *msg->peer_id_;
 }
@@ -2231,7 +2232,7 @@ InboundMessage::InboundMessage(const InboundMessage& from)
       GetArena());
   }
   if (from._internal_has_peer_id()) {
-    peer_id_ = new ::types::H256(*from.peer_id_);
+    peer_id_ = new ::types::H512(*from.peer_id_);
   } else {
     peer_id_ = nullptr;
   }
@@ -2313,7 +2314,7 @@ const char* InboundMessage::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
-      // .types.H256 peer_id = 3;
+      // .types.H512 peer_id = 3;
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
           ptr = ctx->ParseMessage(_internal_mutable_peer_id(), ptr);
@@ -2361,7 +2362,7 @@ failure:
         2, this->_internal_data(), target);
   }
 
-  // .types.H256 peer_id = 3;
+  // .types.H512 peer_id = 3;
   if (this->has_peer_id()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
@@ -2392,7 +2393,7 @@ size_t InboundMessage::ByteSizeLong() const {
         this->_internal_data());
   }
 
-  // .types.H256 peer_id = 3;
+  // .types.H512 peer_id = 3;
   if (this->has_peer_id()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -2440,7 +2441,7 @@ void InboundMessage::MergeFrom(const InboundMessage& from) {
     _internal_set_data(from._internal_data());
   }
   if (from.has_peer_id()) {
-    _internal_mutable_peer_id()->::types::H256::MergeFrom(from._internal_peer_id());
+    _internal_mutable_peer_id()->::types::H512::MergeFrom(from._internal_peer_id());
   }
   if (from.id() != 0) {
     _internal_set_id(from._internal_id());

--- a/interfaces/sentry.pb.h
+++ b/interfaces/sentry.pb.h
@@ -658,23 +658,23 @@ class SendMessageByIdRequest PROTOBUF_FINAL :
       ::sentry::OutboundMessageData* data);
   ::sentry::OutboundMessageData* unsafe_arena_release_data();
 
-  // .types.H256 peer_id = 2;
+  // .types.H512 peer_id = 2;
   bool has_peer_id() const;
   private:
   bool _internal_has_peer_id() const;
   public:
   void clear_peer_id();
-  const ::types::H256& peer_id() const;
-  ::types::H256* release_peer_id();
-  ::types::H256* mutable_peer_id();
-  void set_allocated_peer_id(::types::H256* peer_id);
+  const ::types::H512& peer_id() const;
+  ::types::H512* release_peer_id();
+  ::types::H512* mutable_peer_id();
+  void set_allocated_peer_id(::types::H512* peer_id);
   private:
-  const ::types::H256& _internal_peer_id() const;
-  ::types::H256* _internal_mutable_peer_id();
+  const ::types::H512& _internal_peer_id() const;
+  ::types::H512* _internal_mutable_peer_id();
   public:
   void unsafe_arena_set_allocated_peer_id(
-      ::types::H256* peer_id);
-  ::types::H256* unsafe_arena_release_peer_id();
+      ::types::H512* peer_id);
+  ::types::H512* unsafe_arena_release_peer_id();
 
   // @@protoc_insertion_point(class_scope:sentry.SendMessageByIdRequest)
  private:
@@ -684,7 +684,7 @@ class SendMessageByIdRequest PROTOBUF_FINAL :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   ::sentry::OutboundMessageData* data_;
-  ::types::H256* peer_id_;
+  ::types::H512* peer_id_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_sentry_2eproto;
 };
@@ -960,22 +960,22 @@ class SentPeers PROTOBUF_FINAL :
   enum : int {
     kPeersFieldNumber = 1,
   };
-  // repeated .types.H256 peers = 1;
+  // repeated .types.H512 peers = 1;
   int peers_size() const;
   private:
   int _internal_peers_size() const;
   public:
   void clear_peers();
-  ::types::H256* mutable_peers(int index);
-  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >*
+  ::types::H512* mutable_peers(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H512 >*
       mutable_peers();
   private:
-  const ::types::H256& _internal_peers(int index) const;
-  ::types::H256* _internal_add_peers();
+  const ::types::H512& _internal_peers(int index) const;
+  ::types::H512* _internal_add_peers();
   public:
-  const ::types::H256& peers(int index) const;
-  ::types::H256* add_peers();
-  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >&
+  const ::types::H512& peers(int index) const;
+  ::types::H512* add_peers();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H512 >&
       peers() const;
 
   // @@protoc_insertion_point(class_scope:sentry.SentPeers)
@@ -985,7 +985,7 @@ class SentPeers PROTOBUF_FINAL :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 > peers_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H512 > peers_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_sentry_2eproto;
 };
@@ -1106,23 +1106,23 @@ class PenalizePeerRequest PROTOBUF_FINAL :
     kPeerIdFieldNumber = 1,
     kPenaltyFieldNumber = 2,
   };
-  // .types.H256 peer_id = 1;
+  // .types.H512 peer_id = 1;
   bool has_peer_id() const;
   private:
   bool _internal_has_peer_id() const;
   public:
   void clear_peer_id();
-  const ::types::H256& peer_id() const;
-  ::types::H256* release_peer_id();
-  ::types::H256* mutable_peer_id();
-  void set_allocated_peer_id(::types::H256* peer_id);
+  const ::types::H512& peer_id() const;
+  ::types::H512* release_peer_id();
+  ::types::H512* mutable_peer_id();
+  void set_allocated_peer_id(::types::H512* peer_id);
   private:
-  const ::types::H256& _internal_peer_id() const;
-  ::types::H256* _internal_mutable_peer_id();
+  const ::types::H512& _internal_peer_id() const;
+  ::types::H512* _internal_mutable_peer_id();
   public:
   void unsafe_arena_set_allocated_peer_id(
-      ::types::H256* peer_id);
-  ::types::H256* unsafe_arena_release_peer_id();
+      ::types::H512* peer_id);
+  ::types::H512* unsafe_arena_release_peer_id();
 
   // .sentry.PenaltyKind penalty = 2;
   void clear_penalty();
@@ -1140,7 +1140,7 @@ class PenalizePeerRequest PROTOBUF_FINAL :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::types::H256* peer_id_;
+  ::types::H512* peer_id_;
   int penalty_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_sentry_2eproto;
@@ -1262,23 +1262,23 @@ class PeerMinBlockRequest PROTOBUF_FINAL :
     kPeerIdFieldNumber = 1,
     kMinBlockFieldNumber = 2,
   };
-  // .types.H256 peer_id = 1;
+  // .types.H512 peer_id = 1;
   bool has_peer_id() const;
   private:
   bool _internal_has_peer_id() const;
   public:
   void clear_peer_id();
-  const ::types::H256& peer_id() const;
-  ::types::H256* release_peer_id();
-  ::types::H256* mutable_peer_id();
-  void set_allocated_peer_id(::types::H256* peer_id);
+  const ::types::H512& peer_id() const;
+  ::types::H512* release_peer_id();
+  ::types::H512* mutable_peer_id();
+  void set_allocated_peer_id(::types::H512* peer_id);
   private:
-  const ::types::H256& _internal_peer_id() const;
-  ::types::H256* _internal_mutable_peer_id();
+  const ::types::H512& _internal_peer_id() const;
+  ::types::H512* _internal_mutable_peer_id();
   public:
   void unsafe_arena_set_allocated_peer_id(
-      ::types::H256* peer_id);
-  ::types::H256* unsafe_arena_release_peer_id();
+      ::types::H512* peer_id);
+  ::types::H512* unsafe_arena_release_peer_id();
 
   // uint64 min_block = 2;
   void clear_min_block();
@@ -1296,7 +1296,7 @@ class PeerMinBlockRequest PROTOBUF_FINAL :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::types::H256* peer_id_;
+  ::types::H512* peer_id_;
   ::PROTOBUF_NAMESPACE_ID::uint64 min_block_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_sentry_2eproto;
@@ -1435,23 +1435,23 @@ class InboundMessage PROTOBUF_FINAL :
   std::string* _internal_mutable_data();
   public:
 
-  // .types.H256 peer_id = 3;
+  // .types.H512 peer_id = 3;
   bool has_peer_id() const;
   private:
   bool _internal_has_peer_id() const;
   public:
   void clear_peer_id();
-  const ::types::H256& peer_id() const;
-  ::types::H256* release_peer_id();
-  ::types::H256* mutable_peer_id();
-  void set_allocated_peer_id(::types::H256* peer_id);
+  const ::types::H512& peer_id() const;
+  ::types::H512* release_peer_id();
+  ::types::H512* mutable_peer_id();
+  void set_allocated_peer_id(::types::H512* peer_id);
   private:
-  const ::types::H256& _internal_peer_id() const;
-  ::types::H256* _internal_mutable_peer_id();
+  const ::types::H512& _internal_peer_id() const;
+  ::types::H512* _internal_mutable_peer_id();
   public:
   void unsafe_arena_set_allocated_peer_id(
-      ::types::H256* peer_id);
-  ::types::H256* unsafe_arena_release_peer_id();
+      ::types::H512* peer_id);
+  ::types::H512* unsafe_arena_release_peer_id();
 
   // .sentry.MessageId id = 1;
   void clear_id();
@@ -1470,7 +1470,7 @@ class InboundMessage PROTOBUF_FINAL :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr data_;
-  ::types::H256* peer_id_;
+  ::types::H512* peer_id_;
   int id_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_sentry_2eproto;
@@ -2419,24 +2419,24 @@ inline void SendMessageByIdRequest::set_allocated_data(::sentry::OutboundMessage
   // @@protoc_insertion_point(field_set_allocated:sentry.SendMessageByIdRequest.data)
 }
 
-// .types.H256 peer_id = 2;
+// .types.H512 peer_id = 2;
 inline bool SendMessageByIdRequest::_internal_has_peer_id() const {
   return this != internal_default_instance() && peer_id_ != nullptr;
 }
 inline bool SendMessageByIdRequest::has_peer_id() const {
   return _internal_has_peer_id();
 }
-inline const ::types::H256& SendMessageByIdRequest::_internal_peer_id() const {
-  const ::types::H256* p = peer_id_;
-  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
-      ::types::_H256_default_instance_);
+inline const ::types::H512& SendMessageByIdRequest::_internal_peer_id() const {
+  const ::types::H512* p = peer_id_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H512&>(
+      ::types::_H512_default_instance_);
 }
-inline const ::types::H256& SendMessageByIdRequest::peer_id() const {
+inline const ::types::H512& SendMessageByIdRequest::peer_id() const {
   // @@protoc_insertion_point(field_get:sentry.SendMessageByIdRequest.peer_id)
   return _internal_peer_id();
 }
 inline void SendMessageByIdRequest::unsafe_arena_set_allocated_peer_id(
-    ::types::H256* peer_id) {
+    ::types::H512* peer_id) {
   if (GetArena() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
   }
@@ -2448,35 +2448,35 @@ inline void SendMessageByIdRequest::unsafe_arena_set_allocated_peer_id(
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.SendMessageByIdRequest.peer_id)
 }
-inline ::types::H256* SendMessageByIdRequest::release_peer_id() {
+inline ::types::H512* SendMessageByIdRequest::release_peer_id() {
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   if (GetArena() != nullptr) {
     temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
   }
   return temp;
 }
-inline ::types::H256* SendMessageByIdRequest::unsafe_arena_release_peer_id() {
+inline ::types::H512* SendMessageByIdRequest::unsafe_arena_release_peer_id() {
   // @@protoc_insertion_point(field_release:sentry.SendMessageByIdRequest.peer_id)
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   return temp;
 }
-inline ::types::H256* SendMessageByIdRequest::_internal_mutable_peer_id() {
+inline ::types::H512* SendMessageByIdRequest::_internal_mutable_peer_id() {
   
   if (peer_id_ == nullptr) {
-    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    auto* p = CreateMaybeMessage<::types::H512>(GetArena());
     peer_id_ = p;
   }
   return peer_id_;
 }
-inline ::types::H256* SendMessageByIdRequest::mutable_peer_id() {
+inline ::types::H512* SendMessageByIdRequest::mutable_peer_id() {
   // @@protoc_insertion_point(field_mutable:sentry.SendMessageByIdRequest.peer_id)
   return _internal_mutable_peer_id();
 }
-inline void SendMessageByIdRequest::set_allocated_peer_id(::types::H256* peer_id) {
+inline void SendMessageByIdRequest::set_allocated_peer_id(::types::H512* peer_id) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
   if (message_arena == nullptr) {
     delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
@@ -2607,37 +2607,37 @@ inline void SendMessageToRandomPeersRequest::set_max_peers(::PROTOBUF_NAMESPACE_
 
 // SentPeers
 
-// repeated .types.H256 peers = 1;
+// repeated .types.H512 peers = 1;
 inline int SentPeers::_internal_peers_size() const {
   return peers_.size();
 }
 inline int SentPeers::peers_size() const {
   return _internal_peers_size();
 }
-inline ::types::H256* SentPeers::mutable_peers(int index) {
+inline ::types::H512* SentPeers::mutable_peers(int index) {
   // @@protoc_insertion_point(field_mutable:sentry.SentPeers.peers)
   return peers_.Mutable(index);
 }
-inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >*
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H512 >*
 SentPeers::mutable_peers() {
   // @@protoc_insertion_point(field_mutable_list:sentry.SentPeers.peers)
   return &peers_;
 }
-inline const ::types::H256& SentPeers::_internal_peers(int index) const {
+inline const ::types::H512& SentPeers::_internal_peers(int index) const {
   return peers_.Get(index);
 }
-inline const ::types::H256& SentPeers::peers(int index) const {
+inline const ::types::H512& SentPeers::peers(int index) const {
   // @@protoc_insertion_point(field_get:sentry.SentPeers.peers)
   return _internal_peers(index);
 }
-inline ::types::H256* SentPeers::_internal_add_peers() {
+inline ::types::H512* SentPeers::_internal_add_peers() {
   return peers_.Add();
 }
-inline ::types::H256* SentPeers::add_peers() {
+inline ::types::H512* SentPeers::add_peers() {
   // @@protoc_insertion_point(field_add:sentry.SentPeers.peers)
   return _internal_add_peers();
 }
-inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >&
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H512 >&
 SentPeers::peers() const {
   // @@protoc_insertion_point(field_list:sentry.SentPeers.peers)
   return peers_;
@@ -2647,24 +2647,24 @@ SentPeers::peers() const {
 
 // PenalizePeerRequest
 
-// .types.H256 peer_id = 1;
+// .types.H512 peer_id = 1;
 inline bool PenalizePeerRequest::_internal_has_peer_id() const {
   return this != internal_default_instance() && peer_id_ != nullptr;
 }
 inline bool PenalizePeerRequest::has_peer_id() const {
   return _internal_has_peer_id();
 }
-inline const ::types::H256& PenalizePeerRequest::_internal_peer_id() const {
-  const ::types::H256* p = peer_id_;
-  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
-      ::types::_H256_default_instance_);
+inline const ::types::H512& PenalizePeerRequest::_internal_peer_id() const {
+  const ::types::H512* p = peer_id_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H512&>(
+      ::types::_H512_default_instance_);
 }
-inline const ::types::H256& PenalizePeerRequest::peer_id() const {
+inline const ::types::H512& PenalizePeerRequest::peer_id() const {
   // @@protoc_insertion_point(field_get:sentry.PenalizePeerRequest.peer_id)
   return _internal_peer_id();
 }
 inline void PenalizePeerRequest::unsafe_arena_set_allocated_peer_id(
-    ::types::H256* peer_id) {
+    ::types::H512* peer_id) {
   if (GetArena() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
   }
@@ -2676,35 +2676,35 @@ inline void PenalizePeerRequest::unsafe_arena_set_allocated_peer_id(
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.PenalizePeerRequest.peer_id)
 }
-inline ::types::H256* PenalizePeerRequest::release_peer_id() {
+inline ::types::H512* PenalizePeerRequest::release_peer_id() {
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   if (GetArena() != nullptr) {
     temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
   }
   return temp;
 }
-inline ::types::H256* PenalizePeerRequest::unsafe_arena_release_peer_id() {
+inline ::types::H512* PenalizePeerRequest::unsafe_arena_release_peer_id() {
   // @@protoc_insertion_point(field_release:sentry.PenalizePeerRequest.peer_id)
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   return temp;
 }
-inline ::types::H256* PenalizePeerRequest::_internal_mutable_peer_id() {
+inline ::types::H512* PenalizePeerRequest::_internal_mutable_peer_id() {
   
   if (peer_id_ == nullptr) {
-    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    auto* p = CreateMaybeMessage<::types::H512>(GetArena());
     peer_id_ = p;
   }
   return peer_id_;
 }
-inline ::types::H256* PenalizePeerRequest::mutable_peer_id() {
+inline ::types::H512* PenalizePeerRequest::mutable_peer_id() {
   // @@protoc_insertion_point(field_mutable:sentry.PenalizePeerRequest.peer_id)
   return _internal_mutable_peer_id();
 }
-inline void PenalizePeerRequest::set_allocated_peer_id(::types::H256* peer_id) {
+inline void PenalizePeerRequest::set_allocated_peer_id(::types::H512* peer_id) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
   if (message_arena == nullptr) {
     delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
@@ -2748,24 +2748,24 @@ inline void PenalizePeerRequest::set_penalty(::sentry::PenaltyKind value) {
 
 // PeerMinBlockRequest
 
-// .types.H256 peer_id = 1;
+// .types.H512 peer_id = 1;
 inline bool PeerMinBlockRequest::_internal_has_peer_id() const {
   return this != internal_default_instance() && peer_id_ != nullptr;
 }
 inline bool PeerMinBlockRequest::has_peer_id() const {
   return _internal_has_peer_id();
 }
-inline const ::types::H256& PeerMinBlockRequest::_internal_peer_id() const {
-  const ::types::H256* p = peer_id_;
-  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
-      ::types::_H256_default_instance_);
+inline const ::types::H512& PeerMinBlockRequest::_internal_peer_id() const {
+  const ::types::H512* p = peer_id_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H512&>(
+      ::types::_H512_default_instance_);
 }
-inline const ::types::H256& PeerMinBlockRequest::peer_id() const {
+inline const ::types::H512& PeerMinBlockRequest::peer_id() const {
   // @@protoc_insertion_point(field_get:sentry.PeerMinBlockRequest.peer_id)
   return _internal_peer_id();
 }
 inline void PeerMinBlockRequest::unsafe_arena_set_allocated_peer_id(
-    ::types::H256* peer_id) {
+    ::types::H512* peer_id) {
   if (GetArena() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
   }
@@ -2777,35 +2777,35 @@ inline void PeerMinBlockRequest::unsafe_arena_set_allocated_peer_id(
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.PeerMinBlockRequest.peer_id)
 }
-inline ::types::H256* PeerMinBlockRequest::release_peer_id() {
+inline ::types::H512* PeerMinBlockRequest::release_peer_id() {
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   if (GetArena() != nullptr) {
     temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
   }
   return temp;
 }
-inline ::types::H256* PeerMinBlockRequest::unsafe_arena_release_peer_id() {
+inline ::types::H512* PeerMinBlockRequest::unsafe_arena_release_peer_id() {
   // @@protoc_insertion_point(field_release:sentry.PeerMinBlockRequest.peer_id)
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   return temp;
 }
-inline ::types::H256* PeerMinBlockRequest::_internal_mutable_peer_id() {
+inline ::types::H512* PeerMinBlockRequest::_internal_mutable_peer_id() {
   
   if (peer_id_ == nullptr) {
-    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    auto* p = CreateMaybeMessage<::types::H512>(GetArena());
     peer_id_ = p;
   }
   return peer_id_;
 }
-inline ::types::H256* PeerMinBlockRequest::mutable_peer_id() {
+inline ::types::H512* PeerMinBlockRequest::mutable_peer_id() {
   // @@protoc_insertion_point(field_mutable:sentry.PeerMinBlockRequest.peer_id)
   return _internal_mutable_peer_id();
 }
-inline void PeerMinBlockRequest::set_allocated_peer_id(::types::H256* peer_id) {
+inline void PeerMinBlockRequest::set_allocated_peer_id(::types::H512* peer_id) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
   if (message_arena == nullptr) {
     delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
@@ -2930,24 +2930,24 @@ inline void InboundMessage::set_allocated_data(std::string* data) {
   // @@protoc_insertion_point(field_set_allocated:sentry.InboundMessage.data)
 }
 
-// .types.H256 peer_id = 3;
+// .types.H512 peer_id = 3;
 inline bool InboundMessage::_internal_has_peer_id() const {
   return this != internal_default_instance() && peer_id_ != nullptr;
 }
 inline bool InboundMessage::has_peer_id() const {
   return _internal_has_peer_id();
 }
-inline const ::types::H256& InboundMessage::_internal_peer_id() const {
-  const ::types::H256* p = peer_id_;
-  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
-      ::types::_H256_default_instance_);
+inline const ::types::H512& InboundMessage::_internal_peer_id() const {
+  const ::types::H512* p = peer_id_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H512&>(
+      ::types::_H512_default_instance_);
 }
-inline const ::types::H256& InboundMessage::peer_id() const {
+inline const ::types::H512& InboundMessage::peer_id() const {
   // @@protoc_insertion_point(field_get:sentry.InboundMessage.peer_id)
   return _internal_peer_id();
 }
 inline void InboundMessage::unsafe_arena_set_allocated_peer_id(
-    ::types::H256* peer_id) {
+    ::types::H512* peer_id) {
   if (GetArena() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
   }
@@ -2959,35 +2959,35 @@ inline void InboundMessage::unsafe_arena_set_allocated_peer_id(
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.InboundMessage.peer_id)
 }
-inline ::types::H256* InboundMessage::release_peer_id() {
+inline ::types::H512* InboundMessage::release_peer_id() {
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   if (GetArena() != nullptr) {
     temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
   }
   return temp;
 }
-inline ::types::H256* InboundMessage::unsafe_arena_release_peer_id() {
+inline ::types::H512* InboundMessage::unsafe_arena_release_peer_id() {
   // @@protoc_insertion_point(field_release:sentry.InboundMessage.peer_id)
   
-  ::types::H256* temp = peer_id_;
+  ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   return temp;
 }
-inline ::types::H256* InboundMessage::_internal_mutable_peer_id() {
+inline ::types::H512* InboundMessage::_internal_mutable_peer_id() {
   
   if (peer_id_ == nullptr) {
-    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    auto* p = CreateMaybeMessage<::types::H512>(GetArena());
     peer_id_ = p;
   }
   return peer_id_;
 }
-inline ::types::H256* InboundMessage::mutable_peer_id() {
+inline ::types::H512* InboundMessage::mutable_peer_id() {
   // @@protoc_insertion_point(field_mutable:sentry.InboundMessage.peer_id)
   return _internal_mutable_peer_id();
 }
-inline void InboundMessage::set_allocated_peer_id(::types::H256* peer_id) {
+inline void InboundMessage::set_allocated_peer_id(::types::H512* peer_id) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
   if (message_arena == nullptr) {
     delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);

--- a/interfaces/sentry.proto
+++ b/interfaces/sentry.proto
@@ -69,7 +69,7 @@ message SendMessageByMinBlockRequest {
 
 message SendMessageByIdRequest {
   OutboundMessageData data = 1;
-  types.H256 peer_id = 2;
+  types.H512 peer_id = 2;
 }
 
 message SendMessageToRandomPeersRequest {
@@ -77,24 +77,24 @@ message SendMessageToRandomPeersRequest {
   uint64 max_peers = 2;
 }
 
-message SentPeers {repeated types.H256 peers = 1;}
+message SentPeers {repeated types.H512 peers = 1;}
 
 enum PenaltyKind {Kick = 0;}
 
 message PenalizePeerRequest {
-  types.H256 peer_id = 1;
+  types.H512 peer_id = 1;
   PenaltyKind penalty = 2;
 }
 
 message PeerMinBlockRequest {
-  types.H256 peer_id = 1;
+  types.H512 peer_id = 1;
   uint64 min_block = 2;
 }
 
 message InboundMessage {
   MessageId id = 1;
   bytes data = 2;
-  types.H256 peer_id = 3;
+  types.H512 peer_id = 3;
 }
 
 message Forks {

--- a/node/silkworm/downloader/internals/chain_elements.hpp
+++ b/node/silkworm/downloader/internals/chain_elements.hpp
@@ -100,7 +100,7 @@ struct Anchor {
     std::vector<std::shared_ptr<Link>> links;  // Links attached immediately to this anchor
     PeerId peerId;
 
-    Anchor(const BlockHeader& header, const PeerId& p) {
+    Anchor(const BlockHeader& header, PeerId p) {
         parentHash = header.parent_hash;
         blockHeight = header.number;
         // timestamp = 0; automatically set to unix epoch by the constructor

--- a/node/silkworm/downloader/internals/chain_integration_test.cpp
+++ b/node/silkworm/downloader/internals/chain_integration_test.cpp
@@ -101,7 +101,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers = {header1, header2, header1b};
-        PeerId peerId{1};
+        PeerId peerId = "1";
         wc.accept_headers(headers, peerId);
 
         // saving headers ready to persists as the header downloader does in the forward() method
@@ -176,7 +176,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers = {header1, header2};
-        PeerId peerId{1};
+        PeerId peerId = "1";
         wc.accept_headers(headers, peerId);
 
         // creating the persisted chain as the header downloader does at the beginning of the forward() method
@@ -215,7 +215,7 @@ TEST_CASE("working/persistent-chain integration test") {
         auto header1b_hash = header1b.hash();
 
         std::vector<BlockHeader> headers_bis = {header1b};
-        peerId = Hash{2};
+        peerId = "2";
         wc.accept_headers(headers_bis, peerId);
 
         // saving headers ready to persist as the header downloader does in the forward() method
@@ -288,7 +288,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers = {header1, header2};
-        PeerId peerId{1};
+        PeerId peerId = "1";
         wc.accept_headers(headers, peerId);
 
         // creating the persisted chain as the header downloader does at the beginning of the forward() method
@@ -327,7 +327,7 @@ TEST_CASE("working/persistent-chain integration test") {
         auto header1b_hash = header1b.hash();
 
         std::vector<BlockHeader> headers_bis = {header1b};
-        peerId = Hash{2};
+        peerId = "2";
         wc.accept_headers(headers_bis, peerId);
 
         // saving headers ready to persist as the header downloader does in the forward() method
@@ -397,7 +397,7 @@ TEST_CASE("working/persistent-chain integration test") {
         auto header1b_hash = header1b.hash();
 
         std::vector<BlockHeader> headers = {header1b};
-        PeerId peerId{1};
+        PeerId peerId = "1";
         wc.accept_headers(headers, peerId);
 
         // creating the persisted chain as the header downloader does at the beginning of the forward() method
@@ -439,7 +439,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers_bis = {header1, header2};
-        peerId = Hash{2};
+        peerId = "2";
         wc.accept_headers(headers_bis, peerId);
 
         // saving headers ready to persist as the header downloader does in the forward() method

--- a/node/silkworm/downloader/internals/priority_queue_test.cpp
+++ b/node/silkworm/downloader/internals/priority_queue_test.cpp
@@ -46,28 +46,27 @@ TEST_CASE("heap_based_priority_queue - element ordering") {
 TEST_CASE("Oldest_First_Anchor_Queue") {
     using namespace std::literals::chrono_literals;
     BlockHeader dummy_header;
-    PeerId dummy_peer_id{1};
     time_point_t now = std::chrono::system_clock::now();
 
     OldestFirstAnchorQueue queue;
 
-    auto anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
+    auto anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
     anchor->blockHeight = 1;
     anchor->timestamp = now;
     queue.push(anchor);
 
-    anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
+    anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
     anchor->blockHeight = 3;
     anchor->timestamp = now;
     queue.push(anchor);
 
-    anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
+    anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
     anchor->blockHeight = 2;
     anchor->timestamp = now + 2s;
     queue.push(anchor);
     auto anchor2 = anchor;
 
-    anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
+    anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
     anchor->blockHeight = 4;
     anchor->timestamp = now + 4s;
     queue.push(anchor);

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -80,7 +80,7 @@ inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
     return out;
 }
 
-using PeerId = Hash;
+using PeerId = std::string;
 
 enum Penalty : int {
     NoPenalty = 0,
@@ -98,7 +98,7 @@ struct PeerPenalization {
     Penalty penalty;
     PeerId peerId;
 
-    PeerPenalization(Penalty p, const PeerId& id) : penalty(p), peerId(id) {}  // unnecessary with c++20
+    PeerPenalization(Penalty p, PeerId id) : penalty(p), peerId(id) {}  // unnecessary with c++20
 };
 
 inline std::ostream& operator<<(std::ostream& os, const PeerPenalization& penalization) {

--- a/node/silkworm/downloader/internals/working_chain_test.cpp
+++ b/node/silkworm/downloader/internals/working_chain_test.cpp
@@ -367,7 +367,7 @@ TEST_CASE("WorkingChain - process_segment - (1) simple chain") {
     WorkingChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
 
-    PeerId peerId{1};
+    PeerId peerId = "1";
 
     std::array<BlockHeader, 10> headers;
 
@@ -553,7 +553,7 @@ TEST_CASE("WorkingChain - process_segment - (2) extending down with 2 siblings")
     WorkingChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
 
-    PeerId peerId{1};
+    PeerId peerId = "1";
 
     std::array<BlockHeader, 10> headers;
 
@@ -602,7 +602,7 @@ TEST_CASE("WorkingChain - process_segment - (3) chain with branches") {
     WorkingChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
 
-    PeerId peerId{1};
+    PeerId peerId = "1";
 
     std::array<BlockHeader, 10> headers;
 
@@ -818,7 +818,7 @@ TEST_CASE("WorkingChain - process_segment - (4) pre-verified hashes on canonical
     WorkingChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
 
-    PeerId peerId{1};
+    PeerId peerId = "1";
 
     std::array<BlockHeader, 10> headers;
 
@@ -909,7 +909,7 @@ TEST_CASE("WorkingChain - process_segment - (5) pre-verified hashes with canonic
     WorkingChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
 
-    PeerId peerId{1};
+    PeerId peerId = "1";
 
     std::array<BlockHeader, 6> a_headers;
 

--- a/node/silkworm/downloader/messages/InboundBlockHeaders.cpp
+++ b/node/silkworm/downloader/messages/InboundBlockHeaders.cpp
@@ -29,7 +29,7 @@ InboundBlockHeaders::InboundBlockHeaders(const sentry::InboundMessage& msg, Work
     if (msg.id() != sentry::MessageId::BLOCK_HEADERS_66)
         throw std::logic_error("InboundBlockHeaders received wrong InboundMessage");
 
-    peerId_ = hash_from_H256(msg.peer_id());
+    peerId_ = string_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/InboundGetBlockBodies.cpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockBodies.cpp
@@ -29,7 +29,7 @@ InboundGetBlockBodies::InboundGetBlockBodies(const sentry::InboundMessage& msg, 
         throw std::logic_error("InboundGetBlockBodies received wrong InboundMessage");
     }
 
-    peerId_ = hash_from_H256(msg.peer_id());
+    peerId_ = string_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/InboundGetBlockBodies.hpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockBodies.hpp
@@ -34,7 +34,7 @@ class InboundGetBlockBodies : public InboundMessage {
     void execute() override;
 
   private:
-    PeerId peerId_;
+    std::string peerId_;
     GetBlockBodiesPacket66 packet_;
     Db::ReadOnlyAccess db_;
     SentryClient& sentry_;

--- a/node/silkworm/downloader/messages/InboundGetBlockHeaders.cpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockHeaders.cpp
@@ -31,7 +31,7 @@ InboundGetBlockHeaders::InboundGetBlockHeaders(const sentry::InboundMessage& msg
         throw std::logic_error("InboundGetBlockHeaders received wrong InboundMessage");
     }
 
-    peerId_ = hash_from_H256(msg.peer_id());
+    peerId_ = string_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/InboundGetBlockHeaders.hpp
+++ b/node/silkworm/downloader/messages/InboundGetBlockHeaders.hpp
@@ -34,7 +34,7 @@ class InboundGetBlockHeaders : public InboundMessage {
     void execute() override;
 
   private:
-    PeerId peerId_;
+    std::string peerId_;
     GetBlockHeadersPacket66 packet_;
     Db::ReadOnlyAccess db_;
     SentryClient& sentry_;

--- a/node/silkworm/downloader/messages/InboundNewBlock.cpp
+++ b/node/silkworm/downloader/messages/InboundNewBlock.cpp
@@ -32,7 +32,7 @@ InboundNewBlock::InboundNewBlock(const sentry::InboundMessage& msg, WorkingChain
 
     reqId_ = RANDOM_NUMBER.generate_one();  // for trace purposes
 
-    peerId_ = hash_from_H256(msg.peer_id());
+    peerId_ = string_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/InboundNewBlock.hpp
+++ b/node/silkworm/downloader/messages/InboundNewBlock.hpp
@@ -34,7 +34,7 @@ class InboundNewBlock : public InboundMessage {
     void execute() override;
 
   private:
-    PeerId peerId_;
+    std::string peerId_;
     NewBlockPacket packet_;
     uint64_t reqId_;
     [[maybe_unused]] WorkingChain& working_chain_;

--- a/node/silkworm/downloader/messages/InboundNewBlockHashes.cpp
+++ b/node/silkworm/downloader/messages/InboundNewBlockHashes.cpp
@@ -32,7 +32,7 @@ InboundNewBlockHashes::InboundNewBlockHashes(const sentry::InboundMessage& msg, 
 
     reqId_ = RANDOM_NUMBER.generate_one();  // for trace purposes
 
-    peerId_ = hash_from_H256(msg.peer_id());
+    peerId_ = string_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/InboundNewBlockHashes.hpp
+++ b/node/silkworm/downloader/messages/InboundNewBlockHashes.hpp
@@ -34,7 +34,7 @@ class InboundNewBlockHashes : public InboundMessage {
     void execute() override;
 
   private:
-    PeerId peerId_;
+    std::string peerId_;
     NewBlockHashesPacket packet_;
     uint64_t reqId_;
     WorkingChain& working_chain_;

--- a/node/silkworm/downloader/rpc/PeerMinBlock.cpp
+++ b/node/silkworm/downloader/rpc/PeerMinBlock.cpp
@@ -18,9 +18,9 @@
 
 namespace silkworm::rpc {
 
-PeerMinBlock::PeerMinBlock(const PeerId& peerId, BlockNum minBlock)
+PeerMinBlock::PeerMinBlock(const std::string& peerId, BlockNum minBlock)
     : UnaryCall("PeerMinBlock", &sentry::Sentry::Stub::PeerMinBlock, {}) {
-    request_.set_allocated_peer_id(to_H256(peerId).release());
+    request_.set_allocated_peer_id(to_H512(peerId).release());
     request_.set_min_block(minBlock);  // take ownership
 }
 

--- a/node/silkworm/downloader/rpc/PeerMinBlock.hpp
+++ b/node/silkworm/downloader/rpc/PeerMinBlock.hpp
@@ -23,7 +23,7 @@ namespace silkworm::rpc {
 
 class PeerMinBlock : public rpc::UnaryCall<sentry::Sentry, sentry::PeerMinBlockRequest, google::protobuf::Empty> {
   public:
-    PeerMinBlock(const PeerId& peerId, BlockNum minBlock);
+    PeerMinBlock(const std::string& peerId, BlockNum minBlock);
 };
 
 }  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/PenalizePeer.cpp
+++ b/node/silkworm/downloader/rpc/PenalizePeer.cpp
@@ -18,9 +18,9 @@
 
 namespace silkworm::rpc {
 
-PenalizePeer::PenalizePeer(const PeerId& peerId, Penalty penalty)
+PenalizePeer::PenalizePeer(const std::string& peerId, Penalty penalty)
     : UnaryCall("PenalizePeer", &sentry::Sentry::Stub::PenalizePeer, {}) {
-    request_.set_allocated_peer_id(to_H256(peerId).release());
+    request_.set_allocated_peer_id(to_H512(peerId).release());
 
     sentry::PenaltyKind raw_penalty = static_cast<sentry::PenaltyKind>(penalty);
     request_.set_penalty(raw_penalty);

--- a/node/silkworm/downloader/rpc/PenalizePeer.hpp
+++ b/node/silkworm/downloader/rpc/PenalizePeer.hpp
@@ -23,7 +23,7 @@ namespace silkworm::rpc {
 
 class PenalizePeer : public rpc::UnaryCall<sentry::Sentry, sentry::PenalizePeerRequest, google::protobuf::Empty> {
   public:
-    PenalizePeer(const PeerId& peerId, Penalty penalty);
+    PenalizePeer(const std::string& peerId, Penalty penalty);
 };
 
 }  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/SendMessageById.cpp
+++ b/node/silkworm/downloader/rpc/SendMessageById.cpp
@@ -18,9 +18,9 @@
 
 namespace silkworm::rpc {
 
-SendMessageById::SendMessageById(const PeerId& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
+SendMessageById::SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
     : UnaryCall("SendMessageById", &sentry::Sentry::Stub::SendMessageById, {}) {
-    request_.set_allocated_peer_id(to_H256(peerId).release());
+    request_.set_allocated_peer_id(to_H512(peerId).release());
     request_.set_allocated_data(message.release());  // take ownership
 }
 

--- a/node/silkworm/downloader/rpc/SendMessageById.hpp
+++ b/node/silkworm/downloader/rpc/SendMessageById.hpp
@@ -23,7 +23,7 @@ namespace silkworm::rpc {
 
 class SendMessageById : public rpc::UnaryCall<sentry::Sentry, sentry::SendMessageByIdRequest, sentry::SentPeers> {
   public:
-    SendMessageById(const PeerId& peerId, std::unique_ptr<sentry::OutboundMessageData> message);
+    SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message);
 };
 
 }  // namespace silkworm::rpc


### PR DESCRIPTION
Reverts torquem-ch/silkworm#509 to align Silkworm to the stable version of Erigon's Sentry.

Erigon stable still uses H512 for peer_id.