### PR TITLE
Don't use default data directory in tests

### DIFF
--- a/node/silkworm/common/directories_test.cpp
+++ b/node/silkworm/common/directories_test.cpp
@@ -24,6 +24,19 @@ namespace silkworm {
 
 TEST_CASE("DataDirectory") {
     {
+        // Open and create a storage path
+        TemporaryDirectory tmp_dir0;
+        DataDirectory data_dir(/*base_path=*/tmp_dir0.path(), /*create=*/true);
+        REQUIRE(data_dir.exists());
+        REQUIRE_NOTHROW(data_dir.deploy());
+        REQUIRE_THROWS(data_dir.clear());
+
+        // Eventually delete the created paths
+        std::filesystem::remove_all(data_dir.path());
+        REQUIRE(data_dir.exists() == false);
+    }
+
+    {
         // Open datadir from current process running path
         DataDirectory data_dir{std::filesystem::path(), false};
         REQUIRE(data_dir.is_pristine() == false);

--- a/node/silkworm/common/directories_test.cpp
+++ b/node/silkworm/common/directories_test.cpp
@@ -24,18 +24,6 @@ namespace silkworm {
 
 TEST_CASE("DataDirectory") {
     {
-        // Open and create default storage path
-        DataDirectory data_dir{/*create = */ true};
-        REQUIRE(data_dir.exists());
-        REQUIRE_NOTHROW(data_dir.deploy());
-        REQUIRE_THROWS(data_dir.clear());
-
-        // Eventually delete the created paths
-        std::filesystem::remove_all(data_dir.path());
-        REQUIRE(data_dir.exists() == false);
-    }
-
-    {
         // Open datadir from current process running path
         DataDirectory data_dir{std::filesystem::path(), false};
         REQUIRE(data_dir.is_pristine() == false);


### PR DESCRIPTION
It's dangerous to tamper with the default data directory (e.g. ~/Library/Silkworm), which could contain your real instance, while running unit tests.