### PR TITLE
Optional thousands separator in log lines

### DIFF
--- a/cmd/download_headers.cpp
+++ b/cmd/download_headers.cpp
@@ -45,6 +45,7 @@ int main(int argc, char* argv[]) {
     settings.log_threads = true;
     settings.log_file = "downloader.log";
     settings.log_verbosity = log::Level::kInfo;
+    settings.log_thousands_sep = '\'';
 
     app.add_option("--chaindata", db_path, "Path to the chain database", true)
         ->check(CLI::ExistingDirectory);

--- a/node/silkworm/common/log.cpp
+++ b/node/silkworm/common/log.cpp
@@ -70,8 +70,19 @@ static inline std::pair<const char*, const char*> get_level_settings(Level level
     }
 }
 
+struct separate_thousands : std::numpunct<char> {
+    char separator;
+    explicit separate_thousands(char sep): separator(sep) {}
+    char do_thousands_sep() const override { return separator; }
+    string_type do_grouping() const override { return "\3"; } // groups of 3 digit
+};
+
 BufferBase::BufferBase(Level level) : should_print_(level <= settings_.log_verbosity) {
     if (!should_print_) return;
+
+    if (settings_.log_thousands_sep != 0) {
+        ss_.imbue(std::locale(ss_.getloc(), new separate_thousands(settings_.log_thousands_sep)));
+    }
 
     auto [prefix, color] = get_level_settings(level);
 

--- a/node/silkworm/common/log.hpp
+++ b/node/silkworm/common/log.hpp
@@ -44,6 +44,7 @@ struct Settings {
     bool log_threads{false};            // Whether to print thread ids in log lines
     Level log_verbosity{Level::kInfo};  // Log verbosity level
     std::string log_file;               // Log to file
+    char log_thousands_sep{0};          // Thousands separator
 };
 
 //! \brief Initializes logging facilities


### PR DESCRIPTION
Debugging the downloader requires the analysis of hundreds of thousands of lines of code. Also numbers with many digits, for example block numbers, are difficult to understand at first glance.

Having thousands separator when logging big numbers improves log lines readability a lot.
This PR add a parameter in the log settings to specify a thousands separator.

For example in the downloader, this log line:

`INFO [02-14|20:18:32.143 UTC] [140737348180608] [1/16 Headers] Wrote block headers number=14206352 (+142789), 1890 headers/secs, 1 wait.msgs, 19742 links, 32 anchors [headers: req=16000262 rec=16001437 (100%) -> acc=14206696`

become

`INFO [02-14|20:18:32.143 UTC] [140'737'348'180'608] [1/16 Headers] Wrote block headers number=14'206'352 (+142'789), 1'890  headers/secs, 1 wait.msgs, 19'742 links, 32 anchors [headers: req=16'000'262 rec=16'001'437 (100%) -> acc=14'206'696`

I need to use it at least for debugging and log analysis.