### PR TITLE
[Optimization] Reduce memory allocation in execute_transaction

### DIFF
--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -16,7 +16,6 @@
 
 #include "processor.hpp"
 
-#include <algorithm>
 #include <cassert>
 
 #include <silkworm/chain/dao.hpp>

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -149,8 +149,8 @@ uint64_t ExecutionProcessor::refund_gas(const Transaction& txn, uint64_t gas_lef
 }
 
 ValidationResult ExecutionProcessor::execute_block_no_post_validation(std::vector<Receipt>& receipts) noexcept {
-    receipts.clear();
-    receipts.reserve(evm_.block().transactions.size());
+    const size_t n{evm_.block().transactions.size()};
+    receipts.resize(n);
 
     uint64_t block_num{evm_.block().header.number};
     if (block_num == evm_.config().dao_block) {
@@ -158,12 +158,13 @@ ValidationResult ExecutionProcessor::execute_block_no_post_validation(std::vecto
     }
 
     cumulative_gas_used_ = 0;
-    for (const Transaction& txn : evm_.block().transactions) {
+    for (size_t i{0}; i < n; ++i) {
+        const Transaction& txn{evm_.block().transactions[i]};
         const ValidationResult err{validate_transaction(txn)};
         if (err != ValidationResult::kOk) {
             return err;
         }
-        receipts.push_back(execute_transaction(txn));
+        receipts[i] = execute_transaction(txn);
     }
 
     consensus_engine_.finalize(state_, evm_.block(), evm_.revision());

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -149,17 +149,18 @@ uint64_t ExecutionProcessor::refund_gas(const Transaction& txn, uint64_t gas_lef
 }
 
 ValidationResult ExecutionProcessor::execute_block_no_post_validation(std::vector<Receipt>& receipts) noexcept {
-    const size_t n{evm_.block().transactions.size()};
-    receipts.resize(n);
+    const Block& block{evm_.block()};
 
-    uint64_t block_num{evm_.block().header.number};
-    if (block_num == evm_.config().dao_block) {
+    if (block.header.number == evm_.config().dao_block) {
         dao::transfer_balances(state_);
     }
 
     cumulative_gas_used_ = 0;
+
+    const size_t n{block.transactions.size()};
+    receipts.resize(n);
     for (size_t i{0}; i < n; ++i) {
-        const Transaction& txn{evm_.block().transactions[i]};
+        const Transaction& txn{block.transactions[i]};
         const ValidationResult err{validate_transaction(txn)};
         if (err != ValidationResult::kOk) {
             return err;
@@ -167,7 +168,7 @@ ValidationResult ExecutionProcessor::execute_block_no_post_validation(std::vecto
         receipts[i] = execute_transaction(txn);
     }
 
-    consensus_engine_.finalize(state_, evm_.block(), evm_.revision());
+    consensus_engine_.finalize(state_, block, evm_.revision());
 
     return ValidationResult::kOk;
 }

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -113,12 +113,15 @@ Receipt ExecutionProcessor::execute_transaction(const Transaction& txn) noexcept
 
     cumulative_gas_used_ += gas_used;
 
+    const std::vector<Log> logs{state_.move_logs_out()};
+    const Bloom bloom{logs_bloom(logs)};
+
     return {
         txn.type,                       // type
         vm_res.status == EVMC_SUCCESS,  // success
         cumulative_gas_used_,           // cumulative_gas_used
-        logs_bloom(state_.logs()),      // bloom
-        state_.logs(),                  // logs
+        bloom,                          // bloom
+        logs,                           // logs
     };
 }
 

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -156,15 +156,15 @@ ValidationResult ExecutionProcessor::execute_block_no_post_validation(std::vecto
 
     cumulative_gas_used_ = 0;
 
-    const size_t n{block.transactions.size()};
-    receipts.resize(n);
-    for (size_t i{0}; i < n; ++i) {
-        const Transaction& txn{block.transactions[i]};
+    receipts.resize(block.transactions.size());
+    auto receipt_it{receipts.begin()};
+    for (const auto& txn : block.transactions) {
         const ValidationResult err{validate_transaction(txn)};
         if (err != ValidationResult::kOk) {
             return err;
         }
-        execute_transaction(txn, receipts[i]);
+        execute_transaction(txn, *receipt_it);
+        ++receipt_it;
     }
 
     consensus_engine_.finalize(state_, block, evm_.revision());

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -70,6 +70,7 @@ ValidationResult ExecutionProcessor::validate_transaction(const Transaction& txn
 void ExecutionProcessor::execute_transaction(const Transaction& txn, Receipt& receipt) noexcept {
     assert(validate_transaction(txn) == ValidationResult::kOk);
 
+    // Optimization: since receipt.logs might have some capacity, let's reuse it.
     std::swap(receipt.logs, state_.logs());
 
     state_.clear_journal_and_substate();
@@ -103,7 +104,7 @@ void ExecutionProcessor::execute_transaction(const Transaction& txn, Receipt& re
 
     const uint64_t gas_used{txn.gas_limit - refund_gas(txn, vm_res.gas_left)};
 
-    // award the miner
+    // award the fee recipient
     const intx::uint256 priority_fee_per_gas{txn.priority_fee_per_gas(base_fee_per_gas)};
     state_.add_to_balance(evm_.beneficiary, priority_fee_per_gas * gas_used);
 

--- a/core/silkworm/execution/processor.hpp
+++ b/core/silkworm/execution/processor.hpp
@@ -43,7 +43,7 @@ class ExecutionProcessor {
 
     // Execute a transaction, but do not write to the DB yet.
     // Precondition: transaction must be valid.
-    Receipt execute_transaction(const Transaction& txn) noexcept;
+    void execute_transaction(const Transaction& txn, Receipt& receipt) noexcept;
 
     //! \brief Execute the block and write the result to the DB.
     //! \remarks Warning: This method does not verify state root; pre-Byzantium receipt root isn't validated either.

--- a/core/silkworm/state/intra_block_state.cpp
+++ b/core/silkworm/state/intra_block_state.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2022 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
 */
 
 #include "intra_block_state.hpp"
-
-#include <algorithm>
 
 #include <ethash/keccak.hpp>
 
@@ -373,12 +371,6 @@ void IntraBlockState::clear_journal_and_substate() {
     // EIP-2929
     accessed_addresses_.clear();
     accessed_storage_keys_.clear();
-}
-
-std::vector<Log> IntraBlockState::move_logs_out() noexcept {
-    std::vector<Log> logs;
-    std::swap(logs, logs_);
-    return logs;
 }
 
 void IntraBlockState::add_log(const Log& log) noexcept { logs_.push_back(log); }

--- a/core/silkworm/state/intra_block_state.cpp
+++ b/core/silkworm/state/intra_block_state.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 */
 
 #include "intra_block_state.hpp"
+
+#include <algorithm>
 
 #include <ethash/keccak.hpp>
 
@@ -371,6 +373,12 @@ void IntraBlockState::clear_journal_and_substate() {
     // EIP-2929
     accessed_addresses_.clear();
     accessed_storage_keys_.clear();
+}
+
+std::vector<Log> IntraBlockState::move_logs_out() noexcept {
+    std::vector<Log> logs;
+    std::swap(logs, logs_);
+    return logs;
 }
 
 void IntraBlockState::add_log(const Log& log) noexcept { logs_.push_back(log); }

--- a/core/silkworm/state/intra_block_state.hpp
+++ b/core/silkworm/state/intra_block_state.hpp
@@ -107,8 +107,7 @@ class IntraBlockState {
 
     void add_log(const Log& log) noexcept;
 
-    // Clears the logs and returns their prior value
-    std::vector<Log> move_logs_out() noexcept;
+    std::vector<Log>& logs() noexcept { return logs_; }
 
     void add_refund(uint64_t addend) noexcept;
     void subtract_refund(uint64_t subtrahend) noexcept;

--- a/core/silkworm/state/intra_block_state.hpp
+++ b/core/silkworm/state/intra_block_state.hpp
@@ -108,6 +108,7 @@ class IntraBlockState {
     void add_log(const Log& log) noexcept;
 
     std::vector<Log>& logs() noexcept { return logs_; }
+    const std::vector<Log>& logs() const noexcept { return logs_; }
 
     void add_refund(uint64_t addend) noexcept;
     void subtract_refund(uint64_t subtrahend) noexcept;

--- a/core/silkworm/state/intra_block_state.hpp
+++ b/core/silkworm/state/intra_block_state.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -107,7 +107,8 @@ class IntraBlockState {
 
     void add_log(const Log& log) noexcept;
 
-    const std::vector<Log>& logs() const noexcept { return logs_; }
+    // Clears the logs and returns their prior value
+    std::vector<Log> move_logs_out() noexcept;
 
     void add_refund(uint64_t addend) noexcept;
     void subtract_refund(uint64_t subtrahend) noexcept;


### PR DESCRIPTION
This is a small opimization reducing memory allocation in `ExecutionProcessor::execute_transaction`. The idea is use logs (which might have some capacity already) from the provided out parameter `receipt` in `IntraBlockState`. The total time of executing 14M main net blocks is reduced from 33.8h to 33.4h.