### PR TITLE
Add instrumentation and CI jobs for sanitized builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       TOOLCHAIN: cxx17.cmake
       CLANG_COVERAGE: OFF
       SANITIZE: thread
-    machine:
+    docker:
       image: ethereum/cpp-build-env:17-gcc-11
     resource_class: xlarge
     steps:
@@ -216,7 +216,7 @@ workflows:
   silkworm:
     jobs:
       - linux-gcc-9
-      - linux-gcc-11-sanitizers
+      - linux-gcc-9-sanitizers
       - linux-gcc-11-cpp20
       - linux-clang-10-coverage
       - linux-clang-10-sanitizers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ workflows:
   silkworm:
     jobs:
       - linux-gcc-9
-      - linux-gcc-9-sanitizers
+      - linux-gcc-11-sanitizers
       - linux-gcc-11-cpp20
       - linux-clang-10-coverage
       - linux-clang-10-sanitizers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - build
       - test
 
-  linux-gcc-11-sanitizers:
+  linux-gcc-11-thread-sanitizer:
     environment:
       BUILD_TYPE: Debug
       TOOLCHAIN: cxx17.cmake
@@ -105,7 +105,7 @@ jobs:
       - build
       - test
 
-  linux-clang-10-sanitizers:
+  linux-clang-10-address-sanitizer:
     environment:
       BUILD_TYPE: Debug
       TOOLCHAIN: cxx17.cmake
@@ -216,8 +216,8 @@ workflows:
   silkworm:
     jobs:
       - linux-gcc-9
-      - linux-gcc-11-sanitizers
+      - linux-gcc-11-thread-sanitizer
       - linux-gcc-11-cpp20
       - linux-clang-10-coverage
-      - linux-clang-10-sanitizers
+      - linux-clang-10-address-sanitizer
       - linux-wasm-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       CLANG_COVERAGE: OFF
       SANITIZE: thread
     docker:
-      image: ethereum/cpp-build-env:17-gcc-11
+      - image: ethereum/cpp-build-env:17-gcc-11
     resource_class: xlarge
     steps:
       - checkout_with_submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
       - run:
           name: "Cmake"
           working_directory: ~/build
-          command: cmake ../project -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$HOME/project/cmake/toolchain/$TOOLCHAIN -DSILKWORM_CLANG_COVERAGE=$CLANG_COVERAGE
+          command: cmake ../project -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$HOME/project/cmake/toolchain/$TOOLCHAIN -DSILKWORM_CLANG_COVERAGE=$CLANG_COVERAGE -DSILKWORM_SANITIZE=$SANITIZE
       - save_cache:
           name: "Save Hunter cache"
           key: *hunter-cache-key
@@ -68,8 +68,23 @@ jobs:
       BUILD_TYPE: Release
       TOOLCHAIN: cxx17.cmake
       CLANG_COVERAGE: OFF
+      SANITIZE: OFF
     machine:
       image: ubuntu-2004:202010-01
+    resource_class: xlarge
+    steps:
+      - checkout_with_submodules
+      - build
+      - test
+
+  linux-gcc-11-sanitizers:
+    environment:
+      BUILD_TYPE: Debug
+      TOOLCHAIN: cxx17.cmake
+      CLANG_COVERAGE: OFF
+      SANITIZE: thread
+    machine:
+      image: ethereum/cpp-build-env:17-gcc-11
     resource_class: xlarge
     steps:
       - checkout_with_submodules
@@ -81,6 +96,7 @@ jobs:
       BUILD_TYPE: Debug
       TOOLCHAIN: cxx20.cmake
       CLANG_COVERAGE: OFF
+      SANITIZE: OFF
     docker:
       - image: ethereum/cpp-build-env:17-gcc-11
     resource_class: xlarge
@@ -89,11 +105,26 @@ jobs:
       - build
       - test
 
-  linux-clang-coverage:
+  linux-clang-10-sanitizers:
+    environment:
+      BUILD_TYPE: Debug
+      TOOLCHAIN: cxx17.cmake
+      CLANG_COVERAGE: OFF
+      SANITIZE: address
+    docker:
+      - image: ethereum/cpp-build-env:14-clang-10
+    resource_class: xlarge
+    steps:
+      - checkout_with_submodules
+      - build
+      - test
+
+  linux-clang-10-coverage:
     environment:
       BUILD_TYPE: Debug
       TOOLCHAIN: cxx17.cmake
       CLANG_COVERAGE: ON
+      SANITIZE: OFF
     docker:
       - image: ethereum/cpp-build-env:14-clang-10
     resource_class: xlarge
@@ -185,6 +216,8 @@ workflows:
   silkworm:
     jobs:
       - linux-gcc-9
+      - linux-gcc-11-sanitizers
       - linux-gcc-11-cpp20
-      - linux-clang-coverage
+      - linux-clang-10-coverage
+      - linux-clang-10-sanitizers
       - linux-wasm-build

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build
+build*
 xcode
 *.code-workspace
 .idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ cable_add_buildinfo_library(PROJECT_NAME ${PROJECT_NAME})
 option(SILKWORM_WASM_API "Build WebAssembly API" OFF)
 option(SILKWORM_CORE_ONLY "Only build Silkworm Core" OFF)
 option(SILKWORM_CLANG_COVERAGE "Clang instrumentation for code coverage reports" OFF)
+option(SILKWORM_SANITIZE "Build instrumentation for sanitizers" OFF)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler_settings.cmake)
 

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -69,6 +69,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
+  if(SILKWORM_SANITIZE)
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
+    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
+  endif()
+
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-g1)
   endif()
@@ -78,6 +83,11 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+  endif()
+
+  if(SILKWORM_SANITIZE)
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
+    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
This PR adds:
- instrumentation for running AddressSanitizer (ASAN) and ThreadSanitizer (TSAN) on Clang/GCC builds
- CI jobs with ASAN/TSAN enabled

See #295