### PR TITLE
Bump stack size for core_test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,9 @@ commands:
       - run:
           name: "Core unit tests"
           working_directory: ~/build
-          command: cmd/core_test
+          command: |
+            ulimit -s unlimited
+            cmd/core_test
       - run:
           name: "Node unit tests"
           working_directory: ~/build
@@ -117,9 +119,6 @@ jobs:
     steps:
       - checkout_with_submodules
       - build
-      - run:
-          name: "Set unlimited stack size"
-          command: ulimit -s unlimited
       - test
 
   linux-clang-10-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-#   Copyright 2020-2021 The Silkworm Authors
+#   Copyright 2020-2022 The Silkworm Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -52,9 +52,7 @@ commands:
       - run:
           name: "Core unit tests"
           working_directory: ~/build
-          command: |
-            ulimit -s unlimited
-            cmd/core_test
+          command: cmd/core_test
       - run:
           name: "Node unit tests"
           working_directory: ~/build
@@ -119,6 +117,9 @@ jobs:
     steps:
       - checkout_with_submodules
       - build
+      - run:
+          name: "Set unlimited stack size"
+          command: ulimit -s unlimited
       - test
 
   linux-clang-10-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,9 @@ commands:
       - run:
           name: "Core unit tests"
           working_directory: ~/build
-          command: cmd/core_test
+          command: |
+            ulimit -s unlimited
+            cmd/core_test
       - run:
           name: "Node unit tests"
           working_directory: ~/build

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -20,9 +20,9 @@ if(MSVC)
   add_link_options(/STACK:0x1000000)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_link_options(-Wl,-stack_size -Wl,0x1000000)
+else()
+  add_link_options(-Wl,-z,stack-size=16777216)
 endif()
-# -Wl,-z,stack-size=16777216 doesn't seem to work on Linux; use instead
-# ulimit -s unlimited
 
 file(GLOB_RECURSE SILKWORM_CORE_TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/core/silkworm/*_test.cpp")
 add_executable(core_test unit_test.cpp ${SILKWORM_CORE_TESTS})

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -20,9 +20,9 @@ if(MSVC)
   add_link_options(/STACK:0x1000000)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_link_options(-Wl,-stack_size -Wl,0x1000000)
-else()
-  add_link_options(-Wl,-z,stack-size=50000000)
 endif()
+# -Wl,-z,stack-size=16777216 doesn't seem to work on Linux; use instead
+# ulimit -s unlimited
 
 file(GLOB_RECURSE SILKWORM_CORE_TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/core/silkworm/*_test.cpp")
 add_executable(core_test unit_test.cpp ${SILKWORM_CORE_TESTS})

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -21,7 +21,7 @@ if(MSVC)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_link_options(-Wl,-stack_size -Wl,0x1000000)
 else()
-  add_link_options(-Wl,-z,stack-size=10000000)
+  add_link_options(-Wl,-z,stack-size=50000000)
 endif()
 
 file(GLOB_RECURSE SILKWORM_CORE_TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/core/silkworm/*_test.cpp")


### PR DESCRIPTION
This fixes the [failure](https://app.circleci.com/pipelines/github/torquem-ch/silkworm/4002/workflows/38ce7a1c-651e-4698-bf22-c60ebcda3be0/jobs/11587) of linux-clang-10-address-sanitizer in `core_test`. Now it [fails](https://app.circleci.com/pipelines/github/torquem-ch/silkworm/4009/workflows/ce454612-f8ca-4dda-b975-049a2377dc8a/jobs/11630) in `node_test` due to Issue #575.