### PR TITLE
Reuse cursors - 2

### DIFF
--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -104,6 +104,8 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
                  "Chaindata database opened in exclusive mode");
     cli.add_flag("--chaindata.readahead", node_settings.chaindata_env_config.read_ahead,
                  "Chaindata database enable readahead");
+    cli.add_flag("--chaindata.writemap", node_settings.chaindata_env_config.write_map,
+                 "Chaindata database enable writemap");
     cli.add_option("--chaindata.growthsize", chaindata_growth_size, "Chaindata database growth size", true)
         ->check(HumanSizeParserValidator("64MB"));
     cli.add_option("--chaindata.maxsize", chaindata_max_size, "Chaindata database max size", true)

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -149,6 +149,9 @@ namespace detail {
 }
 
 ::mdbx::map_handle open_map(::mdbx::txn& tx, const MapConfig& config) {
+    if (tx.is_readonly()) {
+        return tx.open_map(config.name, config.key_mode, config.value_mode);
+    }
     return tx.create_map(config.name, config.key_mode, config.value_mode);
 }
 

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -103,6 +103,9 @@ namespace detail {
     if (config.shared) {
         flags |= MDBX_ACCEDE;
     }
+    if (config.write_map) {
+        flags |= MDBX_WRITEMAP;
+    }
 
     ::mdbx::env_managed::create_parameters cp{};  // Default create parameters
     if (!config.shared) {

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -153,6 +153,8 @@ namespace detail {
     return tx.open_cursor(open_map(tx, config));
 }
 
+thread_local ObjectPool<MDBX_cursor, detail::cursor_handle_deleter> Cursor::handles_pool_{};
+
 Cursor::Cursor(::mdbx::txn& txn, const MapConfig& config) {
     handle_ = handles_pool_.acquire();
     if (!handle_) {
@@ -184,7 +186,8 @@ void Cursor::bind(::mdbx::txn& txn, const MapConfig& config) {
             handle_ = ::mdbx_cursor_create(nullptr);
         }
     }
-    ::mdbx::cursor::bind(txn, open_map(txn, config));
+    const auto map{open_map(txn, config)};
+    ::mdbx::cursor::bind(txn, map);
 }
 
 void Cursor::close() {

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -108,6 +108,7 @@ struct EnvConfig {
     bool inmemory{false};        // Whether this db is in memory
     bool shared{false};          // Whether this process opens a db already opened by another process
     bool read_ahead{false};      // Whether to enable mdbx read ahead
+    bool write_map{false};       // Whether to enable mdbx write map
     size_t max_size{3_Tebi};     // Max mdbx map size
     size_t growth_size{2_Gibi};  // Increment size for each extension
     uint32_t max_tables{128};    // Default max number of named tables

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -146,6 +146,7 @@ struct MapConfig {
 class Cursor : public ::mdbx::cursor {
   public:
     explicit Cursor(::mdbx::txn& txn, const MapConfig& config);
+    explicit Cursor(RWTxn& txn, const MapConfig& config) : Cursor(*txn, config){};
     ~Cursor();
 
     Cursor(Cursor&& other) noexcept;
@@ -156,6 +157,9 @@ class Cursor : public ::mdbx::cursor {
 
     //! \brief (re)uses current cursor binding it to provided transaction and map
     void bind(::mdbx::txn& tx, const MapConfig& config);
+    
+    //! \brief (re)uses current cursor binding it to provided transaction and map
+    void bind(RWTxn& tx, const MapConfig& config) { bind(*tx, config); }
 
     //! \brief Closes cursor causing de-allocation of MDBX_cursor handle
     //! \remarks After this call the cursor is not reusable and the handle does not return to the cache

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -167,7 +167,7 @@ class Cursor : public ::mdbx::cursor {
     static const ObjectPool<MDBX_cursor, detail::cursor_handle_deleter>& handles_cache() { return handles_pool_; }
 
   private:
-    static inline thread_local ObjectPool<MDBX_cursor, detail::cursor_handle_deleter> handles_pool_{};
+    static thread_local ObjectPool<MDBX_cursor, detail::cursor_handle_deleter> handles_pool_;
 };
 
 //! \brief Checks whether a provided map name exists in database

--- a/node/silkworm/db/stages.cpp
+++ b/node/silkworm/db/stages.cpp
@@ -20,7 +20,7 @@
 
 namespace silkworm::db::stages {
 
-static uint64_t get_stage_data(mdbx::txn& txn, const char* stage_name, const db::MapConfig& domain,
+static BlockNum get_stage_data(mdbx::txn& txn, const char* stage_name, const db::MapConfig& domain,
                                const char* key_prefix = nullptr) {
     if (!is_known_stage(stage_name)) {
         throw std::invalid_argument("Unknown stage name " + std::string(stage_name));

--- a/node/silkworm/db/stages.cpp
+++ b/node/silkworm/db/stages.cpp
@@ -20,14 +20,14 @@
 
 namespace silkworm::db::stages {
 
-namespace {
+static uint64_t get_stage_data(mdbx::txn& txn, const char* stage_name, const db::MapConfig& domain,
+                               const char* key_prefix = nullptr) {
+    if (!is_known_stage(stage_name)) {
+        throw std::invalid_argument("Unknown stage name " + std::string(stage_name));
+    }
 
-    uint64_t get_stage_data(mdbx::txn& txn, const char* stage_name, const db::MapConfig& domain,
-                            const char* key_prefix = nullptr) {
-        if (!is_known_stage(stage_name)) {
-            throw std::invalid_argument("Unknown stage name " + std::string(stage_name));
-        }
-        auto src{db::open_cursor(txn, domain)};
+    try {
+        db::Cursor src(txn, domain);
         std::string item_key{stage_name};
         if (key_prefix) {
             item_key.insert(0, std::string(key_prefix));
@@ -39,28 +39,34 @@ namespace {
             throw std::length_error("Expected 8 bytes of data got " + std::to_string(data.value.size()));
         }
         return endian::load_big_u64(static_cast<uint8_t*>(data.value.data()));
+    } catch (const mdbx::exception& ex) {
+        std::string what("Error in " + std::string(__FUNCTION__) + " " + std::string(ex.what()));
+        throw std::runtime_error(what);
+    }
+}
+
+static void set_stage_data(mdbx::txn& txn, const char* stage_name, uint64_t block_num, const db::MapConfig& domain,
+                           const char* key_prefix = nullptr) {
+    if (!is_known_stage(stage_name)) {
+        throw std::invalid_argument("Unknown stage name");
     }
 
-    void set_stage_data(mdbx::txn& txn, const char* stage_name, uint64_t block_num, const db::MapConfig& domain,
-                        const char* key_prefix = nullptr) {
-        if (!is_known_stage(stage_name)) {
-            throw std::invalid_argument("Unknown stage name");
-        }
-
+    try {
         std::string item_key{stage_name};
         if (key_prefix) {
             item_key.insert(0, std::string(key_prefix));
         }
         Bytes stage_progress(sizeof(block_num), 0);
         endian::store_big_u64(stage_progress.data(), block_num);
-        auto tgt{db::open_cursor(txn, domain)};
+        db::Cursor target(txn, domain);
         mdbx::slice key(item_key.c_str());
         mdbx::slice value{db::to_slice(stage_progress)};
-        tgt.upsert(key, value);
-        tgt.close();
+        target.upsert(key, value);
+    } catch (const mdbx::exception& ex) {
+        std::string what("Error in " + std::string(__FUNCTION__) + " " + std::string(ex.what()));
+        throw std::runtime_error(what);
     }
-
-}  // namespace
+}
 
 BlockNum read_stage_progress(mdbx::txn& txn, const char* stage_name) {
     return get_stage_data(txn, stage_name, silkworm::db::table::kSyncStageProgress);


### PR DESCRIPTION
- Upgrade libmdbx to latest master so we include changes solving issue from reuse of cursors bound to RO transactions
- Added more cursor pool tests
- make db::Cursor constructible/bindable from RWTxn too