### PR TITLE
Switch execution to evmone baseline interpreter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "evmone"]
 	path = third_party/evmone
-	url = https://github.com/torquem-ch/evmone.git
-	branch = move_analysis
+	url = https://github.com/ethereum/evmone.git
 [submodule "secp256k1"]
 	path = third_party/secp256k1
 	url = https://github.com/bitcoin-core/secp256k1.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "evmone"]
 	path = third_party/evmone
-	url = https://github.com/ethereum/evmone.git
+	url = https://github.com/torquem-ch/evmone.git
+	branch = move_analysis
 [submodule "secp256k1"]
 	path = third_party/secp256k1
 	url = https://github.com/bitcoin-core/secp256k1.git

--- a/cmd/check_changes.cpp
+++ b/cmd/check_changes.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error("Unable to retrieve chain config");
         }
 
-        AnalysisCache analysis_cache;
+        AdvancedAnalysisCache analysis_cache;
         ObjectPool<EvmoneExecutionState> state_pool;
         std::vector<Receipt> receipts;
         auto engine{consensus::engine_factory(chain_config.value())};

--- a/cmd/scan_txs.cpp
+++ b/cmd/scan_txs.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
     // running on the same machine.
     // std::unique_ptr<lmdb::Transaction> txn{env->begin_ro_transaction()};
 
-    AnalysisCache analysis_cache;
+    AdvancedAnalysisCache analysis_cache;
     ObjectPool<EvmoneExecutionState> state_pool;
     std::vector<Receipt> receipts;
 

--- a/core/silkworm/chain/config.cpp
+++ b/core/silkworm/chain/config.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ static const std::vector<std::pair<std::string, const ChainConfig*>> kKnownChain
 constexpr const char* kTerminalTotalDifficulty{"terminalTotalDifficulty"};
 constexpr const char* kTerminalBlockNumber{"terminalBlockNumber"};
 constexpr const char* kTerminalBlockHash{"terminalBlockHash"};
