### PR TITLE
Add intra-block state to EVM tracer

### DIFF
--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -46,9 +46,10 @@ class EvmTracer {
   public:
     virtual void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept = 0;
 
-    virtual void on_instruction_start(uint32_t pc, const evmone::ExecutionState& state) noexcept = 0;
+    virtual void on_instruction_start(uint32_t pc, const evmone::ExecutionState& state,
+                                      const IntraBlockState& intra_block_state) noexcept = 0;
 
-    virtual void on_execution_end(const evmc_result& result) noexcept = 0;
+    virtual void on_execution_end(const evmc_result& result, const IntraBlockState& intra_block_state) noexcept = 0;
 };
 
 class EVM {

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -408,26 +408,40 @@ TEST_CASE("Tracing smart contract with storage") {
 
     class TestTracer : public EvmTracer {
       public:
+        TestTracer(std::optional<evmc::address> contract_address = std::nullopt, std::optional<evmc::bytes32> key = std::nullopt)
+            : contract_address_(contract_address), key_(key) {}
+
         void on_execution_start(evmc_revision /*rev*/, const evmc_message& /*msg*/, evmone::bytes_view bytecode) noexcept override {
-            bytecode_ = silkworm::Bytes{bytecode};
+            bytecode_ = Bytes{bytecode};
         }
-        void on_instruction_start(uint32_t pc, const evmone::ExecutionState& state) noexcept override {
+        void on_instruction_start(uint32_t pc, const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override {
             pc_stack_.push_back(pc);
             memory_size_stack_[pc] = state.memory.size();
+            if (contract_address_) {
+                storage_stack_[pc] = intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
+            }
         }
-        void on_execution_end(const evmc_result& res) noexcept override {
+        void on_execution_end(const evmc_result& res, const IntraBlockState& intra_block_state) noexcept override {
             result_ = {res.status_code, static_cast<uint64_t>(res.gas_left), {res.output_data, res.output_size}};
+            if (contract_address_) {
+                const auto pc = pc_stack_.back();
+                storage_stack_[pc] = intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
+            }
         }
 
-        const silkworm::Bytes& bytecode() const { return bytecode_; }
+        const Bytes& bytecode() const { return bytecode_; }
         const std::vector<uint32_t>& pc_stack() const { return pc_stack_; }
         const std::map<uint32_t, std::size_t>& memory_size_stack() const { return memory_size_stack_; }
+        const std::map<uint32_t, evmc::bytes32>& storage_stack() const { return storage_stack_; }
         const CallResult& result() const { return result_; }
 
       private:
-        silkworm::Bytes bytecode_;
+        std::optional<evmc::address> contract_address_;
+        std::optional<evmc::bytes32> key_;
+        Bytes bytecode_;
         std::vector<uint32_t> pc_stack_;
         std::map<uint32_t, std::size_t> memory_size_stack_;
+        std::map<uint32_t, evmc::bytes32> storage_stack_;
         CallResult result_;
     };
 
@@ -445,7 +459,7 @@ TEST_CASE("Tracing smart contract with storage") {
     CHECK(tracer1.memory_size_stack() == std::map<uint32_t, std::size_t>{{0, 0}});
     CHECK(tracer1.result().status == EVMC_OUT_OF_GAS);
     CHECK(tracer1.result().gas_left == 0);
-    CHECK(tracer1.result().data == silkworm::Bytes{});
+    CHECK(tracer1.result().data == Bytes{});
 
     // Second execution: success
     TestTracer tracer2;
@@ -454,7 +468,7 @@ TEST_CASE("Tracing smart contract with storage") {
     gas = 50'000;
     res = evm.execute(txn, gas);
     CHECK(res.status == EVMC_SUCCESS);
-    CHECK(res.data == silkworm::from_hex("600035600055"));
+    CHECK(res.data == from_hex("600035600055"));
 
     CHECK(tracer2.bytecode() == code);
     CHECK(tracer2.pc_stack() == std::vector<uint32_t>{0,2,4,5,8,10,11,13,14,16,18,19,21});
@@ -465,11 +479,12 @@ TEST_CASE("Tracing smart contract with storage") {
     CHECK(tracer2.result().data == res.data);
 
     // Third execution: success
-    TestTracer tracer3;
-    evm.add_tracer(tracer3);
-
     evmc::address contract_address{create_address(caller, 1)};
     evmc::bytes32 key0{};
+
+    TestTracer tracer3{contract_address, key0};
+    evm.add_tracer(tracer3);
+
     CHECK(to_hex(zeroless_view(state.get_current_storage(contract_address, key0))) == "2a");
     evmc::bytes32 new_val{to_bytes32(*from_hex("f5"))};
     txn.to = contract_address;
@@ -479,12 +494,17 @@ TEST_CASE("Tracing smart contract with storage") {
     CHECK(res.status == EVMC_SUCCESS);
     CHECK(res.data.empty());
     CHECK(state.get_current_storage(contract_address, key0) == new_val);
+    CHECK(tracer3.storage_stack() == std::map<uint32_t, evmc::bytes32>{
+        {0, to_bytes32(*from_hex("2a"))},
+        {2, to_bytes32(*from_hex("2a"))},
+        {3, to_bytes32(*from_hex("2a"))},
+        {5, to_bytes32(*from_hex("f5"))}});
 
     CHECK(tracer3.pc_stack() == std::vector<uint32_t>{0,2,3,5});
     CHECK(tracer3.memory_size_stack() == std::map<uint32_t, std::size_t>{{0, 0}, {2, 0}, {3, 0}, {5, 0}});
     CHECK(tracer3.result().status == EVMC_SUCCESS);
     CHECK(tracer3.result().gas_left == 49191);
-    CHECK(tracer3.result().data == silkworm::Bytes{});
+    CHECK(tracer3.result().data == Bytes{});
 }
 
 }  // namespace silkworm


### PR DESCRIPTION
Add `IntraBlockState` in the `EvmTracer` interface callbacks to access storage values

The `IntraBlockState` parameter is needed also in `on_execution_end` function in order to access intra-block state after the last opcode