### PR TITLE
Fix unnecessary std::string creation/destruction

### DIFF
--- a/core/silkworm/common/endian.cpp
+++ b/core/silkworm/common/endian.cpp
@@ -19,23 +19,23 @@
 #include <silkworm/common/util.hpp>
 
 #if defined(__wasm__)
-#define SILKWORM_THREAD_LOCAL
+#define SILKWORM_THREAD_LOCAL static
 #else
 #define SILKWORM_THREAD_LOCAL thread_local
 #endif
 
 namespace silkworm::endian {
 
-Bytes to_big_compact(const uint64_t value) {
+ByteView to_big_compact(const uint64_t value) {
     SILKWORM_THREAD_LOCAL uint8_t full_be[sizeof(uint64_t)];
     store_big_u64(&full_be[0], value);
-    return Bytes{zeroless_view(full_be)};
+    return zeroless_view(full_be);
 }
 
-Bytes to_big_compact(const intx::uint256& value) {
+ByteView to_big_compact(const intx::uint256& value) {
     SILKWORM_THREAD_LOCAL uint8_t full_be[sizeof(intx::uint256)];
     intx::be::store(full_be, value);
-    return Bytes{zeroless_view(full_be)};
+    return zeroless_view(full_be);
 }
 
 }  // namespace silkworm::endian

--- a/core/silkworm/common/endian.cpp
+++ b/core/silkworm/common/endian.cpp
@@ -27,12 +27,18 @@
 namespace silkworm::endian {
 
 ByteView to_big_compact(const uint64_t value) {
+    if (!value) {
+        return {};
+    }
     SILKWORM_THREAD_LOCAL uint8_t full_be[sizeof(uint64_t)];
     store_big_u64(&full_be[0], value);
     return zeroless_view(full_be);
 }
 
 ByteView to_big_compact(const intx::uint256& value) {
+    if (!value) {
+        return {};
+    }
     SILKWORM_THREAD_LOCAL uint8_t full_be[sizeof(intx::uint256)];
     intx::be::store(full_be, value);
     return zeroless_view(full_be);

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -169,14 +169,18 @@ inline void store_big_u64(uint8_t* bytes, const uint64_t value) {
 
 //! \brief Transforms a uint64_t stored in memory with native endianness to it's compacted big endian byte form
 //! \param [in] value : the value to be transformed
-//! \return A string of bytes
+//! \return A ByteView (std::string_view) into an internal static buffer (thread specific) of the function
+//! \remarks each function call overwrites the buffer, therefore invalidating a previously returned result
+//! \remarks so each returnd ByteView must be used immediately (before a further call to the same function).
 //! \remarks See Erigon TxIndex value
 //! \remarks A "compact" big endian form strips leftmost bytes valued to zero
 ByteView to_big_compact(uint64_t value);
 
 //! \brief Transforms a uint256 stored in memory with native endianness to it's compacted big endian byte form
 //! \param [in] value : the value to be transformed
-//! \return A string of bytes
+//! \return A ByteView (std::string_view) into an internal static buffer (thread specific) of the function
+//! \remarks each function call overwrites the buffer, therefore invalidating a previously returned result
+//! \remarks so each returnd ByteView must be used immediately (before a further call to the same function)
 //! \remarks See Erigon TxIndex value
 //! \remarks A "compact" big endian form strips leftmost bytes valued to zero
 ByteView to_big_compact(const intx::uint256& value);

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -172,14 +172,14 @@ inline void store_big_u64(uint8_t* bytes, const uint64_t value) {
 //! \return A string of bytes
 //! \remarks See Erigon TxIndex value
 //! \remarks A "compact" big endian form strips leftmost bytes valued to zero
-Bytes to_big_compact(uint64_t value);
+ByteView to_big_compact(uint64_t value);
 
 //! \brief Transforms a uint256 stored in memory with native endianness to it's compacted big endian byte form
 //! \param [in] value : the value to be transformed
 //! \return A string of bytes
 //! \remarks See Erigon TxIndex value
 //! \remarks A "compact" big endian form strips leftmost bytes valued to zero
-Bytes to_big_compact(const intx::uint256& value);
+ByteView to_big_compact(const intx::uint256& value);
 
 //! \brief Parses unsigned integer from a compacted big endian byte form
 //! \param [in] data : byte view of compacted value. Length must be <= sizeof(UnsignedInteger)

--- a/core/silkworm/rlp/encode.cpp
+++ b/core/silkworm/rlp/encode.cpp
@@ -25,7 +25,7 @@ void encode_header(Bytes& to, Header header) {
         const uint8_t code{header.list ? kEmptyListCode : kEmptyStringCode};
         to.push_back(static_cast<uint8_t>(code + header.payload_length));
     } else {
-        const Bytes len_be{endian::to_big_compact(header.payload_length)};
+        auto len_be{endian::to_big_compact(header.payload_length)};
         const uint8_t code = header.list ? 0xF7 : 0xB7;
         to.push_back(static_cast<uint8_t>(code + len_be.length()));
         to.append(len_be);
@@ -61,7 +61,7 @@ void encode(Bytes& to, uint64_t n) {
     } else if (n < kEmptyStringCode) {
         to.push_back(static_cast<uint8_t>(n));
     } else {
-        const Bytes be{endian::to_big_compact(n)};
+        auto be{endian::to_big_compact(n)};
         to.push_back(static_cast<uint8_t>(kEmptyStringCode + be.length()));
         to.append(be);
     }
@@ -81,7 +81,7 @@ void encode(Bytes& to, const intx::uint256& n) {
     } else if (n < kEmptyStringCode) {
         to.push_back(static_cast<uint8_t>(n));
     } else {
-        const Bytes be{endian::to_big_compact(n)};
+        auto be{endian::to_big_compact(n)};
         to.push_back(static_cast<uint8_t>(kEmptyStringCode + be.length()));
         to.append(be);
     }

--- a/core/silkworm/types/account.cpp
+++ b/core/silkworm/types/account.cpp
@@ -30,21 +30,21 @@ Bytes Account::encode_for_storage(bool omit_code_hash) const {
 
     if (nonce != 0) {
         field_set |= 1;
-        const Bytes be{endian::to_big_compact(nonce)};
+        auto be{endian::to_big_compact(nonce)};
         res.push_back(static_cast<uint8_t>(be.length()));
         res.append(be);
     }
 
     if (balance != 0) {
         field_set |= 2;
-        const Bytes be{endian::to_big_compact(balance)};
+        auto be{endian::to_big_compact(balance)};
         res.push_back(static_cast<uint8_t>(be.length()));
         res.append(be);
     }
 
     if (incarnation != 0) {
         field_set |= 4;
-        const Bytes be{endian::to_big_compact(incarnation)};
+        auto be{endian::to_big_compact(incarnation)};
         res.push_back(static_cast<uint8_t>(be.length()));
         res.append(be);
     }
@@ -63,17 +63,17 @@ size_t Account::encoding_length_for_storage() const {
     size_t len{1};
 
     if (nonce != 0) {
-        const Bytes be{endian::to_big_compact(nonce)};
+        auto be{endian::to_big_compact(nonce)};
         len += 1 + be.length();
     }
 
     if (balance != 0) {
-        const Bytes be{endian::to_big_compact(balance)};
+        auto be{endian::to_big_compact(balance)};
         len += 1 + be.length();
     }
 
     if (incarnation != 0) {
-        const Bytes be{endian::to_big_compact(incarnation)};
+        auto be{endian::to_big_compact(incarnation)};
         len += 1 + be.length();
     }
 


### PR DESCRIPTION
This is trying to avoid creating a std::string in `to_big_compact()`, which is destroyed immediately after. The issue is that, with this change,   `to_big_compact()`  returns a `ByteView` which points to the static buffer of inside the function. As the result is usually used immediately after the call, I don't think it it a significant issue, but you guys might disagree of course :-).