### PR TITLE
Improving downloader performances

### DIFF
--- a/cmd/download_headers.cpp
+++ b/cmd/download_headers.cpp
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
         auto header_processing = std::thread([&header_downloader]() { header_downloader.execution_loop(); });
 
         // Sample stage loop with 1 stage
-        Stage::Result stage_result{Stage::Result::Unknown};
+        Stage::Result stage_result{Stage::Result::Unspecified};
         do {
             if (stage_result.status != Stage::Result::UnwindNeeded) {
                 stage_result = header_downloader.forward(first_sync);

--- a/cmd/download_headers.cpp
+++ b/cmd/download_headers.cpp
@@ -113,8 +113,9 @@ int main(int argc, char* argv[]) {
             if (stage_result.status != Stage::Result::UnwindNeeded) {
                 stage_result = header_downloader.forward(first_sync);
             } else {
-                stage_result = header_downloader.unwind_to(*stage_result.unwind_point, /*bad_block=*/{});
+                stage_result = header_downloader.unwind_to(*stage_result.unwind_point, *stage_result.bad_block);
             }
+            first_sync = false;
         } while (stage_result.status != Stage::Result::Error);
 
         // Wait for user termination request

--- a/node/silkworm/downloader/header_downloader.hpp
+++ b/node/silkworm/downloader/header_downloader.hpp
@@ -33,7 +33,7 @@ namespace silkworm {
 class Stage {
   public:
     struct Result {
-        enum Status { Unknown, Done, DoneAndUpdated, UnwindNeeded, SkipTx, Error } status;
+        enum Status { Unspecified, Done, DoneAndUpdated, UnwindNeeded, SkipTx, Error } status;
         std::optional<BlockNum> current_point;
         std::optional<BlockNum> unwind_point;
         std::optional<Hash> bad_block;

--- a/node/silkworm/downloader/header_downloader.hpp
+++ b/node/silkworm/downloader/header_downloader.hpp
@@ -34,8 +34,9 @@ class Stage {
   public:
     struct Result {
         enum Status { Unknown, Done, DoneAndUpdated, UnwindNeeded, SkipTx, Error } status;
-        std::optional<BlockNum> current_point;  // todo: do we need this?
+        std::optional<BlockNum> current_point;
         std::optional<BlockNum> unwind_point;
+        std::optional<Hash> bad_block;
     };
 
     virtual Result forward(bool first_sync) = 0;

--- a/node/silkworm/downloader/internals/persisted_chain.hpp
+++ b/node/silkworm/downloader/internals/persisted_chain.hpp
@@ -71,10 +71,8 @@ class PersistedChain {
     Db::ReadWriteAccess::Tx& tx_;
     Hash previous_hash_;
     Hash highest_hash_;
-    BlockNum initial_height_{};
-    BlockNum highest_bn_{};
-    // uint64_t highest_timestamp_{};
-    // BlockNum previous_height_{};
+    BlockNum initial_in_db_{};
+    BlockNum highest_in_db_{};
     BigInt local_td_;
     BlockNum unwind_point_{};
     bool unwind_{false};

--- a/node/silkworm/downloader/internals/working_chain.cpp
+++ b/node/silkworm/downloader/internals/working_chain.cpp
@@ -965,7 +965,7 @@ uint64_t WorkingChain::is_valid_request_id(uint64_t request_id) {
 std::ostream& operator<<(std::ostream& os, const WorkingChain::Statistics& stats) {
     uint64_t rejected_headers = stats.received_headers - stats.accepted_headers;
     uint64_t unknown = rejected_headers - stats.not_requested_headers - stats.duplicated_headers - stats.invalid_headers - stats.bad_headers;
-    long perc_received = stats.requested_headers > 0 ? lround(stats.received_headers * 100.0 / stats.requested_headers) : 0;
+    uint64_t perc_received = stats.requested_headers > 0 ? stats.received_headers * 100 / stats.requested_headers : 0;
     long perc_accepted = stats.received_headers > 0 ? lround(stats.accepted_headers * 100.0 / stats.received_headers) : 0;
     long perc_rejected = stats.received_headers > 0 ? lround(rejected_headers * 100.0 / stats.received_headers) : 0;
     os << "headers: "

--- a/node/silkworm/downloader/internals/working_chain.cpp
+++ b/node/silkworm/downloader/internals/working_chain.cpp
@@ -967,7 +967,7 @@ std::ostream& operator<<(std::ostream& os, const WorkingChain::Statistics& stats
     uint64_t unknown = rejected_headers - stats.not_requested_headers - stats.duplicated_headers - stats.invalid_headers - stats.bad_headers;
     uint64_t perc_received = stats.requested_headers > 0 ? stats.received_headers * 100 / stats.requested_headers : 0;
     uint64_t perc_accepted = stats.received_headers > 0 ? stats.accepted_headers * 100 / stats.received_headers : 0;
-    long perc_rejected = stats.received_headers > 0 ? lround(rejected_headers * 100.0 / stats.received_headers) : 0;
+    uint64_t perc_rejected = stats.received_headers > 0 ? rejected_headers * 100 / stats.received_headers : 0;
     os << "headers: "
        << "req=" << stats.requested_headers << " "
        << "rec=" << stats.received_headers << " (" << perc_received << "%) -> "

--- a/node/silkworm/downloader/internals/working_chain.cpp
+++ b/node/silkworm/downloader/internals/working_chain.cpp
@@ -966,7 +966,7 @@ std::ostream& operator<<(std::ostream& os, const WorkingChain::Statistics& stats
     uint64_t rejected_headers = stats.received_headers - stats.accepted_headers;
     uint64_t unknown = rejected_headers - stats.not_requested_headers - stats.duplicated_headers - stats.invalid_headers - stats.bad_headers;
     uint64_t perc_received = stats.requested_headers > 0 ? stats.received_headers * 100 / stats.requested_headers : 0;
-    long perc_accepted = stats.received_headers > 0 ? lround(stats.accepted_headers * 100.0 / stats.received_headers) : 0;
+    uint64_t perc_accepted = stats.received_headers > 0 ? stats.accepted_headers * 100 / stats.received_headers : 0;
     long perc_rejected = stats.received_headers > 0 ? lround(rejected_headers * 100.0 / stats.received_headers) : 0;
     os << "headers: "
        << "req=" << stats.requested_headers << " "

--- a/node/silkworm/downloader/internals/working_chain.hpp
+++ b/node/silkworm/downloader/internals/working_chain.hpp
@@ -17,6 +17,8 @@
 #ifndef SILKWORM_WORKING_CHAIN_HPP
 #define SILKWORM_WORKING_CHAIN_HPP
 
+#include <cstdio>
+
 #include <gsl/span>
 
 #include <silkworm/common/lru_cache.hpp>
@@ -73,14 +75,9 @@ class WorkingChain {
     BlockNum top_seen_block_height() const;
     void top_seen_block_height(BlockNum);
     size_t pending_links() const;
+    size_t anchors() const;
     std::string human_readable_status() const;
     std::string dump_chain_bundles() const;
-
-    // make an anchor collection (skeleton request) or many anchor extension upon the last execution time
-    auto request_headers(time_point_t tp)
-        -> std::tuple<std::vector<GetBlockHeadersPacket66>, std::vector<PeerPenalization>>;
-    // todo: encapsulate the algo that is in OutboundGetBlockHeaders at the moment + decide when to do the skeleton req
-    // notes: for the skeleton req save the time of last skeleton and make sure the next will be issued not before 60s
 
     // core functionalities: anchor collection
     // to collect anchor more quickly we do a skeleton request i.e. a request of many headers equally distributed in a
@@ -172,6 +169,23 @@ class WorkingChain {
 
     uint64_t request_id_prefix;
     uint64_t request_count = 0;
+
+  public:
+    struct Statistics {
+        // headers status
+        uint64_t requested_headers = 0;
+        uint64_t received_headers = 0;
+        uint64_t accepted_headers = 0;
+        // not accepted
+        uint64_t not_requested_headers = 0;
+        uint64_t duplicated_headers = 0;
+        uint64_t invalid_headers = 0;
+        uint64_t bad_headers = 0;
+        // skeleton condition
+        std::string skeleton_condition;
+
+        friend std::ostream& operator<<(std::ostream& os, const WorkingChain::Statistics& stats);
+    } statistics_;
 };
 
 }  // namespace silkworm

--- a/node/silkworm/downloader/messages/InboundBlockHeaders.cpp
+++ b/node/silkworm/downloader/messages/InboundBlockHeaders.cpp
@@ -50,13 +50,6 @@ void InboundBlockHeaders::execute() {
     // Save the headers
     auto [penalty, requestMoreHeaders] = working_chain_.accept_headers(packet_.request, packet_.requestId, peerId_);
 
-    // If the working chain need more headers we issue an header request here (header downloader issues this request
-    // periodically, but it could not be in a forward phase at this moment)
-    if (penalty == Penalty::NoPenalty && requestMoreHeaders) {
-        OutboundGetBlockHeaders message(working_chain_, sentry_, OutboundGetBlockHeaders::Wide_Req);
-        message.execute();
-    }
-
     // Reply
     if (penalty != Penalty::NoPenalty) {
         SILK_TRACE << "Replying to " << identify(*this) << " with penalize_peer";

--- a/node/silkworm/downloader/messages/OutboundGetBlockHeaders.cpp
+++ b/node/silkworm/downloader/messages/OutboundGetBlockHeaders.cpp
@@ -27,7 +27,7 @@ namespace silkworm {
 OutboundGetBlockHeaders::OutboundGetBlockHeaders(WorkingChain& wc, SentryClient& s)
     : working_chain_(wc), sentry_(s) {}
 
-int OutboundGetBlockHeaders::sent_request() {
+int OutboundGetBlockHeaders::sent_request() const {
     return sent_reqs_;
 }
 
@@ -54,14 +54,14 @@ void OutboundGetBlockHeaders::execute() {
             working_chain_.request_nack(*packet);
             break;
         }
-        sent_reqs_++;
+        ++sent_reqs_;
 
         for (auto& penalization : penalizations) {
             SILK_TRACE << "Penalizing " << penalization;
             send_penalization(penalization, 1s);
         }
 
-        max_requests--;
+        --max_requests;
     } while (max_requests > 0);  // && packet != std::nullopt && receiving_peers != nullptr
 
     // anchor collection

--- a/node/silkworm/downloader/messages/OutboundGetBlockHeaders.cpp
+++ b/node/silkworm/downloader/messages/OutboundGetBlockHeaders.cpp
@@ -75,7 +75,9 @@ void OutboundGetBlockHeaders::execute() {
                      << " peer(s)";
     }
 
-    SILK_TRACE << "Sent message " << *this;
+    if (!packets_.empty()) {
+        SILK_TRACE << "Sent message " << *this;
+    }
 }
 
 sentry::SentPeers OutboundGetBlockHeaders::send_packet(const GetBlockHeadersPacket66& packet_, seconds_t timeout) {
@@ -126,7 +128,10 @@ void OutboundGetBlockHeaders::send_penalization(const PeerPenalization& penaliza
 
 std::string OutboundGetBlockHeaders::content() const {
     std::stringstream content;
-    content << "GetBlockHeadersPackets " << packets_;
+    if (!packets_.empty())
+        content << "GetBlockHeadersPackets " << packets_;
+    else
+        content << "-no message-";
     return content.str();
 }
 

--- a/node/silkworm/downloader/messages/OutboundGetBlockHeaders.hpp
+++ b/node/silkworm/downloader/messages/OutboundGetBlockHeaders.hpp
@@ -26,23 +26,23 @@ namespace silkworm {
 
 class OutboundGetBlockHeaders : public OutboundMessage {
   public:
-    enum Breadth {Wide_Req, Narrow_Req};
-
-    OutboundGetBlockHeaders(WorkingChain&, SentryClient&, Breadth b = Wide_Req);
+    OutboundGetBlockHeaders(WorkingChain&, SentryClient&);
 
     std::string name() const override { return "OutboundGetBlockHeaders"; }
     std::string content() const override;
 
     void execute() override;  // headers_forward function in Erigon
 
+    int sent_request();
+
   private:
     sentry::SentPeers send_packet(const GetBlockHeadersPacket66&, seconds_t timeout);
     void send_penalization(const PeerPenalization&, seconds_t timeout);
 
+    int sent_reqs_{0};
     std::string packets_;
     WorkingChain& working_chain_;
     SentryClient& sentry_;
-    Breadth breadth_;
 };
 
 }  // namespace silkworm

--- a/node/silkworm/downloader/messages/OutboundGetBlockHeaders.hpp
+++ b/node/silkworm/downloader/messages/OutboundGetBlockHeaders.hpp
@@ -33,7 +33,7 @@ class OutboundGetBlockHeaders : public OutboundMessage {
 
     void execute() override;  // headers_forward function in Erigon
 
-    int sent_request();
+    int sent_request() const;
 
   private:
     sentry::SentPeers send_packet(const GetBlockHeadersPacket66&, seconds_t timeout);


### PR DESCRIPTION
This PR removes some unneeded limitations so the header request rate is improved a lot. 

Notes:

1. this PR uses dense pre-verified hashes, not the sparse one of the main branch. Initial performance tests have shown that this branch behaves like Erigon. Another branch and PR will be created to compare performances with and without dense pre-verified hashes.

2. the tests of this PR were done with a different version of the db::access_layer, an old version NOT using mdbx_cursor_bind. In a tests spanning three days no errors was raised by mdbx. Differently using the main branch db::access_layer tests breaks frequently with a MDBX_ERROR. I defer to another PR to understand if there is a problem in the downloader, if there is a problem in db::access_layer or in the mdbx implementation. 