### PR TITLE
Avoid memory leaks detected by LeakSanitizer

### DIFF
--- a/node/silkworm/db/prune_mode.cpp
+++ b/node/silkworm/db/prune_mode.cpp
@@ -210,8 +210,7 @@ std::unique_ptr<PruneMode> parse_prune_mode(const std::string& mode, const Prune
     if (!tx_index) tx_index = std::make_unique<BlockAmount>();
     if (!call_traces) call_traces = std::make_unique<BlockAmount>();
 
-    return std::make_unique<PruneMode>(*history.release(), *receipts.release(), *senders.release(), *tx_index.release(),
-                                       *call_traces.release());
+    return std::make_unique<PruneMode>(*history, *receipts, *senders, *tx_index, *call_traces);
 }
 
 }  // namespace silkworm::db

--- a/node/silkworm/db/prune_mode.hpp
+++ b/node/silkworm/db/prune_mode.hpp
@@ -67,8 +67,8 @@ class BlockAmount {
 class PruneMode {
   public:
     explicit PruneMode() : history_(), receipts_(), tx_index_(), call_traces_(){};
-    explicit PruneMode(BlockAmount& history, BlockAmount& receipts, BlockAmount& senders, BlockAmount& tx_index,
-                       BlockAmount& call_traces)
+    explicit PruneMode(BlockAmount history, BlockAmount receipts, BlockAmount senders, BlockAmount tx_index,
+                       BlockAmount call_traces)
         : history_{std::move(history)},
           receipts_{std::move(receipts)},
           senders_{std::move(senders)},


### PR DESCRIPTION
Fixes Silkworm part of #575 

Rationale: `BlockAmount` is cheap to copy, so we can pass by value and avoid memory leak detected by LeakSanitizer