### PR TITLE
Fix account decoding

### DIFF
--- a/core/silkworm/common/endian.cpp
+++ b/core/silkworm/common/endian.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/silkworm/rlp/decode.hpp
+++ b/core/silkworm/rlp/decode.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ enum class [[nodiscard]] DecodingResult{
     kListLengthMismatch,
     kInvalidVInSignature,         // v != 27 && v != 28 && v < 35, see EIP-155
     kUnsupportedTransactionType,  // EIP-2718
+    kInvalidFieldset,
 };
 
 // Consumes RLP header unless it's a single byte in the [0x00, 0x7f] range,

--- a/core/silkworm/types/account.cpp
+++ b/core/silkworm/types/account.cpp
@@ -88,7 +88,7 @@ std::pair<Account, rlp::DecodingResult> Account::from_encoded_storage(ByteView e
     Account a{};
     if (encoded_payload.empty()) {
         return {a, rlp::DecodingResult::kOk};
-    } else if (encoded_payload.length() == 1) {
+    } else if (encoded_payload[0] && encoded_payload.length() == 1) {
         // Must be at least 2 bytes : field_set + len of payload
         return {a, rlp::DecodingResult::kInputTooShort};
     }
@@ -141,7 +141,7 @@ std::pair<Account, rlp::DecodingResult> Account::from_encoded_storage(ByteView e
 std::pair<uint64_t, rlp::DecodingResult> Account::incarnation_from_encoded_storage(ByteView encoded_payload) noexcept {
     if (encoded_payload.empty()) {
         return {0, rlp::DecodingResult::kOk};
-    } else if (encoded_payload.length() == 1) {
+    } else if (encoded_payload[0] && encoded_payload.length() == 1) {
         // Must be at least 2 bytes : field_set + len of payload
         return {0, rlp::DecodingResult::kInputTooShort};
     }

--- a/core/silkworm/types/account.cpp
+++ b/core/silkworm/types/account.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -84,85 +84,96 @@ size_t Account::encoding_length_for_storage() const {
     return len;
 }
 
-std::pair<uint64_t, rlp::DecodingResult> extract_incarnation(ByteView encoded) {
-    uint8_t field_set = encoded[0];
-    size_t pos{1};
-
-    if (field_set & 1) {
-        pos += encoded[pos++];
-    }
-    if (field_set & 2) {
-        pos += encoded[pos++];
-    }
-    if (field_set & 4) {
-        // Incarnation has been found.
-        uint8_t len = encoded[pos++];
-        const std::optional<uint64_t> incarnation{endian::from_big_compact<uint64_t>(encoded.substr(pos, len))};
-        if (incarnation == std::nullopt) {
-            return {0, rlp::DecodingResult::kOverflow};
-        }
-        return {*incarnation, rlp::DecodingResult::kOk};
-    }
-    return {0, rlp::DecodingResult::kOk};
-}
-
-std::pair<Account, rlp::DecodingResult> decode_account_from_storage(ByteView encoded) noexcept {
+std::pair<Account, rlp::DecodingResult> Account::from_encoded_storage(ByteView encoded_payload) noexcept {
     Account a{};
-    if (encoded.empty()) {
+    if (encoded_payload.empty()) {
         return {a, rlp::DecodingResult::kOk};
+    } else if (encoded_payload.length() == 1) {
+        // Must be at least 2 bytes : field_set + len of payload
+        return {a, rlp::DecodingResult::kInputTooShort};
     }
 
-    uint8_t field_set = encoded[0];
+    uint8_t field_set = encoded_payload[0];
     size_t pos{1};
 
-    if (field_set & 1) {
-        uint8_t len = encoded[pos++];
-        if (encoded.length() < pos + len) {
-            return {a, rlp::DecodingResult::kInputTooShort};
+    for (int i{1}; i < 16; i *= 2) {
+        if (field_set & i) {
+            uint8_t len = encoded_payload[pos++];
+            if (encoded_payload.length() < pos + len) {
+                return {a, rlp::DecodingResult::kInputTooShort};
+            }
+            switch (i) {
+                case 1: {
+                    const std::optional<uint64_t> nonce{endian::from_big_compact<uint64_t>(encoded_payload.substr(pos, len))};
+                    if (nonce == std::nullopt) {
+                        return {a, rlp::DecodingResult::kLeadingZero};
+                    }
+                    a.nonce = *nonce;
+                } break;
+                case 2:
+                    std::memcpy(&as_bytes(a.balance)[32 - len], &encoded_payload[pos], len);
+                    a.balance = bswap(a.balance);
+                    break;
+                case 4: {
+                    const std::optional<uint64_t> incarnation{
+                        endian::from_big_compact<uint64_t>(encoded_payload.substr(pos, len))};
+                    if (incarnation == std::nullopt) {
+                        return {a, rlp::DecodingResult::kLeadingZero};
+                    }
+                    a.incarnation = *incarnation;
+                } break;
+                case 8:
+                    if (len != kHashLength) {
+                        return {a, rlp::DecodingResult::kUnexpectedLength};
+                    }
+                    std::memcpy(a.code_hash.bytes, &encoded_payload[pos], kHashLength);
+                    break;
+                default:
+                    len = 0;
+            }
+            pos += len;
         }
-        const std::optional<uint64_t> nonce{endian::from_big_compact<uint64_t>(encoded.substr(pos, len))};
-        if (nonce == std::nullopt) {
-            return {a, rlp::DecodingResult::kOverflow};
-        }
-        a.nonce = *nonce;
-        pos += len;
-    }
-
-    if (field_set & 2) {
-        uint8_t len = encoded[pos++];
-        if (encoded.length() < pos + len) {
-            return {a, rlp::DecodingResult::kInputTooShort};
-        }
-        std::memcpy(&as_bytes(a.balance)[32 - len], &encoded[pos], len);
-        a.balance = bswap(a.balance);
-        pos += len;
-    }
-
-    if (field_set & 4) {
-        uint8_t len = encoded[pos++];
-        if (encoded.length() < pos + len) {
-            return {a, rlp::DecodingResult::kInputTooShort};
-        }
-        const std::optional<uint64_t> incarnation{endian::from_big_compact<uint64_t>(encoded.substr(pos, len))};
-        if (incarnation == std::nullopt) {
-            return {a, rlp::DecodingResult::kOverflow};
-        }
-        a.incarnation = *incarnation;
-        pos += len;
-    }
-
-    if (field_set & 8) {
-        uint8_t len = encoded[pos++];
-        if (len != kHashLength) {
-            return {a, rlp::DecodingResult::kUnexpectedLength};
-        }
-        if (encoded.length() < pos + len) {
-            return {a, rlp::DecodingResult::kInputTooShort};
-        }
-        std::memcpy(a.code_hash.bytes, &encoded[pos], kHashLength);
     }
 
     return {a, rlp::DecodingResult::kOk};
+}
+
+std::pair<uint64_t, rlp::DecodingResult> Account::incarnation_from_encoded_storage(ByteView encoded_payload) noexcept {
+    if (encoded_payload.empty()) {
+        return {0, rlp::DecodingResult::kOk};
+    } else if (encoded_payload.length() == 1) {
+        // Must be at least 2 bytes : field_set + len of payload
+        return {0, rlp::DecodingResult::kInputTooShort};
+    }
+
+    uint8_t field_set = encoded_payload[0];
+    size_t pos{1};
+
+    for (int i{1}; i < 8; i *= 2) {
+        if (field_set & i) {
+            uint8_t len = encoded_payload[pos++];
+            if (encoded_payload.length() < pos + len) {
+                return {0, rlp::DecodingResult::kInputTooShort};
+            }
+            switch (i) {
+                case 1:
+                case 2:
+                    break;
+                case 4: {
+                    const std::optional<uint64_t> incarnation{
+                        endian::from_big_compact<uint64_t>(encoded_payload.substr(pos, len))};
+                    if (incarnation == std::nullopt) {
+                        return {0, rlp::DecodingResult::kLeadingZero};
+                    }
+                    return {*incarnation, rlp::DecodingResult::kOk};
+                } break;
+                default:
+                    len = 0;
+            }
+            pos += len;
+        }
+    }
+    return {0, rlp::DecodingResult::kOk};
 }
 
 Bytes Account::rlp(const evmc::bytes32& storage_root) const {

--- a/core/silkworm/types/account.hpp
+++ b/core/silkworm/types/account.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -35,24 +35,24 @@ struct Account {
     evmc::bytes32 code_hash{kEmptyHash};
     uint64_t incarnation{0};
 
-    // Erigon (*Account)EncodeForStorage
-    Bytes encode_for_storage(bool omit_code_hash = false) const;
+    //! \remarks Erigon's (*Account)EncodeForStorage
+    [[nodiscard]] Bytes encode_for_storage(bool omit_code_hash = false) const;
 
-    // Erigon (*Account)EncodingLengthForStorage
-    size_t encoding_length_for_storage() const;
+    //! \remarks Erigon's (*Account)EncodingLengthForStorage
+    [[nodiscard]] size_t encoding_length_for_storage() const;
 
-    Bytes rlp(const evmc::bytes32& storage_root) const;
+    //! \brief Rlp encodes Account
+    [[nodiscard]] Bytes rlp(const evmc::bytes32& storage_root) const;
+
+    //! \brief Returns an Account from it's encoded representation
+    [[nodiscard]] static std::pair<Account, rlp::DecodingResult> from_encoded_storage(ByteView encoded_payload) noexcept;
+
+    //! \brief Returns an Account Incarnation from it's encoded representation
+    //! \remarks Similar to from_encoded_storage but faster as it parses only incarnation
+    [[nodiscard]] static std::pair<uint64_t, rlp::DecodingResult> incarnation_from_encoded_storage(ByteView encoded_payload) noexcept;
 };
 
 bool operator==(const Account& a, const Account& b);
-
-/*
- * Extract the incarnation from an encoded account object without fully decoding it.
- */
-std::pair<uint64_t, rlp::DecodingResult> extract_incarnation(ByteView);
-
-// Erigon (*Account)DecodeForStorage
-[[nodiscard]] std::pair<Account, rlp::DecodingResult> decode_account_from_storage(ByteView encoded) noexcept;
 
 }  // namespace silkworm
 

--- a/core/silkworm/types/account_test.cpp
+++ b/core/silkworm/types/account_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,18 +23,55 @@
 namespace silkworm {
 
 TEST_CASE("Decode account from storage") {
-    Bytes encoded{*from_hex("0f01020203e8010520f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239")};
+    SECTION("Correct payload") {
+        Bytes encoded{*from_hex("0f01020203e8010520f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kOk);
 
-    auto [decoded, err]{decode_account_from_storage(encoded)};
-    REQUIRE(err == rlp::DecodingResult::kOk);
+        CHECK(decoded.nonce == 2);
+        CHECK(decoded.balance == 1000);
+        CHECK(decoded.code_hash == 0xf1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239_bytes32);
+        CHECK(decoded.incarnation == 5);
 
-    CHECK(decoded.nonce == 2);
-    CHECK(decoded.balance == 1000);
-    CHECK(decoded.code_hash == 0xf1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239_bytes32);
-    CHECK(decoded.incarnation == 5);
+        CHECK(decoded.encoding_length_for_storage() == encoded.length());
+        CHECK(decoded.encode_for_storage() == encoded);
+    }
 
-    CHECK(decoded.encoding_length_for_storage() == encoded.length());
-    CHECK(decoded.encode_for_storage() == encoded);
+    SECTION("Correct payload only incarnation") {
+        Bytes encoded{*from_hex("0f01020203e8010520f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c9239")};
+        auto [incarnation, err]{Account::incarnation_from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kOk);
+        REQUIRE(incarnation == 5);
+    }
+
+    SECTION("Empty payload") {
+        Bytes encoded{};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kOk);
+
+        CHECK(decoded.nonce == 0);
+        CHECK(decoded.balance == 0);
+        CHECK(decoded.code_hash == kEmptyHash);
+        CHECK(decoded.incarnation == 0);
+    }
+
+    SECTION("Too short payload") {
+        Bytes encoded{*from_hex("0f")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kInputTooShort);
+    }
+
+    SECTION("Wrong nonce payload") {
+        Bytes encoded{*from_hex("01020001")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kLeadingZero);
+    }
+
+    SECTION("Wrong code_hash payload") {
+        Bytes encoded{*from_hex("0x0805c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kUnexpectedLength);
+    }
 }
 
 }  // namespace silkworm

--- a/core/silkworm/types/account_test.cpp
+++ b/core/silkworm/types/account_test.cpp
@@ -55,6 +55,18 @@ TEST_CASE("Decode account from storage") {
         CHECK(decoded.incarnation == 0);
     }
 
+    SECTION("One zero byte payload") {
+        Bytes encoded{*from_hex("00")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kOk);
+    }
+
+    SECTION("One non-zero byte payload") {
+        Bytes encoded{*from_hex("04")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kInputTooShort);
+    }
+
     SECTION("Too short payload") {
         Bytes encoded{*from_hex("0f")};
         auto [decoded, err]{Account::from_encoded_storage(encoded)};

--- a/core/silkworm/types/account_test.cpp
+++ b/core/silkworm/types/account_test.cpp
@@ -67,6 +67,12 @@ TEST_CASE("Decode account from storage") {
         REQUIRE(err == rlp::DecodingResult::kInputTooShort);
     }
 
+    SECTION("One >15 byte head plus 1byte") {
+        Bytes encoded{*from_hex("1e01")};
+        auto [decoded, err]{Account::from_encoded_storage(encoded)};
+        REQUIRE(err == rlp::DecodingResult::kInvalidFieldset);
+    }
+
     SECTION("Too short payload") {
         Bytes encoded{*from_hex("0f")};
         auto [decoded, err]{Account::from_encoded_storage(encoded)};

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -351,7 +351,7 @@ std::optional<Account> read_account(mdbx::txn& txn, const evmc::address& address
         return std::nullopt;
     }
 
-    auto [acc, err]{decode_account_from_storage(encoded.value())};
+    auto [acc, err]{Account::from_encoded_storage(encoded.value())};
     rlp::success_or_throw(err);
 
     if (acc.incarnation > 0 && acc.code_hash == kEmptyHash) {

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -200,7 +200,7 @@ static void revert_state(ByteView key, ByteView value, mdbx::cursor& plain_state
                          mdbx::cursor& plain_code_table) {
     if (key.size() == kAddressLength) {
         if (!value.empty()) {
-            auto [account, err1]{decode_account_from_storage(value)};
+            auto [account, err1]{Account::from_encoded_storage(value)};
             rlp::success_or_throw(err1);
             if (account.incarnation > 0 && account.code_hash == kEmptyHash) {
                 Bytes code_hash_key(kAddressLength + db::kIncarnationLength, '\0');
@@ -212,7 +212,8 @@ static void revert_state(ByteView key, ByteView value, mdbx::cursor& plain_state
             // cleaning up contract codes
             auto state_account_encoded{plain_state_table.find(db::to_slice(key), /*throw_notfound=*/false)};
             if (state_account_encoded) {
-                auto [state_incarnation, err2]{extract_incarnation(db::from_slice(state_account_encoded.value))};
+                auto [state_incarnation,
+                      err2]{Account::incarnation_from_encoded_storage(db::from_slice(state_account_encoded.value))};
                 rlp::success_or_throw(err2);
                 // cleanup each code incarnation
                 for (uint64_t i = state_incarnation; i > account.incarnation; --i) {

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ void hashstate_promote(mdbx::txn& txn, HashstateOperation operation) {
                 changeset_data = changeset_table.to_next(/*throw_notfound=*/false);
                 continue;
             }
-            auto [incarnation, err]{extract_incarnation(db::from_slice(encoded_account.value))};
+            auto [incarnation, err]{Account::incarnation_from_encoded_storage(db::from_slice(encoded_account.value))};
             rlp::success_or_throw(err);
             if (incarnation == 0) {
                 changeset_data = changeset_table.to_next(/*throw_notfound=*/false);
@@ -298,7 +298,7 @@ static void hashstate_unwind(mdbx::txn& txn, BlockNum unwind_to, HashstateOperat
                     target_table.erase(new_key);
                     return true;
                 }
-                auto [acc, err]{decode_account_from_storage(db_value)};
+                auto [acc, err]{Account::from_encoded_storage(db_value)};
                 rlp::success_or_throw(err);
 
                 if (acc.incarnation <= 0 || acc.code_hash != kEmptyHash) {
@@ -345,7 +345,7 @@ static void hashstate_unwind(mdbx::txn& txn, BlockNum unwind_to, HashstateOperat
                 if (db_value.empty()) {
                     return true;
                 }
-                auto [incarnation, err]{extract_incarnation(db_value)};
+                auto [incarnation, err]{Account::incarnation_from_encoded_storage(db_value)};
                 rlp::success_or_throw(err);
                 if (incarnation == 0) {
                     return true;

--- a/node/silkworm/stagedsync/stage_hashstate_test.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ TEST_CASE("Stage Hashstate") {
     REQUIRE(hashed_address_table.seek(db::to_slice(sender_keccak.bytes)));
     {
         auto account_encoded{db::from_slice(hashed_address_table.current().value)};
-        auto [acc, _]{decode_account_from_storage(account_encoded)};
+        auto [acc, _]{Account::from_encoded_storage(account_encoded)};
         CHECK(acc.nonce == 3);
         CHECK(acc.balance < kEther);
     }
@@ -172,7 +172,7 @@ TEST_CASE("Stage Hashstate") {
     REQUIRE(hashed_address_table.seek(db::to_slice(address_keccak.bytes)));
     {
         auto account_encoded{db::from_slice(hashed_address_table.current().value)};
-        auto [acc, _]{decode_account_from_storage(account_encoded)};
+        auto [acc, _]{Account::from_encoded_storage(account_encoded)};
         CHECK(acc.nonce == 2);
         CHECK(acc.balance < kEther);  // Slightly less due to fees
         CHECK(db::stages::read_stage_progress(*txn, db::stages::kHashStateKey) == 1);

--- a/node/silkworm/trie/intermediate_hashes.cpp
+++ b/node/silkworm/trie/intermediate_hashes.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -302,7 +302,7 @@ evmc::bytes32 DbTrieLoader::calculate_root(PrefixSet& changed) {
             if (trie.key().has_value() && trie.key().value() < unpacked_key) {
                 break;
             }
-            const auto [account, err]{decode_account_from_storage(db::from_slice(acc.value))};
+            const auto [account, err]{Account::from_encoded_storage(db::from_slice(acc.value))};
             rlp::success_or_throw(err);
 
             evmc::bytes32 storage_root{kEmptyRoot};


### PR DESCRIPTION
- fix decode account from encoded rlp : 1) Check payload is either empty or > 1 (otherwise first `encoded_payload[pos++]` gives undefined behavior); 2) remove duplicate checks and reduce to a loop; 
- fix decode incarnation from encoded rlp : implementation did not include all checks of the previous
- move `decode_account_from_storage` to `Account::from_encoded_storage`
- move `extract_incarnation` to `Account::incarnation_from_encoded_storage`
- addedd missing tests for wrong payloads