### PR TITLE
Enable consensus tests under thread sanitizer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ commands:
       - run:
           name: "Ethereum consensus tests"
           working_directory: ~/build
+          no_output_timeout: 20m
           command: cmd/test/consensus --threads 4 # out of memory with 8 threads under linux-gcc-11-thread-sanitizer 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       SANITIZE: thread
     docker:
       - image: ethereum/cpp-build-env:17-gcc-11
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - checkout_with_submodules
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,7 @@ commands:
       - run:
           name: "Ethereum consensus tests"
           working_directory: ~/build
-          command: |
-            ulimit -s unlimited
-            cmd/test/consensus --threads 2
+          command: cmd/test/consensus --threads 4 # out of memory with 8 threads under linux-gcc-11-thread-sanitizer 
 
 jobs:
   linux-gcc-9:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,16 +93,7 @@ jobs:
     steps:
       - checkout_with_submodules
       - build
-      - run:
-          name: "Core unit tests"
-          working_directory: ~/build
-          command: |
-            ulimit -s unlimited
-            cmd/test/core_test
-      - run:
-          name: "Node unit tests"
-          working_directory: ~/build
-          command: cmd/test/node_test
+      - test
 
   linux-gcc-11-cpp20:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
           working_directory: ~/build
           command: |
             ulimit -s unlimited
-            cmd/test/consensus
+            cmd/test/consensus --threads 2
 
 jobs:
   linux-gcc-9:
@@ -89,7 +89,7 @@ jobs:
       SANITIZE: thread
     docker:
       - image: ethereum/cpp-build-env:17-gcc-11
-    resource_class: 2xlarge
+    resource_class: xlarge
     steps:
       - checkout_with_submodules
       - build

--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -704,7 +704,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    size_t stack_size{128 * kMebi};
+    size_t stack_size{40 * kMebi};
 #ifdef NDEBUG
     stack_size = 16 * kMebi;
 #endif

--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -702,7 +702,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    size_t stack_size{40 * kMebi};
+    size_t stack_size{80 * kMebi};
 #ifdef NDEBUG
     stack_size = 16 * kMebi;
 #endif

--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -510,6 +510,8 @@ void run_test_file(const fs::path& file_path, RunnerFunc runner) {
     std::ifstream in{file_path.string()};
     nlohmann::json json;
 
+    std::cout << file_path.string() << std::endl;
+
     try {
         in >> json;
     } catch (nlohmann::detail::parse_error& e) {
@@ -702,7 +704,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    size_t stack_size{80 * kMebi};
+    size_t stack_size{128 * kMebi};
 #ifdef NDEBUG
     stack_size = 16 * kMebi;
 #endif

--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -510,8 +510,6 @@ void run_test_file(const fs::path& file_path, RunnerFunc runner) {
     std::ifstream in{file_path.string()};
     nlohmann::json json;
 
-    std::cout << file_path.string() << std::endl;
-
     try {
         in >> json;
     } catch (nlohmann::detail::parse_error& e) {


### PR DESCRIPTION
Previously they were killed probably due to out of memory, so I reduced the number of threads to 4 ([xlarge](https://circleci.com/docs/2.0/configuration-reference/?utm_source=google&utm_medium=sem&utm_campaign=sem-google-dg--emea-en-dsa-maxConv-auth-brand&utm_term=g_-_c__dsa_&utm_content=&gclid=Cj0KCQiAmpyRBhC-ARIsABs2EAocMlkHTx5LIFPhLdyjLiHjVG1JdcweZ3tBqKRYj0ZSa2zaxV8B0xYaAshSEALw_wcB#machine-executor-linux) resource_class in CircleCI has 8 CPUs).