### PR TITLE
Small fixes

### DIFF
--- a/core/silkworm/common/util.cpp
+++ b/core/silkworm/common/util.cpp
@@ -147,7 +147,7 @@ std::string abridge(std::string_view input, size_t length) {
     if (input.length() <= length) {
         return std::string(input);
     }
-    return std::string(input.substr(0, length)) + "…";
+    return std::string(input.substr(0, length)) + "...";
 }
 
 static inline uint8_t unhex_lut(uint8_t x) { return kUnhexTable[x]; }

--- a/core/silkworm/common/util_test.cpp
+++ b/core/silkworm/common/util_test.cpp
@@ -172,7 +172,7 @@ TEST_CASE("iequals") {
 TEST_CASE("abridge") {
     std::string a{"0x1234567890abcdef"};
     std::string b{abridge(a, 6)};
-    CHECK(b == "0x1234…");
+    CHECK(b == "0x1234...");
     b = abridge(a, a.length() + 1);
     CHECK(b == a);
 }

--- a/node/silkworm/common/stopwatch.cpp
+++ b/node/silkworm/common/stopwatch.cpp
@@ -81,13 +81,7 @@ void StopWatch::reset() noexcept {
 std::string StopWatch::format(Duration duration) noexcept {
     using namespace std::chrono_literals;
     using days = std::chrono::duration<int, std::ratio<86400>>;
-    //    auto d = std::chrono::duration_cast<days>(duration);
-    //    duration -= d;
-    //    auto h = std::chrono::duration_cast<std::chrono::hours>(duration);
-    //    duration -= h;
-    //    auto m = std::chrono::duration_cast<std::chrono::minutes>(duration);
-    //    duration -= m;
-
+    
     std::ostringstream os;
     char fill = os.fill('0');
 

--- a/node/silkworm/common/stopwatch.cpp
+++ b/node/silkworm/common/stopwatch.cpp
@@ -81,26 +81,36 @@ void StopWatch::reset() noexcept {
 std::string StopWatch::format(Duration duration) noexcept {
     using namespace std::chrono_literals;
     using days = std::chrono::duration<int, std::ratio<86400>>;
-    auto d = std::chrono::duration_cast<days>(duration);
-    duration -= d;
-    auto h = std::chrono::duration_cast<std::chrono::hours>(duration);
-    duration -= h;
-    auto m = std::chrono::duration_cast<std::chrono::minutes>(duration);
-    duration -= m;
+    //    auto d = std::chrono::duration_cast<days>(duration);
+    //    duration -= d;
+    //    auto h = std::chrono::duration_cast<std::chrono::hours>(duration);
+    //    duration -= h;
+    //    auto m = std::chrono::duration_cast<std::chrono::minutes>(duration);
+    //    duration -= m;
 
     std::ostringstream os;
     char fill = os.fill('0');
 
-    if (d.count() || h.count() || m.count()) {
-        if (d.count()) {
-            os << d.count() << "d ";
+    if (duration >= 60s) {
+        bool need_space{false};
+        if (auto d = std::chrono::duration_cast<days>(duration); d.count()) {
+            os << d.count() << "d";
+            duration -= d;
+            need_space = true;
         }
-        if (d.count() || h.count()) {
-            os << std::setw(d.count() ? 2 : 1) << h.count() << "h ";
+        if (auto h = std::chrono::duration_cast<std::chrono::hours>(duration); h.count()) {
+            os << (need_space ? " " : "") << h.count() << "h";
+            duration -= h;
+            need_space = true;
         }
-        os << std::setw(d.count() || h.count() ? 2 : 1) << m.count() << "m ";
-        auto s = std::chrono::duration_cast<std::chrono::seconds>(duration);
-        os << std::setw(2) << s.count() << "s";
+        if (auto m = std::chrono::duration_cast<std::chrono::minutes>(duration); m.count()) {
+            os << (need_space ? " " : "") << m.count() << "m";
+            duration -= m;
+            need_space = true;
+        }
+        if (auto s = std::chrono::duration_cast<std::chrono::seconds>(duration); s.count()) {
+            os << (need_space ? " " : "") << s.count() << "s";
+        }
     } else {
         if (duration >= 1s) {
             auto s = std::chrono::duration_cast<std::chrono::seconds>(duration);

--- a/node/silkworm/common/stopwatch.cpp
+++ b/node/silkworm/common/stopwatch.cpp
@@ -79,6 +79,7 @@ void StopWatch::reset() noexcept {
 }
 
 std::string StopWatch::format(Duration duration) noexcept {
+    using namespace std::chrono_literals;
     using days = std::chrono::duration<int, std::ratio<86400>>;
     auto d = std::chrono::duration_cast<days>(duration);
     duration -= d;
@@ -86,47 +87,46 @@ std::string StopWatch::format(Duration duration) noexcept {
     duration -= h;
     auto m = std::chrono::duration_cast<std::chrono::minutes>(duration);
     duration -= m;
-    auto s = std::chrono::duration_cast<std::chrono::seconds>(duration);
-    duration -= s;
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
-    duration -= ms;
-    auto us = std::chrono::duration_cast<std::chrono::microseconds>(duration);
-    duration -= us;
 
     std::ostringstream os;
-    if (d.count()) {
-        os << d.count() << "d";
-        if (h.count() || m.count() || s.count()) {
-            os << " ";
+    char fill = os.fill('0');
+
+    if (d.count() || h.count() || m.count()) {
+        if (d.count()) {
+            os << d.count() << "d ";
         }
-    }
-    if (h.count()) {
-        os << h.count() << "h";
-        if (m.count() || s.count()) {
-            os << " ";
+        if (d.count() || h.count()) {
+            os << std::setw(d.count() ? 2 : 1) << h.count() << "h ";
         }
-    }
-    if (m.count()) {
-        os << m.count() << "m";
-        if (s.count() || ms.count()) {
-            os << " ";
-        }
-    }
-    if (s.count()) {
-        os << s.count() << "s";
-    }
-    if (!(d.count() || h.count() || m.count()) && (ms.count() || us.count())) {
-        if (s.count()) {
-            os << " ";
-        }
-        if (ms.count()) {
-            os << ms.count() << "ms" << (us.count() ? " " : "");
-        }
-        if (us.count()) {
-            os << us.count() << "μs";
+        os << std::setw(d.count() || h.count() ? 2 : 1) << m.count() << "m ";
+        auto s = std::chrono::duration_cast<std::chrono::seconds>(duration);
+        os << std::setw(2) << s.count() << "s";
+    } else {
+        if (duration >= 1s) {
+            auto s = std::chrono::duration_cast<std::chrono::seconds>(duration);
+            duration -= s;
+            auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+            os << s.count();
+            if (ms.count()) {
+                os << "." << std::setw(3) << ms.count();
+            }
+            os << "s";
+        } else if (duration >= 1ms) {
+            auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+            duration -= ms;
+            auto us = std::chrono::duration_cast<std::chrono::microseconds>(duration);
+            os << ms.count();
+            if (us.count()) {
+                os << "." << std::setw(3) << us.count();
+            }
+            os << "ms";
+        } else if (duration >= 1us) {
+            auto us = std::chrono::duration_cast<std::chrono::microseconds>(duration);
+            os << us.count() << "us";
         }
     }
 
+    os.fill(fill);
     return os.str();
 }
 }  // namespace silkworm

--- a/node/silkworm/common/stopwatch.cpp
+++ b/node/silkworm/common/stopwatch.cpp
@@ -81,7 +81,7 @@ void StopWatch::reset() noexcept {
 std::string StopWatch::format(Duration duration) noexcept {
     using namespace std::chrono_literals;
     using days = std::chrono::duration<int, std::ratio<86400>>;
-    
+
     std::ostringstream os;
     char fill = os.fill('0');
 

--- a/node/silkworm/common/stopwatch_test.cpp
+++ b/node/silkworm/common/stopwatch_test.cpp
@@ -56,9 +56,9 @@ TEST_CASE("Stop Watch") {
     CHECK(sw1.format(918734032564785ns) == "10d 15h 12m 14s");
     CHECK(sw1.format(432034ms) == "7m 12s");
     CHECK(sw1.format(1ms) == "1ms");
-    CHECK(sw1.format(1200ms) == "1s 200ms");
-    CHECK(sw1.format(1010us) == "1ms 10μs");
-    CHECK(sw1.format(20us) == "20μs");
+    CHECK(sw1.format(1200ms) == "1.200s");
+    CHECK(sw1.format(1010us) == "1.010ms");
+    CHECK(sw1.format(20us) == "20us");
 
     (void)sw1.stop();
     (void)sw1.start(/*with_reset=*/true);

--- a/node/silkworm/common/stopwatch_test.cpp
+++ b/node/silkworm/common/stopwatch_test.cpp
@@ -24,8 +24,12 @@ namespace silkworm {
 
 TEST_CASE("Stop Watch") {
     using namespace std::chrono_literals;
+
+    silkworm::StopWatch sw_autostart(true);
+    REQUIRE(sw_autostart); // Must be started
+
     silkworm::StopWatch sw1{};
-    CHECK_FALSE(sw1);  // Not started
+    REQUIRE(sw1);  // Not started
 
     auto [lap_time0, duration0] = sw1.lap();
     CHECK(duration0.count() == 0);

--- a/node/silkworm/common/stopwatch_test.cpp
+++ b/node/silkworm/common/stopwatch_test.cpp
@@ -26,10 +26,10 @@ TEST_CASE("Stop Watch") {
     using namespace std::chrono_literals;
 
     silkworm::StopWatch sw_autostart(true);
-    REQUIRE(sw_autostart); // Must be started
+    REQUIRE(sw_autostart);  // Must be started
 
     silkworm::StopWatch sw1{};
-    REQUIRE(sw1);  // Not started
+    REQUIRE(!sw1);  // Not started
 
     auto [lap_time0, duration0] = sw1.lap();
     CHECK(duration0.count() == 0);
@@ -57,8 +57,10 @@ TEST_CASE("Stop Watch") {
     }
 
     CHECK(!sw1.format(duration3).empty());
-    CHECK(sw1.format(918734032564785ns) == "10d 15h 12m 14s");
-    CHECK(sw1.format(432034ms) == "7m 12s");
+    CHECK(sw1.format(255h + 12min + 14s) == "10d 15h 12m 14s");
+    CHECK(sw1.format(240h) == "10d");
+    CHECK(sw1.format(240h + 14s) == "10d 14s");
+    CHECK(sw1.format(7min + 12s + 120ms) == "7m 12s");
     CHECK(sw1.format(1ms) == "1ms");
     CHECK(sw1.format(1200ms) == "1.200s");
     CHECK(sw1.format(1010us) == "1.010ms");
@@ -74,7 +76,6 @@ TEST_CASE("Stop Watch") {
     sw1.reset();
     CHECK(sw1.laps().empty());  // No more laps
     CHECK_FALSE(sw1);           // Not started
-
 }
 
 }  // namespace silkworm

--- a/node/silkworm/etl/collector.hpp
+++ b/node/silkworm/etl/collector.hpp
@@ -76,7 +76,7 @@ class Collector {
 
     //! \brief Returns the hex representation of current load key (for progress tracking)
     [[nodiscard]] std::string get_load_key() const {
-        std::unique_lock l{mutex_};
+        std::atomic_thread_fence(std::memory_order_acquire);
         return loading_key_;
     }
 
@@ -86,8 +86,8 @@ class Collector {
     void flush_buffer();  // Write buffer to file
 
     void set_loading_key(ByteView key) {
-        std::unique_lock l{mutex_};
         loading_key_ = to_hex(key, true);
+        std::atomic_thread_fence(std::memory_order_release);
     }
 
     bool work_path_managed_;
@@ -109,7 +109,6 @@ class Collector {
 
     std::vector<std::unique_ptr<FileProvider>> file_providers_;  // Collection of file providers
     size_t size_{0};                                             // Total collected size
-    mutable std::mutex mutex_{};                                 // To sync loading_key_
     std::string loading_key_{};                                  // Actual load key (for log purposes)
 };
 

--- a/node/silkworm/etl/collector.hpp
+++ b/node/silkworm/etl/collector.hpp
@@ -76,7 +76,7 @@ class Collector {
 
     //! \brief Returns the hex representation of current load key (for progress tracking)
     [[nodiscard]] std::string get_load_key() const {
-        std::atomic_thread_fence(std::memory_order_acquire);
+        std::unique_lock l{mutex_};
         return loading_key_;
     }
 
@@ -86,8 +86,8 @@ class Collector {
     void flush_buffer();  // Write buffer to file
 
     void set_loading_key(ByteView key) {
+        std::unique_lock l{mutex_};
         loading_key_ = to_hex(key, true);
-        std::atomic_thread_fence(std::memory_order_release);
     }
 
     bool work_path_managed_;
@@ -109,6 +109,7 @@ class Collector {
 
     std::vector<std::unique_ptr<FileProvider>> file_providers_;  // Collection of file providers
     size_t size_{0};                                             // Total collected size
+    mutable std::mutex mutex_{};                                 // To sync loading_key_
     std::string loading_key_{};                                  // Actual load key (for log purposes)
 };
 

--- a/node/silkworm/stagedsync/stagedsync.hpp
+++ b/node/silkworm/stagedsync/stagedsync.hpp
@@ -157,8 +157,9 @@ class HashState final : public IStage {
     void reset_log_progress();
 
     // Logger info
-    std::atomic_bool incremental_{false};        // Whether operation is incremental
-    std::atomic_bool loading_{false};            // Whether we're in ETL loading phase
+    std::mutex log_mtx_{};                       // Guards access for async logger
+    bool incremental_{false};                    // Whether operation is incremental
+    bool loading_{false};                        // Whether we're in ETL loading phase
     std::string current_source_;                 // Current source of data
     std::string current_target_;                 // Current target of transformed data
     std::string current_key_;                    // Actual processing key


### PR DESCRIPTION
Minor fixes

- lock guard all HashState stats access
- remove UTF-8 ellipsis from abridged text and replace with triple ASCII dot
- better duration formatting : for durations >= 1 minute we get a formatting like `[xd] [xxh] [xxm] [xxs]`; for durations < 1m we get seconds (or lower milliseconds or microseconds) with a precision of three digits. Examples (from tests) :
```
    CHECK(sw1.format(255h + 12min + 14s) == "10d 15h 12m 14s");
    CHECK(sw1.format(240h) == "10d");
    CHECK(sw1.format(240h + 14s) == "10d 14s");
    CHECK(sw1.format(7min + 12s + 120ms) == "7m 12s");
    CHECK(sw1.format(1ms) == "1ms");
    CHECK(sw1.format(1200ms) == "1.200s");
    CHECK(sw1.format(1010us) == "1.010ms");
    CHECK(sw1.format(20us) == "20us");
```