### PR TITLE
Remove batch size from db::Buffer

### DIFF
--- a/node/silkworm/db/buffer.hpp
+++ b/node/silkworm/db/buffer.hpp
@@ -113,12 +113,6 @@ class Buffer : public State {
         return block_storage_changes_;
     }
 
-    //! \brief Approximate size of accrued state in bytes.
-    [[nodiscard]] size_t current_batch_state_size() const noexcept { return batch_state_size_; }
-
-    //! \brief Approximate size of accrued history in bytes.
-    [[nodiscard]] size_t current_batch_history_size() const noexcept { return batch_history_size_; }
-
     //! \brief Persists *all* accrued contents into db
     //! \remarks write_history_to_db is implicitly called
     void write_to_db();
@@ -157,9 +151,6 @@ class Buffer : public State {
     absl::btree_map<uint64_t, StorageChanges> block_storage_changes_;  // per block
     absl::btree_map<Bytes, Bytes> receipts_;
     absl::btree_map<Bytes, Bytes> logs_;
-
-    mutable size_t batch_state_size_{0};    // Accounts in memory data for state
-    mutable size_t batch_history_size_{0};  // Accounts in memory data for history
 
     // Current block stuff
     uint64_t block_number_{0};

--- a/node/silkworm/db/buffer_test.cpp
+++ b/node/silkworm/db/buffer_test.cpp
@@ -50,8 +50,7 @@ TEST_CASE("Storage update") {
     buffer.update_storage(address, kDefaultIncarnation, location_a,
                           /*initial=*/value_a1, /*current=*/value_a2);
 
-    REQUIRE(buffer.storage_changes().empty() == false);
-    REQUIRE(buffer.current_batch_history_size() != 0);
+    REQUIRE(!buffer.storage_changes().empty());
 
     buffer.write_to_db();
 
@@ -135,11 +134,10 @@ TEST_CASE("Account update") {
     }
 
     SECTION("Delete Contract account") {
-
         const auto address{0xbe00000000000000000000000000000000000000_address};
         Account account;
         account.incarnation = kDefaultIncarnation;
-        account.code_hash = to_bytes32(keccak256(address.bytes).bytes); // Just a fake hash
+        account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
 
         Buffer buffer{txn, 0};
         buffer.begin_block(1);
@@ -152,9 +150,7 @@ TEST_CASE("Account update") {
         auto data{incarnations.current()};
         REQUIRE(memcmp(data.key.data(), address.bytes, kAddressLength) == 0);
         REQUIRE(endian::load_big_u64(db::from_slice(data.value).data()) == account.incarnation);
-
     }
-
 }
 
 }  // namespace silkworm::db

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -203,12 +203,10 @@ StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, Blo
 
             // Flush whole buffer if time to
             if (gas_batch_size >= gas_max_batch_size || block_num_ >= max_block_num) {
-                log::Trace("Buffer State", {"size", human_size(buffer.current_batch_state_size())});
                 buffer.write_to_db();
                 break;
             } else if (gas_history_size >= gas_max_history_size) {
                 // or flush history only if needed
-                log::Trace("Buffer History", {"size", human_size(buffer.current_batch_history_size())});
                 buffer.write_history_to_db();
                 gas_history_size = 0;
             }


### PR DESCRIPTION
After PR #571 batch size is used only for trace logging, while adding considerable code complexity.