### PR TITLE
[WIP] Small clean-ups

### DIFF
--- a/cmd/consensus.cpp
+++ b/cmd/consensus.cpp
@@ -60,9 +60,9 @@ static const std::vector<fs::path> kSlowTests{
 };
 
 static const std::vector<fs::path> kFailingTests{
-    // Gas limit >= 2^64 is not supported; see EIP-1985.
+    // Gas limit >= 2^64 is not supported; see EIP-4803.
     // Geth excludes this test as well:
-    // https://github.com/ethereum/go-ethereum/blob/v1.9.25/tests/transaction_test.go#L31
+    // https://github.com/ethereum/go-ethereum/blob/v1.10.16/tests/transaction_test.go#L35
     kTransactionDir / "ttGasLimit" / "TransactionWithGasLimitxPriceOverflow.json",
 };
 

--- a/core/silkworm/chain/protocol_param.hpp
+++ b/core/silkworm/chain/protocol_param.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -52,8 +52,10 @@ namespace fee {
 
 namespace param {
 
-    // https://eips.ethereum.org/EIPS/eip-170
-    inline constexpr size_t kMaxCodeSize{0x6000};
+    inline constexpr size_t kMaxCodeSize{0x6000};  // EIP-170
+
+    inline constexpr uint64_t kMinGasLimit{5000};
+    inline constexpr uint64_t kMaxGasLimit{INT64_MAX};  // EIP-4803
 
     inline constexpr uint64_t kBlockRewardFrontier{5 * kEther};
     inline constexpr uint64_t kBlockRewardByzantium{3 * kEther};

--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -102,13 +102,7 @@ ValidationResult EngineBase::validate_block_header(const BlockHeader& header, co
         return ValidationResult::kGasAboveLimit;
     }
 
-    if (header.gas_limit < 5000) {
-        return ValidationResult::kInvalidGasLimit;
-    }
-
-    // https://github.com/ethereum/go-ethereum/blob/v1.9.25/consensus/ethash/consensus.go#L267
-    // https://eips.ethereum.org/EIPS/eip-1985
-    if (header.gas_limit > INT64_MAX) {
+    if (header.gas_limit < param::kMinGasLimit || header.gas_limit > param::kMaxGasLimit) {
         return ValidationResult::kInvalidGasLimit;
     }
 

--- a/core/silkworm/crypto/rmd160.cpp
+++ b/core/silkworm/crypto/rmd160.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 namespace silkworm::crypto {
 
-void calculate_ripemd_160(gsl::span<uint8_t, 20> out, ByteView in) noexcept {
+void calculate_ripemd_160(ByteView in, gsl::span<uint8_t, 20> out) noexcept {
     uint32_t buf[160 / 32];
 
     rmd160_init(buf);

--- a/core/silkworm/crypto/rmd160.hpp
+++ b/core/silkworm/crypto/rmd160.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 
 namespace silkworm::crypto {
 
-void calculate_ripemd_160(gsl::span<uint8_t, 20> out, ByteView in) noexcept;
+void calculate_ripemd_160(ByteView in, gsl::span<uint8_t, 20> out) noexcept;
 
 }
 

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -523,7 +523,7 @@ evmc_tx_context EvmHost::get_tx_context() const noexcept {
     context.block_number = static_cast<int64_t>(header.number);
     assert(header.timestamp <= INT64_MAX);  // EIP-1985
     context.block_timestamp = static_cast<int64_t>(header.timestamp);
-    assert(header.gas_limit <= INT64_MAX);  // EIP-1985
+    assert(header.gas_limit <= INT64_MAX);  // EIP-4803
     context.block_gas_limit = static_cast<int64_t>(header.gas_limit);
     if (header.difficulty != 0) {
         intx::be::store(context.block_difficulty.bytes, header.difficulty);

--- a/core/silkworm/execution/precompiled.cpp
+++ b/core/silkworm/execution/precompiled.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ uint64_t rip160_gas(ByteView input, evmc_revision) noexcept { return 600 + 120 *
 
 std::optional<Bytes> rip160_run(ByteView input) noexcept {
     Bytes out(32, '\0');
-    crypto::calculate_ripemd_160(gsl::span<uint8_t, 20>{&out[12], 20}, input);
+    crypto::calculate_ripemd_160(input, gsl::span<uint8_t, 20>{&out[12], 20});
     return out;
 }
 

--- a/node/silkworm/downloader/internals/chain_integration_test.cpp
+++ b/node/silkworm/downloader/internals/chain_integration_test.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/chain/difficulty.hpp>
 #include <silkworm/chain/genesis.hpp>
+#include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/cast.hpp>
 #include <silkworm/common/test_context.hpp>
 #include <silkworm/consensus/engine.hpp>
@@ -102,7 +103,7 @@ TEST_CASE("working/persistent-chain integration test") {
         BlockHeader header1b;
         header1b.number = 1;
         header1b.difficulty = 2'000'000;
-        header1b.gas_limit = 5000;
+        header1b.gas_limit = param::kMinGasLimit;
         header1b.parent_hash = header0_hash;
         header1b.extra_data = string_view_to_byte_view("I'm different");
         auto header1b_hash = header1b.hash();


### PR DESCRIPTION
This is a small code clean-up (extract `kMinGasLimit` & `kMaxGasLimit` constants). See also [EIP-4803](https://eips.ethereum.org/EIPS/eip-4803): Limit transaction gas to a maximum of 2^63-1.

Also a small clean-up in `calculate_ripemd_160`: per [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs) out params should come after inputs.