-constexpr const char* kMergeForkBlock{"mergeForkBlock"};
 
 static inline void member_to_json(nlohmann::json& json, const std::string& key, const std::optional<uint64_t>& source) {
     if (source.has_value()) {
@@ -75,7 +74,6 @@ nlohmann::json ChainConfig::to_json() const noexcept {
     member_to_json(ret, "muirGlacierBlock", muir_glacier_block);
     member_to_json(ret, "arrowGlacierBlock", arrow_glacier_block);
     member_to_json(ret, kTerminalBlockNumber, terminal_block_number);
-    member_to_json(ret, kMergeForkBlock, merge_fork_block);
 
     if (terminal_total_difficulty.has_value()) {
         // TODO (Andrew) geth probably treats terminalTotalDifficulty as a JSON number
@@ -114,8 +112,7 @@ std::optional<ChainConfig> ChainConfig::from_json(const nlohmann::json& json) no
     read_json_config_member(json, "muirGlacierBlock", config.muir_glacier_block);
     read_json_config_member(json, "arrowGlacierBlock", config.arrow_glacier_block);
     read_json_config_member(json, kTerminalBlockNumber, config.terminal_block_number);
-    read_json_config_member(json, kMergeForkBlock, config.merge_fork_block);
-    
+
     if (json.contains(kTerminalTotalDifficulty)) {
         config.terminal_total_difficulty =
             intx::from_string<intx::uint256>(json[kTerminalTotalDifficulty].get<std::string>());

--- a/core/silkworm/chain/config.hpp
+++ b/core/silkworm/chain/config.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,7 +51,9 @@ struct ChainConfig {
         "berlinBlock",  // EVMC_BERLIN
         "londonBlock",  // EVMC_LONDON
         // there's no evmc_revision for arrowGlacierBlock
-        "shanghaiBlock",  // EVMC_SHANGHAI
+        "mergeForkBlock",  // EVMC_PARIS, corresponds to FORK_NEXT_VALUE of EIP-3675
+        "shanghaiBlock",   // EVMC_SHANGHAI
+        "cancunBlock",     // EVMC_CANCUN
     };
 
     static_assert(std::size(kJsonForkNames) == EVMC_MAX_REVISION);
@@ -77,7 +79,7 @@ struct ChainConfig {
     std::optional<intx::uint256> terminal_total_difficulty{std::nullopt};
     std::optional<uint64_t> terminal_block_number{std::nullopt};
     std::optional<evmc::bytes32> terminal_block_hash{std::nullopt};
-    std::optional<uint64_t> merge_fork_block{std::nullopt};
+
     // Returns the revision level at given block number
     // In other words, on behalf of Json chain config data
     // returns whether specific HF have occurred

--- a/core/silkworm/chain/config_test.cpp
+++ b/core/silkworm/chain/config_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ TEST_CASE("JSON serialization") {
     CHECK(config2->terminal_total_difficulty == intx::from_string<intx::uint256>("39387012740608862000000"));
     CHECK(config2->terminal_block_number == 10000);
     CHECK(config2->terminal_block_hash == 0x6dc57fd586f41ee340124c3a005642af7731a9ca7a7b70d989a7e2833e4ab740_bytes32);
-    CHECK(config2->merge_fork_block == 10000);
+    CHECK(config2->revision_block(EVMC_PARIS) == 10000);
 
     CHECK(config2->to_json() == merge_test_json);
 }

--- a/core/silkworm/common/base.hpp
+++ b/core/silkworm/common/base.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -24,10 +24,7 @@
 #include <string>
 #include <string_view>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <evmc/evmc.hpp>
-#pragma GCC diagnostic pop
 
 namespace silkworm {
 

--- a/core/silkworm/execution/analysis_cache.cpp
+++ b/core/silkworm/execution/analysis_cache.cpp
@@ -20,7 +20,8 @@
 
 namespace silkworm {
 
-std::shared_ptr<EvmoneCodeAnalysis> AnalysisCache::get(const evmc::bytes32& key, evmc_revision revision) noexcept {
+std::shared_ptr<evmone::advanced::AdvancedCodeAnalysis> AdvancedAnalysisCache::get(const evmc::bytes32& key,
+                                                                                   evmc_revision revision) noexcept {
     if (revision_ == revision) {
         const auto* ptr{cache_.get(key)};
         return ptr ? *ptr : nullptr;
@@ -29,8 +30,9 @@ std::shared_ptr<EvmoneCodeAnalysis> AnalysisCache::get(const evmc::bytes32& key,
     }
 }
 
-void AnalysisCache::put(const evmc::bytes32& key, const std::shared_ptr<EvmoneCodeAnalysis>& analysis,
-                        evmc_revision revision) noexcept {
+void AdvancedAnalysisCache::put(const evmc::bytes32& key,
+                                const std::shared_ptr<evmone::advanced::AdvancedCodeAnalysis>& analysis,
+                                evmc_revision revision) noexcept {
     if (revision_ != revision) {
         // multiple revisions are not supported
         cache_.clear();

--- a/core/silkworm/execution/analysis_cache.hpp
+++ b/core/silkworm/execution/analysis_cache.hpp
@@ -29,35 +29,34 @@
 
 namespace silkworm {
 
-using EvmoneCodeAnalysis = evmone::advanced::AdvancedCodeAnalysis;
-
 /** @brief Cache of EVM analyses.
  *
  * Analyses performed for different EVM revisions do not coexist in the cache
  * and all other revisions are evicted on revision update.
  */
-class AnalysisCache {
+class AdvancedAnalysisCache {
   public:
     static constexpr size_t kDefaultMaxSize{5'000};
 
-    explicit AnalysisCache(size_t maxSize = kDefaultMaxSize) : cache_{maxSize} {}
+    explicit AdvancedAnalysisCache(size_t maxSize = kDefaultMaxSize) : cache_{maxSize} {}
 
-    AnalysisCache(const AnalysisCache&) = delete;
-    AnalysisCache& operator=(const AnalysisCache&) = delete;
+    AdvancedAnalysisCache(const AdvancedAnalysisCache&) = delete;
+    AdvancedAnalysisCache& operator=(const AdvancedAnalysisCache&) = delete;
 
     /** @brief Gets an EVM analysis from the cache.
      * A nullptr is returned if there's nothing in the cache for this key & revision.
      */
-    std::shared_ptr<EvmoneCodeAnalysis> get(const evmc::bytes32& key, evmc_revision revision) noexcept;
+    std::shared_ptr<evmone::advanced::AdvancedCodeAnalysis> get(const evmc::bytes32& key,
+                                                                evmc_revision revision) noexcept;
 
     /** @brief Puts an EVM analysis into the cache.
      * All cache entries for other EVM revisions are evicted.
      */
-    void put(const evmc::bytes32& key, const std::shared_ptr<EvmoneCodeAnalysis>& analysis,
+    void put(const evmc::bytes32& key, const std::shared_ptr<evmone::advanced::AdvancedCodeAnalysis>& analysis,
              evmc_revision revision) noexcept;
 
   private:
-    lru_cache<evmc::bytes32, std::shared_ptr<EvmoneCodeAnalysis>> cache_;
+    lru_cache<evmc::bytes32, std::shared_ptr<evmone::advanced::AdvancedCodeAnalysis>> cache_;
     evmc_revision revision_{EVMC_MAX_REVISION};
 };
 

--- a/core/silkworm/execution/analysis_cache.hpp
+++ b/core/silkworm/execution/analysis_cache.hpp
@@ -40,6 +40,7 @@ class AdvancedAnalysisCache {
 
     explicit AdvancedAnalysisCache(size_t maxSize = kDefaultMaxSize) : cache_{maxSize} {}
 
+    // Not copyable nor movable
     AdvancedAnalysisCache(const AdvancedAnalysisCache&) = delete;
     AdvancedAnalysisCache& operator=(const AdvancedAnalysisCache&) = delete;
 

--- a/core/silkworm/execution/analysis_cache.hpp
+++ b/core/silkworm/execution/analysis_cache.hpp
@@ -19,13 +19,10 @@
 
 #include <memory>
 
+#include <evmone/advanced_analysis.hpp>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/lru_cache.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#include <evmone/advanced_analysis.hpp>
-#pragma GCC diagnostic pop
 
 namespace silkworm {
 

--- a/core/silkworm/execution/analysis_cache.hpp
+++ b/core/silkworm/execution/analysis_cache.hpp
@@ -20,11 +20,15 @@
 #include <memory>
 
 #include <evmone/advanced_analysis.hpp>
+#include <evmone/baseline.hpp>
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/lru_cache.hpp>
 
 namespace silkworm {
+
+// Cache of EVM baseline analyses.
+using BaselineAnalysisCache = lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>;
 
 /** @brief Cache of EVM advanced analyses.
  *

--- a/core/silkworm/execution/analysis_cache.hpp
+++ b/core/silkworm/execution/analysis_cache.hpp
@@ -26,9 +26,9 @@
 
 namespace silkworm {
 
-/** @brief Cache of EVM analyses.
+/** @brief Cache of EVM advanced analyses.
  *
- * Analyses performed for different EVM revisions do not coexist in the cache
+ * Adavanced interpreter analyses performed for different EVM revisions do not coexist in the cache
  * and all other revisions are evicted on revision update.
  */
 class AdvancedAnalysisCache {

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -262,7 +262,7 @@ evmc::result EVM::execute(const evmc_message& msg, ByteView code, std::optional<
         EvmHost host{*this};
         res = exo_evm->execute(exo_evm, &host.get_interface(), host.to_context(), rev, &msg, code.data(), code.size());
     } else if (code_hash != std::nullopt && advanced_analysis_cache != nullptr) {
-        res = execute_with_default_interpreter(rev, msg, code, *code_hash);
+        res = execute_with_advanced_interpreter(rev, msg, code, *code_hash);
     } else {
         // for one-off execution baseline interpreter is generally faster
         res = execute_with_baseline_interpreter(rev, msg, code);
@@ -305,13 +305,13 @@ evmc_result EVM::execute_with_baseline_interpreter(evmc_revision rev, const evmc
     return res;
 }
 
-evmc_result EVM::execute_with_default_interpreter(evmc_revision rev, const evmc_message& msg, ByteView code,
-                                                  const evmc::bytes32& code_hash) noexcept {
+evmc_result EVM::execute_with_advanced_interpreter(evmc_revision rev, const evmc_message& msg, ByteView code,
+                                                   const evmc::bytes32& code_hash) noexcept {
     assert(advanced_analysis_cache != nullptr);
 
-    std::shared_ptr<EvmoneCodeAnalysis> analysis{advanced_analysis_cache->get(code_hash, rev)};
+    std::shared_ptr<evmone::advanced::AdvancedCodeAnalysis> analysis{advanced_analysis_cache->get(code_hash, rev)};
     if (!analysis) {
-        analysis = std::make_shared<EvmoneCodeAnalysis>(evmone::advanced::analyze(rev, code));
+        analysis = std::make_shared<evmone::advanced::AdvancedCodeAnalysis>(evmone::advanced::analyze(rev, code));
         advanced_analysis_cache->put(code_hash, analysis, rev);
     }
 

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -24,7 +24,6 @@
 
 #include <ethash/keccak.hpp>
 #include <evmone/advanced_execution.hpp>
-#include <evmone/baseline.hpp>
 #include <evmone/evmone.h>
 #include <evmone/tracing.hpp>
 #include <evmone/vm.hpp>
@@ -156,7 +155,7 @@ evmc::result EVM::create(const evmc_message& message) noexcept {
         message.value,   // value
     };
 
-    res = execute(deploy_message, ByteView{message.input_data, message.input_size}, /*code_hash=*/std::nullopt);
+    res = execute(deploy_message, ByteView{message.input_data, message.input_size}, /*code_hash=*/nullptr);
 
     if (res.status_code == EVMC_SUCCESS) {
         const size_t code_len{res.output_size};
@@ -240,8 +239,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
         }
 
         const evmc::bytes32 code_hash{state_.get_code_hash(message.code_address)};
-
-        res = execute(message, code, code_hash);
+        res = execute(message, code, &code_hash);
     }
 
     if (res.status_code != EVMC_SUCCESS) {
@@ -254,18 +252,18 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
     return res;
 }
 
-evmc::result EVM::execute(const evmc_message& msg, ByteView code, std::optional<evmc::bytes32> code_hash) noexcept {
+evmc::result EVM::execute(const evmc_message& msg, ByteView code, const evmc::bytes32* code_hash) noexcept {
     const evmc_revision rev{revision()};
 
     evmc_result res;
     if (exo_evm) {
         EvmHost host{*this};
         res = exo_evm->execute(exo_evm, &host.get_interface(), host.to_context(), rev, &msg, code.data(), code.size());
-    } else if (code_hash != std::nullopt && advanced_analysis_cache != nullptr) {
+    } else if (code_hash && advanced_analysis_cache) {
         res = execute_with_advanced_interpreter(rev, msg, code, *code_hash);
     } else {
         // for one-off execution baseline interpreter is generally faster
-        res = execute_with_baseline_interpreter(rev, msg, code);
+        res = execute_with_baseline_interpreter(rev, msg, code, code_hash);
     }
 
     return evmc::result{res};
@@ -290,15 +288,29 @@ void EVM::release_state(gsl::owner<EvmoneExecutionState*> state) noexcept {
     }
 }
 
-evmc_result EVM::execute_with_baseline_interpreter(evmc_revision rev, const evmc_message& msg, ByteView code) noexcept {
-    const auto vm{static_cast<evmone::VM*>(evm1_)};
-    const auto analysis{evmone::baseline::analyze(code)};
+evmc_result EVM::execute_with_baseline_interpreter(evmc_revision rev, const evmc_message& msg, ByteView code,
+                                                   const evmc::bytes32* code_hash) noexcept {
+    std::shared_ptr<evmone::baseline::CodeAnalysis> analysis;
+    const bool use_cache{code_hash && baseline_analysis_cache};
+    if (use_cache) {
+        const auto* ptr{baseline_analysis_cache->get(*code_hash)};
+        if (ptr) {
+            analysis = *ptr;
+        }
+    }
+    if (!analysis) {
+        analysis = std::make_shared<evmone::baseline::CodeAnalysis>(evmone::baseline::analyze(code));
+        if (use_cache) {
+            baseline_analysis_cache->put(*code_hash, analysis);
+        }
+    }
 
     EvmHost host{*this};
     gsl::owner<EvmoneExecutionState*> state{acquire_state()};
     state->reset(msg, rev, host.get_interface(), host.to_context(), code);
 
-    evmc_result res{evmone::baseline::execute(*vm, *state, analysis)};
+    const auto vm{static_cast<evmone::VM*>(evm1_)};
+    evmc_result res{evmone::baseline::execute(*vm, *state, *analysis)};
 
     release_state(state);
 

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -79,7 +79,7 @@ class EVM {
     void add_tracer(EvmTracer& tracer) noexcept;
 
     // Point to a cache instance in order to enable execution with evmone advanced rather than baseline interpreter
-    AnalysisCache* advanced_analysis_cache{nullptr};
+    AdvancedAnalysisCache* advanced_analysis_cache{nullptr};
 
     ObjectPool<EvmoneExecutionState>* state_pool{nullptr};  // use for better performance
 
@@ -99,8 +99,8 @@ class EVM {
     evmc_result execute_with_baseline_interpreter(evmc_revision rev, const evmc_message& message,
                                                   ByteView code) noexcept;
 
-    evmc_result execute_with_default_interpreter(evmc_revision rev, const evmc_message& message, ByteView code,
-                                                 const evmc::bytes32& code_hash) noexcept;
+    evmc_result execute_with_advanced_interpreter(evmc_revision rev, const evmc_message& message, ByteView code,
+                                                  const evmc::bytes32& code_hash) noexcept;
 
     gsl::owner<EvmoneExecutionState*> acquire_state() noexcept;
     void release_state(gsl::owner<EvmoneExecutionState*> state) noexcept;

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -20,7 +20,13 @@
 #include <stack>
 #include <vector>
 
+#include <evmone/baseline.hpp>
 #include <intx/intx.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#include <evmone/advanced_analysis.hpp>
+#pragma GCC diagnostic pop
 
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/object_pool.hpp>
@@ -28,11 +34,6 @@
 #include <silkworm/execution/analysis_cache.hpp>
 #include <silkworm/state/intra_block_state.hpp>
 #include <silkworm/types/block.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#include <evmone/advanced_analysis.hpp>
-#pragma GCC diagnostic pop
 
 namespace silkworm {
 
@@ -78,6 +79,9 @@ class EVM {
 
     void add_tracer(EvmTracer& tracer) noexcept;
 
+    // Use for better performance with evmone baseline interpreter
+    lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>* baseline_analysis_cache{nullptr};
+
     // Point to a cache instance in order to enable execution with evmone advanced rather than baseline interpreter
     AdvancedAnalysisCache* advanced_analysis_cache{nullptr};
 
@@ -94,10 +98,10 @@ class EVM {
 
     evmc::result call(const evmc_message& message) noexcept;
 
-    evmc::result execute(const evmc_message& message, ByteView code, std::optional<evmc::bytes32> code_hash) noexcept;
+    evmc::result execute(const evmc_message& message, ByteView code, const evmc::bytes32* code_hash) noexcept;
 
-    evmc_result execute_with_baseline_interpreter(evmc_revision rev, const evmc_message& message,
-                                                  ByteView code) noexcept;
+    evmc_result execute_with_baseline_interpreter(evmc_revision rev, const evmc_message& message, ByteView code,
+                                                  const evmc::bytes32* code_hash) noexcept;
 
     evmc_result execute_with_advanced_interpreter(evmc_revision rev, const evmc_message& message, ByteView code,
                                                   const evmc::bytes32& code_hash) noexcept;

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -20,8 +20,6 @@
 #include <stack>
 #include <vector>
 
-#include <evmone/advanced_analysis.hpp>
-#include <evmone/baseline.hpp>
 #include <intx/intx.hpp>
 
 #include <silkworm/chain/config.hpp>
@@ -76,7 +74,7 @@ class EVM {
     void add_tracer(EvmTracer& tracer) noexcept;
 
     // Use for better performance with evmone baseline interpreter
-    lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>* baseline_analysis_cache{nullptr};
+    BaselineAnalysisCache* baseline_analysis_cache{nullptr};
 
     // Point to a cache instance in order to enable execution with evmone advanced rather than baseline interpreter
     AdvancedAnalysisCache* advanced_analysis_cache{nullptr};

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -20,13 +20,9 @@
 #include <stack>
 #include <vector>
 
+#include <evmone/advanced_analysis.hpp>
 #include <evmone/baseline.hpp>
 #include <intx/intx.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#include <evmone/advanced_analysis.hpp>
-#pragma GCC diagnostic pop
 
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/object_pool.hpp>

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -168,7 +168,7 @@ TEST_CASE("Maximum call depth") {
 
     EVM evm{block, state, kMainnetConfig};
 
-    AnalysisCache analysis_cache{/*maxSize=*/16};
+    AdvancedAnalysisCache analysis_cache{/*maxSize=*/16};
     evm.advanced_analysis_cache = &analysis_cache;
 
     Transaction txn{};

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -85,7 +85,7 @@ StageResult Execution::forward(db::RWTxn& txn) {
     }
 
     static constexpr size_t kCacheSize{5'000};
-    lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>> analysis_cache{kCacheSize};
+    BaselineAnalysisCache analysis_cache{kCacheSize};
     ObjectPool<EvmoneExecutionState> state_pool;
 
     while (!is_stopping() && block_num_ <= max_block_num) {
@@ -157,10 +157,9 @@ std::queue<Block> Execution::prefetch_blocks(db::RWTxn& txn, BlockNum from, Bloc
     return ret;
 }
 
-StageResult Execution::execute_batch(
-    db::RWTxn& txn, BlockNum max_block_num,
-    lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>& analysis_cache,
-    ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold, BlockNum prune_receipts_threshold) {
+StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, BaselineAnalysisCache& analysis_cache,
+                                     ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold,
+                                     BlockNum prune_receipts_threshold) {
     try {
         db::Buffer buffer(*txn, prune_history_threshold);
         std::vector<Receipt> receipts;

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -84,11 +84,11 @@ StageResult Execution::forward(db::RWTxn& txn) {
         prune_receipts = std::min(prune_receipts, hashstate_stage_progress - 1);
     }
 
-    AnalysisCache analysis_cache;
+    //  AnalysisCache analysis_cache;
     ObjectPool<EvmoneExecutionState> state_pool;
 
     while (!is_stopping() && block_num_ <= max_block_num) {
-        const auto res{execute_batch(txn, max_block_num, analysis_cache, state_pool, prune_history, prune_receipts)};
+        const auto res{execute_batch(txn, max_block_num, state_pool, prune_history, prune_receipts)};
         if (res != StageResult::kSuccess) {
             return res;
         }
@@ -156,7 +156,7 @@ std::queue<Block> Execution::prefetch_blocks(db::RWTxn& txn, BlockNum from, Bloc
     return ret;
 }
 
-StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, AnalysisCache& analysis_cache,
+StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num,  // AnalysisCache& analysis_cache,
                                      ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold,
                                      BlockNum prune_receipts_threshold) {
     try {
@@ -195,7 +195,7 @@ StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, Ana
             }
 
             ExecutionProcessor processor(block, *consensus_engine_, buffer, node_settings_->chain_config.value());
-            processor.evm().advanced_analysis_cache = &analysis_cache;
+            // processor.evm().advanced_analysis_cache = &analysis_cache;
             processor.evm().state_pool = &state_pool;
 
             // TODO(Andrea) Add Tracer

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -84,11 +84,12 @@ StageResult Execution::forward(db::RWTxn& txn) {
         prune_receipts = std::min(prune_receipts, hashstate_stage_progress - 1);
     }
 
-    //  AnalysisCache analysis_cache;
+    static constexpr size_t kCacheSize{5'000};
+    lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>> analysis_cache{kCacheSize};
     ObjectPool<EvmoneExecutionState> state_pool;
 
     while (!is_stopping() && block_num_ <= max_block_num) {
-        const auto res{execute_batch(txn, max_block_num, state_pool, prune_history, prune_receipts)};
+        const auto res{execute_batch(txn, max_block_num, analysis_cache, state_pool, prune_history, prune_receipts)};
         if (res != StageResult::kSuccess) {
             return res;
         }
@@ -156,9 +157,10 @@ std::queue<Block> Execution::prefetch_blocks(db::RWTxn& txn, BlockNum from, Bloc
     return ret;
 }
 
-StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num,  // AnalysisCache& analysis_cache,
-                                     ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold,
-                                     BlockNum prune_receipts_threshold) {
+StageResult Execution::execute_batch(
+    db::RWTxn& txn, BlockNum max_block_num,
+    lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>& analysis_cache,
+    ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold, BlockNum prune_receipts_threshold) {
     try {
         db::Buffer buffer(*txn, prune_history_threshold);
         std::vector<Receipt> receipts;
@@ -195,7 +197,7 @@ StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num,  //
             }
 
             ExecutionProcessor processor(block, *consensus_engine_, buffer, node_settings_->chain_config.value());
-            // processor.evm().advanced_analysis_cache = &analysis_cache;
+            processor.evm().baseline_analysis_cache = &analysis_cache;
             processor.evm().state_pool = &state_pool;
 
             // TODO(Andrea) Add Tracer

--- a/node/silkworm/stagedsync/stage_execution.hpp
+++ b/node/silkworm/stagedsync/stage_execution.hpp
@@ -49,7 +49,7 @@ class Execution final : public IStage {
 
     //! \brief Executes a batch of blocks
     //! \remarks A batch completes when either max block is reached or buffer dimensions overflow
-    StageResult execute_batch(db::RWTxn& txn, BlockNum max_block_num, AnalysisCache& analysis_cache,
+    StageResult execute_batch(db::RWTxn& txn, BlockNum max_block_num,  // AnalysisCache& analysis_cache,
                               ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold,
                               BlockNum prune_receipts_threshold);
 

--- a/node/silkworm/stagedsync/stage_execution.hpp
+++ b/node/silkworm/stagedsync/stage_execution.hpp
@@ -49,7 +49,8 @@ class Execution final : public IStage {
 
     //! \brief Executes a batch of blocks
     //! \remarks A batch completes when either max block is reached or buffer dimensions overflow
-    StageResult execute_batch(db::RWTxn& txn, BlockNum max_block_num,  // AnalysisCache& analysis_cache,
+    StageResult execute_batch(db::RWTxn& txn, BlockNum max_block_num,
+                              lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>& analysis_cache,
                               ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold,
                               BlockNum prune_receipts_threshold);
 

--- a/node/silkworm/stagedsync/stage_execution.hpp
+++ b/node/silkworm/stagedsync/stage_execution.hpp
@@ -49,8 +49,7 @@ class Execution final : public IStage {
 
     //! \brief Executes a batch of blocks
     //! \remarks A batch completes when either max block is reached or buffer dimensions overflow
-    StageResult execute_batch(db::RWTxn& txn, BlockNum max_block_num,
-                              lru_cache<evmc::bytes32, std::shared_ptr<evmone::baseline::CodeAnalysis>>& analysis_cache,
+    StageResult execute_batch(db::RWTxn& txn, BlockNum max_block_num, BaselineAnalysisCache& analysis_cache,
                               ObjectPool<EvmoneExecutionState>& state_pool, BlockNum prune_history_threshold,
                               BlockNum prune_receipts_threshold);
 


### PR DESCRIPTION
Switching execution from advanced to baseline evmone interpreter results in performance saving of about 1h (out of circa 1day) of the execution time. One contributing factor, I think,  is that baseline `CodeAnalysis` is more compact than `AdavancedCodeAnalysis`, so the cache is significantly smaller and thus more RAM is available for MDBX page caching by the OS.

| master@[01158d73](https://github.com/torquem-ch/silkworm/commit/01158d7375adbb366d826ece1ba407c4f9c28671) | baseline@[a972151c](https://github.com/torquem-ch/silkworm/commit/a972151c2d5c561561d971963bc26855f6e4ed11) |
| --- | --- | 
| Execution         done=22h 9m 42s | Execution         done=21h 13m 35s | 
|![master](https://user-images.githubusercontent.com/34320705/159516825-edac0599-ac6e-42dd-b786-416b2aafab8a.png)|![baseline](https://user-images.githubusercontent.com/34320705/159270273-66eb35d7-3f3c-4403-b346-0a76949575b4.png)|

linux-x86_64, gcc 11.2.0