### PR TITLE
cmd/consensus depends on node now and can't be built if SILKWORM_CORE_ONLY

### DIFF
--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -115,9 +115,6 @@ if(NOT SILKWORM_CORE_ONLY)
   # Benchmarks
   add_subdirectory(benchmark)
 
-endif(NOT SILKWORM_CORE_ONLY)
-
-if(NOT SILKWORM_WASM_API)
   # Ethereum Consensus Tests
   hunter_add_package(CLI11)
   find_package(CLI11 CONFIG REQUIRED)


### PR DESCRIPTION
after PR #500 