### PR TITLE
Fix core_test on Windows

### DIFF
--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -199,11 +199,14 @@ static DecodingResult from_big_compact(ByteView data, UnsignedInteger& out) {
         return DecodingResult::kOverflow;
     }
 
-    if (!data.empty() && data[0] == 0) {
-        return DecodingResult::kLeadingZero;
+    out = 0;
+    if (data.empty()) {
+        return DecodingResult::kOk;
     }
 
-    out = 0;
+    if (data[0] == 0) {
+        return DecodingResult::kLeadingZero;
+    }
 
     auto* ptr{reinterpret_cast<uint8_t*>(&out)};
     std::memcpy(ptr + (sizeof(UnsignedInteger) - data.length()), &data[0], data.length());


### PR DESCRIPTION
This reverts a small part of PR #582 which somehow causes `core_test` to [hang](https://ci.appveyor.com/project/torquem/silkworm/builds/42721668) in Windows CI.