### PR TITLE
Add initial KV Tx RPC implementation

### DIFF
--- a/node/silkworm/backend/ethereum_backend.cpp
+++ b/node/silkworm/backend/ethereum_backend.cpp
@@ -20,7 +20,7 @@
 
 namespace silkworm {
 
-EthereumBackEnd::EthereumBackEnd(const NodeSettings& node_settings, mdbx::env_managed* chaindata_env)
+EthereumBackEnd::EthereumBackEnd(const NodeSettings& node_settings, mdbx::env* chaindata_env)
     : node_settings_(node_settings), chaindata_env_(chaindata_env) {
     // Get the numeric chain identifier from node settings
     if (node_settings_.chain_config) {

--- a/node/silkworm/backend/ethereum_backend.hpp
+++ b/node/silkworm/backend/ethereum_backend.hpp
@@ -32,12 +32,12 @@ constexpr const char kSentryAddressDelimiter{','};
 
 class EthereumBackEnd {
   public:
-    explicit EthereumBackEnd(const NodeSettings& node_settings, mdbx::env_managed* chaindata_env);
+    explicit EthereumBackEnd(const NodeSettings& node_settings, mdbx::env* chaindata_env);
 
     EthereumBackEnd(const EthereumBackEnd&) = delete;
     EthereumBackEnd& operator=(const EthereumBackEnd&) = delete;
 
-    mdbx::env_managed* chaindata_env() const noexcept { return chaindata_env_; }
+    mdbx::env* chaindata_env() const noexcept { return chaindata_env_; }
     const std::string& node_name() const noexcept { return node_name_; }
     std::optional<uint64_t> chain_id() const noexcept { return chain_id_; }
     std::optional<evmc::address> etherbase() const noexcept { return node_settings_.etherbase; }
@@ -47,7 +47,7 @@ class EthereumBackEnd {
 
   private:
     const NodeSettings& node_settings_;
-    mdbx::env_managed* chaindata_env_;
+    mdbx::env* chaindata_env_;
     std::string node_name_{kDefaultNodeName};
     std::optional<uint64_t> chain_id_{std::nullopt};
     std::vector<std::string> sentry_addresses_;

--- a/node/silkworm/rpc/backend_calls.cpp
+++ b/node/silkworm/rpc/backend_calls.cpp
@@ -50,8 +50,8 @@ void EtherbaseCall::fill_predefined_reply(const EthereumBackEnd& backend) {
     }
 }
 
-EtherbaseCall::EtherbaseCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::EtherbaseRequest, remote::EtherbaseReply>(service, queue, handlers) {
+EtherbaseCall::EtherbaseCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::EtherbaseRequest, remote::EtherbaseReply>(scheduler, service, queue, handlers) {
 }
 
 void EtherbaseCall::process(const remote::EtherbaseRequest* request) {
@@ -82,8 +82,8 @@ void NetVersionCall::fill_predefined_reply(const EthereumBackEnd& backend) {
     }
 }
 
-NetVersionCall::NetVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::NetVersionRequest, remote::NetVersionReply>(service, queue, handlers) {
+NetVersionCall::NetVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::NetVersionRequest, remote::NetVersionReply>(scheduler, service, queue, handlers) {
 }
 
 void NetVersionCall::process(const remote::NetVersionRequest* request) {
@@ -109,8 +109,8 @@ void NetPeerCountCall::remove_sentry(SentryClient* sentry) {
     NetPeerCountCall::sentries_.erase(sentry);
 }
 
-NetPeerCountCall::NetPeerCountCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::NetPeerCountRequest, remote::NetPeerCountReply>(service, queue, handlers) {
+NetPeerCountCall::NetPeerCountCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::NetPeerCountRequest, remote::NetPeerCountReply>(scheduler, service, queue, handlers) {
 }
 
 void NetPeerCountCall::process(const remote::NetPeerCountRequest* request) {
@@ -169,8 +169,8 @@ void BackEndVersionCall::fill_predefined_reply() {
     BackEndVersionCall::response_.set_patch(std::get<2>(kEthBackEndApiVersion));
 }
 
-BackEndVersionCall::BackEndVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, google::protobuf::Empty, types::VersionReply>(service, queue, handlers) {
+BackEndVersionCall::BackEndVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, google::protobuf::Empty, types::VersionReply>(scheduler, service, queue, handlers) {
 }
 
 void BackEndVersionCall::process(const google::protobuf::Empty* request) {
@@ -192,8 +192,8 @@ void ProtocolVersionCall::fill_predefined_reply() {
     ProtocolVersionCall::response_.set_id(kEthDevp2pProtocolVersion);
 }
 
-ProtocolVersionCall::ProtocolVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::ProtocolVersionRequest, remote::ProtocolVersionReply>(service, queue, handlers) {
+ProtocolVersionCall::ProtocolVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::ProtocolVersionRequest, remote::ProtocolVersionReply>(scheduler, service, queue, handlers) {
 }
 
 void ProtocolVersionCall::process(const remote::ProtocolVersionRequest* request) {
@@ -215,8 +215,8 @@ void ClientVersionCall::fill_predefined_reply(const EthereumBackEnd& backend) {
     ClientVersionCall::response_.set_nodename(backend.node_name());
 }
 
-ClientVersionCall::ClientVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::ClientVersionRequest, remote::ClientVersionReply>(service, queue, handlers) {
+ClientVersionCall::ClientVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::ClientVersionRequest, remote::ClientVersionReply>(scheduler, service, queue, handlers) {
 }
 
 void ClientVersionCall::process(const remote::ClientVersionRequest* request) {
@@ -232,8 +232,8 @@ ClientVersionCallFactory::ClientVersionCallFactory(const EthereumBackEnd& backen
     ClientVersionCall::fill_predefined_reply(backend);
 }
 
-SubscribeCall::SubscribeCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : ServerStreamingRpc<remote::ETHBACKEND::AsyncService, remote::SubscribeRequest, remote::SubscribeReply>(service, queue, handlers) {
+SubscribeCall::SubscribeCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : ServerStreamingRpc<remote::ETHBACKEND::AsyncService, remote::SubscribeRequest, remote::SubscribeReply>(scheduler, service, queue, handlers) {
 }
 
 void SubscribeCall::process(const remote::SubscribeRequest* request) {
@@ -268,8 +268,8 @@ void NodeInfoCall::remove_sentry(SentryClient* sentry) {
     NodeInfoCall::sentries_.erase(sentry);
 }
 
-NodeInfoCall::NodeInfoCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::NodesInfoRequest, remote::NodesInfoReply>(service, queue, handlers) {
+NodeInfoCall::NodeInfoCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::ETHBACKEND::AsyncService, remote::NodesInfoRequest, remote::NodesInfoReply>(scheduler, service, queue, handlers) {
 }
 
 void NodeInfoCall::process(const remote::NodesInfoRequest* request) {
@@ -316,16 +316,16 @@ BackEndService::BackEndService(const EthereumBackEnd& backend)
     : etherbase_factory_{backend}, net_version_factory_{backend}, client_version_factory_{backend} {
 }
 
-void BackEndService::register_backend_request_calls(remote::ETHBACKEND::AsyncService* async_service, grpc::ServerCompletionQueue* queue) {
+void BackEndService::register_backend_request_calls(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* async_service, grpc::ServerCompletionQueue* queue) {
     // Register one requested call for each RPC factory
-    etherbase_factory_.create_rpc(async_service, queue);
-    net_version_factory_.create_rpc(async_service, queue);
-    net_peer_count_factory_.create_rpc(async_service, queue);
-    backend_version_factory_.create_rpc(async_service, queue);
-    protocol_version_factory_.create_rpc(async_service, queue);
-    client_version_factory_.create_rpc(async_service, queue);
-    subscribe_factory_.create_rpc(async_service, queue);
-    node_info_factory_.create_rpc(async_service, queue);
+    etherbase_factory_.create_rpc(scheduler, async_service, queue);
+    net_version_factory_.create_rpc(scheduler, async_service, queue);
+    net_peer_count_factory_.create_rpc(scheduler, async_service, queue);
+    backend_version_factory_.create_rpc(scheduler, async_service, queue);
+    protocol_version_factory_.create_rpc(scheduler, async_service, queue);
+    client_version_factory_.create_rpc(scheduler, async_service, queue);
+    subscribe_factory_.create_rpc(scheduler, async_service, queue);
+    node_info_factory_.create_rpc(scheduler, async_service, queue);
 }
 
 void BackEndService::add_sentry(std::unique_ptr<SentryClient>&& sentry) {

--- a/node/silkworm/rpc/backend_calls.hpp
+++ b/node/silkworm/rpc/backend_calls.hpp
@@ -49,7 +49,7 @@ class EtherbaseCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, remote::
   public:
     static void fill_predefined_reply(const EthereumBackEnd& backend);
 
-    EtherbaseCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    EtherbaseCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::EtherbaseRequest* request) override;
 
@@ -68,7 +68,7 @@ class NetVersionCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, remote:
   public:
     static void fill_predefined_reply(const EthereumBackEnd& backend);
 
-    NetVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    NetVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::NetVersionRequest* request) override;
 
@@ -88,7 +88,7 @@ class NetPeerCountCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, remot
     static void add_sentry(SentryClient* sentry);
     static void remove_sentry(SentryClient* sentry);
 
-    NetPeerCountCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    NetPeerCountCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::NetPeerCountRequest* request) override;
 
@@ -111,7 +111,7 @@ class BackEndVersionCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, goo
   public:
     static void fill_predefined_reply();
 
-    BackEndVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    BackEndVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const google::protobuf::Empty* request) override;
 
@@ -130,7 +130,7 @@ class ProtocolVersionCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, re
   public:
     static void fill_predefined_reply();
 
-    ProtocolVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    ProtocolVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::ProtocolVersionRequest* request) override;
 
@@ -149,7 +149,7 @@ class ClientVersionCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, remo
   public:
     static void fill_predefined_reply(const EthereumBackEnd& backend);
 
-    ClientVersionCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    ClientVersionCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::ClientVersionRequest* request) override;
 
@@ -166,7 +166,7 @@ class ClientVersionCallFactory : public CallFactory<remote::ETHBACKEND::AsyncSer
 //! Server-streaming RPC for Subscribe method of 'ethbackend' gRPC protocol.
 class SubscribeCall : public ServerStreamingRpc<remote::ETHBACKEND::AsyncService, remote::SubscribeRequest, remote::SubscribeReply> {
   public:
-    SubscribeCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    SubscribeCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::SubscribeRequest* request) override;
 };
@@ -183,7 +183,7 @@ class NodeInfoCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, remote::N
     static void add_sentry(SentryClient* sentry);
     static void remove_sentry(SentryClient* sentry);
 
-    NodeInfoCall(remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
+    NodeInfoCall(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
     void process(const remote::NodesInfoRequest* request) override;
 
@@ -207,7 +207,7 @@ struct BackEndService {
     explicit BackEndService(const EthereumBackEnd& backend);
     ~BackEndService();
 
-    void register_backend_request_calls(remote::ETHBACKEND::AsyncService* async_service, grpc::ServerCompletionQueue* queue);
+    void register_backend_request_calls(boost::asio::io_context& scheduler, remote::ETHBACKEND::AsyncService* async_service, grpc::ServerCompletionQueue* queue);
 
     void add_sentry(std::unique_ptr<SentryClient>&& sentry);
 

--- a/node/silkworm/rpc/backend_kv_server.cpp
+++ b/node/silkworm/rpc/backend_kv_server.cpp
@@ -45,7 +45,6 @@ void BackEndKvServer::register_request_calls() {
     // Start one server-side RPC request for each available server context
     for (auto& backend_kv_svc : backend_kv_services_) {
         const auto& server_context = next_context();
-        const auto server_queue = server_context.server_queue();
         const auto client_queue = server_context.client_queue();
 
         // Complete the service initialization
@@ -55,8 +54,10 @@ void BackEndKvServer::register_request_calls() {
         }
 
         // Register initial requested calls for ETHBACKEND and KV services
-        backend_kv_svc->register_backend_request_calls(&backend_async_service_, server_queue);
-        backend_kv_svc->register_kv_request_calls(&kv_async_service_, server_queue);
+        const auto io_context = server_context.io_context();
+        const auto server_queue = server_context.server_queue();
+        backend_kv_svc->register_backend_request_calls(*io_context, &backend_async_service_, server_queue);
+        backend_kv_svc->register_kv_request_calls(*io_context, &kv_async_service_, server_queue);
     }
 }
 

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1185,7 +1185,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->Read(&response);
         CHECK(response.k() == "AA");
         CHECK(response.v() == "00");
-        std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
+        //std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
         remote::Cursor next2;
         next2.set_op(remote::Op::NEXT);
         next2.set_cursor(cursor_id);

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -688,15 +688,15 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm
     grpc::Status INTERNAL_ERROR{grpc::StatusCode::INTERNAL, "internal error"};
     grpc::Status DEADLINE_EXCEEDED_ERROR{grpc::StatusCode::DEADLINE_EXCEEDED, "timeout"};
     BackEndKvE2eTest test{silkworm::log::Level::kNone, node_settings, {INTERNAL_ERROR, DEADLINE_EXCEEDED_ERROR}};
-    /*auto backend_client =*/ *test.backend_client;
+    auto backend_client = *test.backend_client;
 
-    /*SECTION("NetPeerCount: return expected status error", "[silkworm][node][rpc]") {
+    SECTION("NetPeerCount: return expected status error", "[silkworm][node][rpc]") {
         remote::NetPeerCountReply response;
-        const auto status = backend_client.net_peer_count(&response);
-        CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
+        /*const auto status =*/ backend_client.net_peer_count(&response);
+        //CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
     }
 
-    SECTION("NodeInfo: return expected status error", "[silkworm][node][rpc]") {
+    /*SECTION("NodeInfo: return expected status error", "[silkworm][node][rpc]") {
         remote::NodesInfoRequest request;
         request.set_limit(0);
         remote::NodesInfoReply response;

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -692,8 +692,8 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm
 
     SECTION("NetPeerCount: return expected status error", "[silkworm][node][rpc]") {
         remote::NetPeerCountReply response;
-        /*const auto status =*/ backend_client.net_peer_count(&response);
-        //CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
+        const auto status = backend_client.net_peer_count(&response);
+        CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
     }
 
     /*SECTION("NodeInfo: return expected status error", "[silkworm][node][rpc]") {

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1185,7 +1185,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->Read(&response);
         CHECK(response.k() == "AA");
         CHECK(response.v() == "00");
-        //std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
+        std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
         remote::Cursor next2;
         next2.set_op(remote::Op::NEXT);
         next2.set_cursor(cursor_id);
@@ -1197,6 +1197,9 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->WritesDone();
         auto status = tx_reader_writer->Finish();
         CHECK(status.ok());
+        if (!status.ok()){
+            std::cout << "status.error_message(): " << status.error_message() << "\n";
+        }
     }
 }
 

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -221,12 +221,12 @@ struct BackEndKvE2eTest {
     }
 
     ~BackEndKvE2eTest() {
+        server->shutdown();
+        server->join();
         for (auto& sentry_server : sentry_servers) {
             sentry_server->Shutdown();
             sentry_server->Wait();
         }
-        server->shutdown();
-        server->join();
     }
 
     rpc::Grpc2SilkwormLogGuard log_guard;
@@ -682,7 +682,7 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, at least one status KO", "
     }
 }
 
-TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm][node][rpc]") {
+/*TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm][node][rpc]") {
     NodeSettings node_settings;
     node_settings.sentry_api_addr = kTestSentryAddress1 + "," + kTestSentryAddress2;
     grpc::Status INTERNAL_ERROR{grpc::StatusCode::INTERNAL, "internal error"};
@@ -703,6 +703,6 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm
         const auto status = backend_client.node_info(request, &response);
         CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
     }
-}
+}*/
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -696,13 +696,13 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm
         CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
     }
 
-    /*SECTION("NodeInfo: return expected status error", "[silkworm][node][rpc]") {
+    SECTION("NodeInfo: return expected status error", "[silkworm][node][rpc]") {
         remote::NodesInfoRequest request;
         request.set_limit(0);
         remote::NodesInfoReply response;
-        const auto status = backend_client.node_info(request, &response);
-        CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
-    }*/
+        /*const auto status =*/ backend_client.node_info(request, &response);
+        //CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
+    }
 }
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1068,7 +1068,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[2].k() == "AA");
         CHECK(responses[2].v() == "00");
         CHECK(responses[3].cursorid() == 0);
-    }
+    }*/
 
     SECTION("Tx OK: one NEXT_DUP operation on multi-value table", "[silkworm][node][rpc]") {
         test.fill_test_table();
@@ -1092,7 +1092,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[2].k() == "AA");
         CHECK(responses[2].v() == "00");
         CHECK(responses[3].cursorid() == 0);
-    }*/
+    }
 }
 
 TEST_CASE("BackEndKvServer E2E: Tx cursor invalid operations", "[silkworm][node][rpc]") {

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -24,8 +24,8 @@
 #include <catch2/catch.hpp>
 #include <grpc/grpc.h>
 
-#include <silkworm/common/log.hpp>
 #include <silkworm/common/directories.hpp>
+#include <silkworm/common/log.hpp>
 #include <silkworm/db/mdbx.hpp>
 #include <silkworm/rpc/util.hpp>
 #include <types/types.pb.h>
@@ -441,7 +441,12 @@ TEST_CASE("BackEndKvServer: RPC basic config", "[silkworm][node][rpc]") {
         CHECK(responses[1].cursorid() != 0);
     }
 
-    /*SECTION("Tx OK: cursor first", "[silkworm][node][rpc]") {
+    SECTION("Tx cursor first: OK", "[silkworm][node][rpc]") {
+        rw_txn = database_env.start_write();
+        db::Cursor rw_cursor{rw_txn, test_map_config};
+        rw_cursor.upsert(mdbx::slice{"00"}, mdbx::slice{"11"});
+        rw_txn.commit();
+
         remote::SubscribeRequest request;
         remote::Cursor open;
         open.set_op(remote::Op::OPEN);
@@ -453,15 +458,15 @@ TEST_CASE("BackEndKvServer: RPC basic config", "[silkworm][node][rpc]") {
         std::vector<remote::Cursor> requests{open, first, close};
         std::vector<remote::Pair> responses;
         const auto status = kv_client.tx(requests, responses);
-        std::cout << "status: " << status << "\n";
         CHECK(status.ok());
+        CHECK(status.error_message().empty());
         CHECK(responses.size() == 4);
         CHECK(responses[0].txid() != 0);
         CHECK(responses[1].cursorid() != 0);
-        CHECK(!responses[2].k().empty());
-        CHECK(!responses[2].v().empty());
+        CHECK(responses[2].k() == "00");
+        CHECK(responses[2].v() == "11");
         CHECK(responses[3].cursorid() == 0);
-    }*/
+    }
 
     // TODO(canepat): change using something meaningful when really implemented
     SECTION("StateChanges: return streamed state changes", "[silkworm][node][rpc]") {

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1259,7 +1259,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         CHECK(status.ok());
     }
 
-    SECTION("Tx: cursor NEXT_DUP ops across renew are consecutive", "[silkworm][node][rpc]") {
+    /*SECTION("Tx: cursor NEXT_DUP ops across renew are consecutive", "[silkworm][node][rpc]") {
         test.fill_test_table();
 
         grpc::ClientContext context;
@@ -1295,7 +1295,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->WritesDone();
         auto status = tx_reader_writer->Finish();
         CHECK(status.ok());
-    }
+    }*/
 }
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1021,7 +1021,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[3].cursorid() == 0);
     }
 
-    /*SECTION("Tx OK: one FIRST_DUP operation on multi-value table", "[silkworm][node][rpc]") {
+    SECTION("Tx OK: one FIRST_DUP operation on multi-value table", "[silkworm][node][rpc]") {
         test.fill_test_table();
 
         remote::Cursor open;
@@ -1046,7 +1046,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[3].cursorid() == 0);
     }
 
-    SECTION("Tx OK: one NEXT_DUP operation on single-value table", "[silkworm][node][rpc]") {
+    /*SECTION("Tx OK: one NEXT_DUP operation on single-value table", "[silkworm][node][rpc]") {
         test.fill_test_table();
 
         remote::Cursor open;
@@ -1197,9 +1197,6 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->WritesDone();
         auto status = tx_reader_writer->Finish();
         CHECK(status.ok());
-        if (!status.ok()){
-            std::cout << "status.error_message(): " << status.error_message() << "\n";
-        }
     }
 }
 

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -997,7 +997,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[6].cursorid() == 0);
     }
 
-    /*SECTION("Tx OK: one FIRST_DUP operation w/o key on multi-value table", "[silkworm][node][rpc]") {
+    SECTION("Tx OK: one FIRST_DUP operation w/o key on multi-value table", "[silkworm][node][rpc]") {
         test.fill_test_table();
 
         remote::Cursor open;
@@ -1021,7 +1021,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[3].cursorid() == 0);
     }
 
-    SECTION("Tx OK: one FIRST_DUP operation on multi-value table", "[silkworm][node][rpc]") {
+    /*SECTION("Tx OK: one FIRST_DUP operation on multi-value table", "[silkworm][node][rpc]") {
         test.fill_test_table();
 
         remote::Cursor open;

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -207,10 +207,8 @@ struct BackEndKvE2eTest {
         std::size_t i{0};
         while (std::getline(sentry_list_stream, sentry_address, kSentryAddressDelimiter)) {
             SILKWORM_ASSERT(i < statuses.size());
-            auto sentry_service = std::make_unique<SentryService>(statuses[i]);
-            auto sentry_server = sentry_service->build_and_start(sentry_address);
-            sentry_services.push_back(std::move(sentry_service));
-            sentry_servers.push_back(std::move(sentry_server));
+            sentry_services.emplace_back(std::make_unique<SentryService>(statuses[i]));
+            sentry_servers.emplace_back(sentry_services.back()->build_and_start(sentry_address));
             ++i;
         }
     }
@@ -223,12 +221,12 @@ struct BackEndKvE2eTest {
     }
 
     ~BackEndKvE2eTest() {
-        server->shutdown();
-        server->join();
         for (auto& sentry_server : sentry_servers) {
             sentry_server->Shutdown();
             sentry_server->Wait();
         }
+        server->shutdown();
+        server->join();
     }
 
     rpc::Grpc2SilkwormLogGuard log_guard;

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1285,7 +1285,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         CHECK(response.v() == "00");
         std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
         remote::Cursor next_dup2;
-        next_dup2.set_op(remote::Op::NEXT);
+        next_dup2.set_op(remote::Op::NEXT_DUP);
         next_dup2.set_cursor(cursor_id);
         CHECK(tx_reader_writer->Write(next_dup2));
         response.clear_cursorid();

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -700,8 +700,8 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm
         remote::NodesInfoRequest request;
         request.set_limit(0);
         remote::NodesInfoReply response;
-        /*const auto status =*/ backend_client.node_info(request, &response);
-        //CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
+        const auto status = backend_client.node_info(request, &response);
+        CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
     }
 }
 

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1579,6 +1579,74 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[2].v().empty());
         CHECK(responses[3].cursorid() == 0);
     }
+
+    SECTION("Tx OK: SEEK_EXACT operation w/o key on single-value table", "[silkworm][node][rpc]") {
+        remote::Cursor open;
+        open.set_op(remote::Op::OPEN);
+        open.set_bucketname(kTestMap.name);
+        remote::Cursor seek_exact;
+        seek_exact.set_op(remote::Op::SEEK_EXACT);
+        seek_exact.set_cursor(0); // automatically assigned by KvClient::tx
+        remote::Cursor close;
+        close.set_op(remote::Op::CLOSE);
+        close.set_cursor(0); // automatically assigned by KvClient::tx
+        std::vector<remote::Cursor> requests{open, seek_exact, close};
+        std::vector<remote::Pair> responses;
+        const auto status = kv_client.tx(requests, responses);
+        CHECK(status.ok());
+        CHECK(responses.size() == 4);
+        CHECK(responses[0].txid() != 0);
+        CHECK(responses[1].cursorid() != 0);
+        CHECK(responses[2].k().empty());
+        CHECK(responses[2].v().empty());
+        CHECK(responses[3].cursorid() == 0);
+    }
+
+    SECTION("Tx OK: SEEK_EXACT operation w/ existent key on single-value table", "[silkworm][node][rpc]") {
+        remote::Cursor open;
+        open.set_op(remote::Op::OPEN);
+        open.set_bucketname(kTestMap.name);
+        remote::Cursor seek_exact;
+        seek_exact.set_op(remote::Op::SEEK_EXACT);
+        seek_exact.set_cursor(0); // automatically assigned by KvClient::tx
+        seek_exact.set_k("BB");
+        remote::Cursor close;
+        close.set_op(remote::Op::CLOSE);
+        close.set_cursor(0); // automatically assigned by KvClient::tx
+        std::vector<remote::Cursor> requests{open, seek_exact, close};
+        std::vector<remote::Pair> responses;
+        const auto status = kv_client.tx(requests, responses);
+        CHECK(status.ok());
+        CHECK(responses.size() == 4);
+        CHECK(responses[0].txid() != 0);
+        CHECK(responses[1].cursorid() != 0);
+        CHECK(responses[2].k() == "BB");
+        CHECK(responses[2].v().empty());
+        CHECK(responses[3].cursorid() == 0);
+    }
+
+    SECTION("Tx OK: SEEK_EXACT operation w/ unexistent key on single-value table", "[silkworm][node][rpc]") {
+        remote::Cursor open;
+        open.set_op(remote::Op::OPEN);
+        open.set_bucketname(kTestMap.name);
+        remote::Cursor seek_exact;
+        seek_exact.set_op(remote::Op::SEEK_EXACT);
+        seek_exact.set_cursor(0); // automatically assigned by KvClient::tx
+        seek_exact.set_k("ZZ");
+        remote::Cursor close;
+        close.set_op(remote::Op::CLOSE);
+        close.set_cursor(0); // automatically assigned by KvClient::tx
+        std::vector<remote::Cursor> requests{open, seek_exact, close};
+        std::vector<remote::Pair> responses;
+        const auto status = kv_client.tx(requests, responses);
+        CHECK(status.ok());
+        CHECK(responses.size() == 4);
+        CHECK(responses[0].txid() != 0);
+        CHECK(responses[1].cursorid() != 0);
+        CHECK(responses[2].k().empty());
+        CHECK(responses[2].v().empty());
+        CHECK(responses[3].cursorid() == 0);
+    }
 }
 
 TEST_CASE("BackEndKvServer E2E: Tx cursor invalid operations", "[silkworm][node][rpc]") {

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -783,7 +783,8 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry all status KO", "[silkworm]
     }
 }
 
-TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
+// Unfortunately this test triggers some data races within gRPC library.
+/*TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
     {
         const uint32_t kNumTxs{10};
         NodeSettings node_settings;
@@ -808,8 +809,7 @@ TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][no
         }
     }
     // Server-side lifecyle of Tx calls must be OK.
-    CHECK(true);
-}
+}*/
 
 TEST_CASE("BackEndKvServer E2E: exceed max simultaneous readers", "[silkworm][node][rpc]") {
     NodeSettings node_settings;

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -682,15 +682,15 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, at least one status KO", "
     }
 }
 
-/*TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm][node][rpc]") {
+TEST_CASE("BackEndKvServer E2E: more than one Sentry, all status KO", "[silkworm][node][rpc]") {
     NodeSettings node_settings;
     node_settings.sentry_api_addr = kTestSentryAddress1 + "," + kTestSentryAddress2;
     grpc::Status INTERNAL_ERROR{grpc::StatusCode::INTERNAL, "internal error"};
     grpc::Status DEADLINE_EXCEEDED_ERROR{grpc::StatusCode::DEADLINE_EXCEEDED, "timeout"};
     BackEndKvE2eTest test{silkworm::log::Level::kNone, node_settings, {INTERNAL_ERROR, DEADLINE_EXCEEDED_ERROR}};
-    auto backend_client = *test.backend_client;
+    /*auto backend_client =*/ *test.backend_client;
 
-    SECTION("NetPeerCount: return expected status error", "[silkworm][node][rpc]") {
+    /*SECTION("NetPeerCount: return expected status error", "[silkworm][node][rpc]") {
         remote::NetPeerCountReply response;
         const auto status = backend_client.net_peer_count(&response);
         CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
@@ -702,7 +702,7 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry, at least one status KO", "
         remote::NodesInfoReply response;
         const auto status = backend_client.node_info(request, &response);
         CHECK((status == INTERNAL_ERROR || status == DEADLINE_EXCEEDED_ERROR));
-    }
-}*/
+    }*/
+}
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1259,7 +1259,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         CHECK(status.ok());
     }
 
-    /*SECTION("Tx: cursor NEXT_DUP ops across renew are consecutive", "[silkworm][node][rpc]") {
+    SECTION("Tx: cursor NEXT_DUP ops across renew are consecutive", "[silkworm][node][rpc]") {
         test.fill_test_table();
 
         grpc::ClientContext context;
@@ -1283,7 +1283,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->Read(&response);
         CHECK(response.k() == "AA");
         CHECK(response.v() == "00");
-        std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
+        //std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
         remote::Cursor next_dup2;
         next_dup2.set_op(remote::Op::NEXT_DUP);
         next_dup2.set_cursor(cursor_id);
@@ -1295,7 +1295,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->WritesDone();
         auto status = tx_reader_writer->Finish();
         CHECK(status.ok());
-    }*/
+    }
 }
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -1283,7 +1283,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         tx_reader_writer->Read(&response);
         CHECK(response.k() == "AA");
         CHECK(response.v() == "00");
-        //std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
+        std::this_thread::sleep_for(std::chrono::milliseconds{kCustomMaxTimeToLive});
         remote::Cursor next_dup2;
         next_dup2.set_op(remote::Op::NEXT_DUP);
         next_dup2.set_cursor(cursor_id);

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -783,17 +783,15 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry all status KO", "[silkworm]
     }
 }
 
-// Unfortunately this test triggers some data races within gRPC library.
-/*TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
+TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
     {
-        const uint32_t kNumTxs{10};
+        const uint32_t kNumTxs{1000};
         NodeSettings node_settings;
-        BackEndKvE2eTest test{silkworm::log::Level::kNone, node_settings};
+        BackEndKvE2eTest test{silkworm::log::Level::kError, node_settings};
         test.fill_tables();
         auto kv_client = *test.kv_client;
 
-        // Start and keep open some Tx calls w/o reading responses after writing requests.
-        std::vector<TxStreamPtr> tx_streams;
+        // Start many Tx calls w/o reading responses after writing requests.
         for (uint32_t i{0}; i<kNumTxs; i++) {
             grpc::ClientContext context;
             auto tx_stream = kv_client.tx_start(&context);
@@ -804,12 +802,10 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry all status KO", "[silkworm]
             open.set_op(remote::Op::OPEN);
             open.set_bucketname(kTestMap.name);
             CHECK(tx_stream->Write(open));
-            // Make each Tx call outlive its own context: this triggers write errors.
-            tx_streams.push_back(std::move(tx_stream));
         }
     }
     // Server-side lifecyle of Tx calls must be OK.
-}*/
+}
 
 TEST_CASE("BackEndKvServer E2E: exceed max simultaneous readers", "[silkworm][node][rpc]") {
     NodeSettings node_settings;

--- a/node/silkworm/rpc/call.hpp
+++ b/node/silkworm/rpc/call.hpp
@@ -642,6 +642,13 @@ class BidirectionalStreamingRpc : public BaseRpc {
             } else {
                 // TODO(canepat) test this path
                 SILK_ERROR << "BidirectionalStreamingRpc::process_write peer " << peer() << " ok: false [" << this << "]";
+                client_streaming_done_ = true;
+                end();
+
+                // Stop the idle guard timer.
+                idle_timer_.cancel();
+
+                close();
             }
         }
         SILK_TRACE << "BidirectionalStreamingRpc::process_write END [" << this << "]";

--- a/node/silkworm/rpc/call.hpp
+++ b/node/silkworm/rpc/call.hpp
@@ -57,9 +57,6 @@ class BaseRpc {
         SILK_TRACE << "BaseRpc::~BaseRpc [" << this << "] instances: " << instance_count_ << " total: " << total_count_;
     }
 
-    //! Try to cancel this RPC from the server side (best-effort, no guarantee).
-    void cancel() { return context_.TryCancel(); }
-
     //! Returns a unique identifier of the RPC client for this call.
     std::string peer() const { return context_.peer(); }
 

--- a/node/silkworm/rpc/call.hpp
+++ b/node/silkworm/rpc/call.hpp
@@ -642,7 +642,7 @@ class BidirectionalStreamingRpc : public BaseRpc {
                     }
                 }
             } else {
-                SILK_ERROR << "BidirectionalStreamingRpc::process_write peer " << peer() << " ok: false [" << this << "]";
+                SILK_DEBUG << "BidirectionalStreamingRpc::process_write peer " << peer() << " ok: false [" << this << "]";
                 client_streaming_done_ = true;
 
                 // The call has just ended so let the application layer know it.

--- a/node/silkworm/rpc/call.hpp
+++ b/node/silkworm/rpc/call.hpp
@@ -606,6 +606,8 @@ class BidirectionalStreamingRpc : public BaseRpc {
                 // Client has closed the stream, so let the application layer know it.
                 SILK_DEBUG << "BidirectionalStreamingRpc::process_read stream closed by peer " << peer() << " [" << this << "]";
                 client_streaming_done_ = true;
+
+                // The call has just ended so let the application layer know it.
                 end();
 
                 // Stop the idle guard timer.
@@ -640,9 +642,10 @@ class BidirectionalStreamingRpc : public BaseRpc {
                     }
                 }
             } else {
-                // TODO(canepat) test this path
                 SILK_ERROR << "BidirectionalStreamingRpc::process_write peer " << peer() << " ok: false [" << this << "]";
                 client_streaming_done_ = true;
+
+                // The call has just ended so let the application layer know it.
                 end();
 
                 // Stop the idle guard timer.

--- a/node/silkworm/rpc/call.hpp
+++ b/node/silkworm/rpc/call.hpp
@@ -647,8 +647,9 @@ class BidirectionalStreamingRpc : public BaseRpc {
     void handle_idle_timer_expired(const boost::system::error_code& ec) {
         SILK_TRACE << "BidirectionalStreamingRpc::handle_idle_timer_expired " << this << " ec: " << ec << " START";
         if (!ec) {
-            SILK_DEBUG << "BidirectionalStreamingRpc::handle_idle_timer_expired " << this << " close stream for peer " << peer();
-            close();
+            const std::string error_message{"call idle, no incoming request from peer: " + peer()};
+            SILK_ERROR << "Idle timer expired " << this << " " << error_message;
+            finish_with_error(grpc::Status{grpc::StatusCode::DEADLINE_EXCEEDED, error_message});
         }
         SILK_TRACE << "BidirectionalStreamingRpc::handle_idle_timer_expired " << this << " ec: " << ec << " END";
     }

--- a/node/silkworm/rpc/call.hpp
+++ b/node/silkworm/rpc/call.hpp
@@ -500,6 +500,17 @@ class BidirectionalStreamingRpc : public BaseRpc {
     virtual void end() = 0;
 
     bool send_response(const Response& response) {
+        response_queue_.push_back(response);
+        SILK_DEBUG << "BidirectionalStreamingRpc::send_response enqueued response [" << this << "]";
+
+        if (!write_in_progress()) {
+            write();
+            return true;
+        }
+        return false;
+    }
+
+    bool send_response(Response&& response) {
         response_queue_.push_back(std::move(response));
         SILK_DEBUG << "BidirectionalStreamingRpc::send_response enqueued response [" << this << "]";
 

--- a/node/silkworm/rpc/call_factory.hpp
+++ b/node/silkworm/rpc/call_factory.hpp
@@ -40,10 +40,10 @@ class CallFactory {
     using CallHandlers = typename Call::Handlers;
 
   public:
-    void create_rpc(AsyncService* service, grpc::ServerCompletionQueue* queue) {
+    void create_rpc(boost::asio::io_context& scheduler, AsyncService* service, grpc::ServerCompletionQueue* queue) {
         SILK_TRACE << "CallFactory::create_rpc START service: " << service << " queue: " << queue;
 
-        auto rpc = new Call(service, queue, handlers_);
+        auto rpc = new Call(scheduler, service, queue, handlers_);
         add_rpc(rpc);
 
         SILK_TRACE << "CallFactory::create_rpc END rpc: " << rpc;
@@ -65,7 +65,7 @@ class CallFactory {
     CallFactory(typename CallHandlers::RequestRpcFunc request_rpc, std::size_t requestsInitialCapacity)
         : handlers_{
             {
-                [&](auto* svc, auto* cq) { create_rpc(svc, cq); },
+                [&](auto& scheduler, auto* svc, auto* cq) { create_rpc(scheduler, svc, cq); },
                 [&](auto& rpc, bool cancelled) { cleanup_rpc(rpc, cancelled); }
             },
             request_rpc

--- a/node/silkworm/rpc/call_test.cpp
+++ b/node/silkworm/rpc/call_test.cpp
@@ -22,28 +22,32 @@ namespace silkworm::rpc {
 
 TEST_CASE("BaseRpc", "[silkworm][rpc][call]") {
     class FakeRpc : public BaseRpc {
+      public:
+        explicit FakeRpc(boost::asio::io_context& scheduler) : BaseRpc(scheduler) {}
       protected:
         void cleanup() override {}
     };
 
+    boost::asio::io_context scheduler;
+
     SECTION("count live instances") {
         REQUIRE(BaseRpc::instance_count() == 0);
         {
-            FakeRpc rpc1;
+            FakeRpc rpc1{scheduler};
             CHECK(BaseRpc::instance_count() == 1);
         }
         REQUIRE(BaseRpc::instance_count() == 0);
         {
-            FakeRpc rpc1;
+            FakeRpc rpc1{scheduler};
             CHECK(BaseRpc::instance_count() == 1);
-            FakeRpc rpc2;
+            FakeRpc rpc2{scheduler};
             CHECK(BaseRpc::instance_count() == 2);
         }
         REQUIRE(BaseRpc::instance_count() == 0);
     }
 
     SECTION("count total instances") {
-        FakeRpc rpc;
+        FakeRpc rpc{scheduler};
         CHECK(BaseRpc::total_count() > 0);
     }
 }

--- a/node/silkworm/rpc/call_test.cpp
+++ b/node/silkworm/rpc/call_test.cpp
@@ -50,6 +50,11 @@ TEST_CASE("BaseRpc", "[silkworm][rpc][call]") {
         FakeRpc rpc{scheduler};
         CHECK(BaseRpc::total_count() > 0);
     }
+
+    SECTION("peer") {
+        FakeRpc rpc{scheduler};
+        CHECK(rpc.peer().empty());
+    }
 }
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/client/sentry_client.cpp
+++ b/node/silkworm/rpc/client/sentry_client.cpp
@@ -22,7 +22,7 @@ namespace silkworm::rpc {
 
 UnaryStats AsyncCall::unary_stats_;
 
-AsyncPeerCountCall::AsyncPeerCountCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, SentryStubPtr& stub)
+AsyncPeerCountCall::AsyncPeerCountCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, sentry::Sentry::StubInterface* stub)
 : AsyncUnaryCall(queue, completion_handler, stub) {
 }
 
@@ -39,7 +39,7 @@ bool AsyncPeerCountCall::proceed(bool ok) {
     return true;
 }
 
-AsyncNodeInfoCall::AsyncNodeInfoCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, SentryStubPtr& stub)
+AsyncNodeInfoCall::AsyncNodeInfoCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, sentry::Sentry::StubInterface* stub)
 : AsyncUnaryCall(queue, completion_handler, stub) {
 }
 
@@ -64,7 +64,7 @@ void RemoteSentryClient::peer_count(PeerCountCallback callback) {
     const auto rpc = new AsyncPeerCountCall(queue_, [this, callback](auto* call) {
         callback(call->status(), call->reply());
         remove_rpc(call);
-    }, stub_);
+    }, stub_.get());
     add_rpc(rpc);
     rpc->start(sentry::PeerCountRequest{});
 }
@@ -73,7 +73,7 @@ void RemoteSentryClient::node_info(NodeInfoCallback callback) {
     const auto rpc = new AsyncNodeInfoCall(queue_, [this, callback](auto* call) {
         callback(call->status(), call->reply());
         remove_rpc(call);
-    }, stub_);
+    }, stub_.get());
     add_rpc(rpc);
     rpc->start(google::protobuf::Empty{});
 }

--- a/node/silkworm/rpc/client/sentry_client.hpp
+++ b/node/silkworm/rpc/client/sentry_client.hpp
@@ -33,16 +33,15 @@
 
 namespace silkworm::rpc {
 
-using SentryStubPtr = std::unique_ptr<sentry::Sentry::Stub>;
+using SentryStubPtr = sentry::Sentry::StubInterface*;
 
 class AsyncPeerCountCall : public AsyncUnaryCall<
     sentry::PeerCountRequest,
     sentry::PeerCountReply,
     sentry::Sentry::StubInterface,
-    sentry::Sentry::Stub,
     &sentry::Sentry::StubInterface::PrepareAsyncPeerCount> {
   public:
-    explicit AsyncPeerCountCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, SentryStubPtr& stub);
+    explicit AsyncPeerCountCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, sentry::Sentry::StubInterface* stub);
 
     bool proceed(bool ok) override;
 };
@@ -51,10 +50,9 @@ class AsyncNodeInfoCall : public AsyncUnaryCall<
     google::protobuf::Empty,
     types::NodeInfoReply,
     sentry::Sentry::StubInterface,
-    sentry::Sentry::Stub,
     &sentry::Sentry::StubInterface::PrepareAsyncNodeInfo> {
   public:
-    explicit AsyncNodeInfoCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, SentryStubPtr& stub);
+    explicit AsyncNodeInfoCall(grpc::CompletionQueue* queue, CompletionFunc completion_handler, sentry::Sentry::StubInterface* stub);
 
     bool proceed(bool ok) override;
 };
@@ -103,7 +101,7 @@ class RemoteSentryClient : public SentryClient {
     }
 
     grpc::CompletionQueue* queue_;
-    SentryStubPtr stub_;
+    std::unique_ptr<sentry::Sentry::Stub> stub_;
     std::unordered_set<std::unique_ptr<AsyncCall>> requests_;
 };
 

--- a/node/silkworm/rpc/completion_end_point.cpp
+++ b/node/silkworm/rpc/completion_end_point.cpp
@@ -26,8 +26,6 @@
 namespace silkworm::rpc {
 
 int CompletionEndPoint::poll_one() {
-    SILK_TRACE << "CompletionEndPoint::poll_one START";
-
     int num_completed{0}; // returned when next_status == grpc::CompletionQueue::TIMEOUT
 
     void* tag{nullptr};
@@ -43,7 +41,6 @@ int CompletionEndPoint::poll_one() {
         num_completed = -1;
     }
 
-    SILK_TRACE << "CompletionEndPoint::poll_one num_completed=" << num_completed << " END";
     return num_completed;
 }
 

--- a/node/silkworm/rpc/completion_end_point.cpp
+++ b/node/silkworm/rpc/completion_end_point.cpp
@@ -43,7 +43,7 @@ int CompletionEndPoint::poll_one() {
         num_completed = -1;
     }
 
-    SILK_TRACE << "CompletionEndPoint::poll_one next_status=" << next_status << " END";
+    SILK_TRACE << "CompletionEndPoint::poll_one num_completed=" << num_completed << " END";
     return num_completed;
 }
 

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -377,16 +377,14 @@ void TxCall::handle_first(const remote::Cursor* request, db::Cursor& cursor) {
 void TxCall::handle_first_dup(const remote::Cursor* request, db::Cursor& cursor) {
     try {
         SILK_TRACE << "TxCall::handle_first_dup " << this << " START";
-        remote::Pair kv_pair;
 
-        const auto first_result = cursor.to_first(/*throw_notfound=*/false);
-        SILK_LOG << "Tx FIRST_DUP first_result: " << detail::dump_mdbx_result(first_result);
-        if (first_result) {
-            const auto first_dup_result = cursor.to_current_first_multi(/*throw_notfound=*/false);
-            SILK_LOG << "Tx FIRST_DUP first_dup_result: " << detail::dump_mdbx_result(first_dup_result);
-            if (first_dup_result) {
-                kv_pair.set_v(first_dup_result.value.as_string());
-            }
+        const auto result = cursor.to_current_first_multi(/*throw_notfound=*/false);
+        SILK_LOG << "Tx FIRST_DUP result: " << detail::dump_mdbx_result(result);
+
+        remote::Pair kv_pair;
+        // Do not use `operator bool(result)` to avoid MDBX Assertion `!done || (bool(key) && bool(value))' failed
+        if (result.done && result.value) {
+            kv_pair.set_v(result.value.as_string());
         }
 
         const bool sent = send_response(kv_pair);
@@ -521,6 +519,7 @@ void TxCall::handle_last_dup(const remote::Cursor* request, db::Cursor& cursor) 
         SILK_TRACE << "TxCall::handle_last_dup " << this << " START";
 
         const auto result = cursor.to_current_last_multi(/*throw_notfound=*/false);
+        SILK_LOG << "Tx LAST_DUP result: " << detail::dump_mdbx_result(result);
 
         remote::Pair kv_pair;
         if (result) {
@@ -559,6 +558,7 @@ void TxCall::handle_next_dup(const remote::Cursor* request, db::Cursor& cursor) 
         SILK_TRACE << "TxCall::handle_next_dup " << this << " START";
 
         const auto result = cursor.to_current_next_multi(/*throw_notfound=*/false);
+        SILK_LOG << "Tx NEXT_DUP result: " << detail::dump_mdbx_result(result);
 
         remote::Pair kv_pair;
         if (result) {

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -16,6 +16,9 @@
 
 #include "kv_calls.hpp"
 
+#include <boost/date_time/posix_time/posix_time_io.hpp>
+
+#include <silkworm/common/assert.hpp>
 #include <silkworm/common/log.hpp>
 
 namespace silkworm::rpc {
@@ -49,8 +52,8 @@ void KvVersionCall::fill_predefined_reply() {
     KvVersionCall::response_.set_patch(std::get<2>(max_version));
 }
 
-KvVersionCall::KvVersionCall(remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : UnaryRpc<remote::KV::AsyncService, google::protobuf::Empty, types::VersionReply>(service, queue, handlers) {
+KvVersionCall::KvVersionCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : UnaryRpc<remote::KV::AsyncService, google::protobuf::Empty, types::VersionReply>(scheduler, service, queue, handlers) {
 }
 
 void KvVersionCall::process(const google::protobuf::Empty* request) {
@@ -66,49 +69,196 @@ KvVersionCallFactory::KvVersionCallFactory()
     KvVersionCall::fill_predefined_reply();
 }
 
-TxCall::TxCall(remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : BidirectionalStreamingRpc<remote::KV::AsyncService, remote::Cursor, remote::Pair>(service, queue, handlers) {
+mdbx::env_managed* TxCall::chaindata_env_{nullptr};
+uint32_t TxCall::next_cursor_id_{0};
+
+void TxCall::set_chaindata_env(mdbx::env_managed* chaindata_env) {
+    TxCall::chaindata_env_ = chaindata_env;
+}
+
+TxCall::TxCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : BidirectionalStreamingRpc<remote::KV::AsyncService, remote::Cursor, remote::Pair>(scheduler, service, queue, handlers),
+    max_ttl_timer_{scheduler} {
+}
+
+void TxCall::start() {
+    SILKWORM_ASSERT(!read_only_txn_);
+
+    // Create a new read-only transaction.
+    read_only_txn_ = chaindata_env_->start_read();
+    SILK_INFO << "Tx peer: " << peer() << " started tx: " << read_only_txn_.id();
+
+    // Send an unsolicited message containing the transaction ID.
+    remote::Pair kv_pair;
+    kv_pair.set_txid(read_only_txn_.id());
+    const bool sent = send_response(kv_pair);
+    SILK_DEBUG << "TxCall::process message with txid=" << read_only_txn_.id() << " sent: " << sent;
+
+    // Start a guard timer for closing and reopening to avoid long-lived transactions.
+    max_ttl_timer_.expires_from_now(boost::posix_time::milliseconds(kMaxTxDuration));
+    max_ttl_timer_.async_wait([&](const auto& ec) { handle_max_ttl_timer_expired(ec); });
+    SILK_DEBUG << "Tx peer: " << peer() << " max TTL timer expires at: " << max_ttl_timer_.expires_at();
 }
 
 void TxCall::process(const remote::Cursor* request) {
     SILK_TRACE << "TxCall::process " << this << " request: " << request << " START";
 
-    if (request == nullptr) {
-        // The client has closed its stream of requests, we can close too.
-        const bool closed = close();
-        SILK_TRACE << "TxCall::process " << this << " closed: " << closed;
+    // Handle separately main use cases: cursor OPEN, cursor CLOSE and any other cursor operation.
+    const auto cursor_op = request->op();
+    if (cursor_op == remote::Op::OPEN) {
+        handle_cursor_open(request);
+    } else if (cursor_op == remote::Op::CLOSE) {
+        handle_cursor_close(request);
     } else {
-        // TODO(canepat): remove this example and fill the correct stream responses
-        const auto cursor_op = request->op();
-        if (cursor_op == remote::Op::OPEN) {
-            remote::Pair kv_pair;
-            kv_pair.set_txid(1);
-            kv_pair.set_cursorid(1);
-            SILK_INFO << "Tx peer: " << peer() << " op=" << remote::Op_Name(cursor_op) << " cursor=" << kv_pair.cursorid();
-            const bool sent = send_response(kv_pair);
-            SILK_TRACE << "TxFactory::process " << this << " open cursor: " << kv_pair.cursorid() << " sent: " << sent;
-        } else if (cursor_op == remote::Op::CLOSE) {
-            SILK_INFO << "Tx peer: " << peer() << " op=" << remote::Op_Name(cursor_op) << " cursor=" << request->cursor();
-            const bool sent = send_response(remote::Pair{});
-            SILK_TRACE << "TxFactory::process " << this << " close cursor: " << request->cursor() << " sent: " << sent;
-        } else {
-            SILK_INFO << "Tx peer: " << peer() << " op=" << remote::Op_Name(cursor_op) << " cursor=" << request->cursor();
-            remote::Pair kv_pair;
-            const bool sent = send_response(kv_pair);
-            SILK_TRACE << "TxFactory::process " << this << " cursor: " << request->cursor() << " sent: " << sent;
-        }
+        handle_cursor_operation(request);
     }
 
     SILK_TRACE << "TxCall::process " << this << " request: " << request << " END";
 }
 
-TxCallFactory::TxCallFactory(const EthereumBackEnd& backend)
-    : CallFactory<remote::KV::AsyncService, TxCall>(&remote::KV::AsyncService::RequestTx),
-    chaindata_env_(backend.chaindata_env()) {
+void TxCall::end() {
+    SILK_TRACE << "TxCall::end " << this << " START";
+
+    // The client has closed its stream of requests, we can release cursors immediately.
+    cursors_.clear();
+
+    // Stop the max TTL timer.
+    max_ttl_timer_.cancel();
+
+    SILK_TRACE << "TxCall::end " << this << " END";
 }
 
-StateChangesCall::StateChangesCall(remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
-    : ServerStreamingRpc<remote::KV::AsyncService, remote::StateChangeRequest, remote::StateChangeBatch>(service, queue, handlers) {
+void TxCall::handle_cursor_open(const remote::Cursor* request) {
+    const std::string& bucket_name = request->bucketname();
+
+    // Bucket name must be a valid MDBX map name
+    if (!db::has_map(read_only_txn_, bucket_name.c_str())) {
+        const auto error_message = "unknown bucket: " + request->bucketname();
+        SILK_ERROR << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " " << error_message;
+        finish_with_error(grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, error_message});
+        return;
+    }
+
+    // Create a new database cursor tracking also bucket name (needed for reopening).
+    const db::MapConfig map_config{bucket_name.c_str()};
+    db::Cursor cursor{read_only_txn_, map_config};
+    const auto [cursor_it, inserted] = cursors_.insert({++next_cursor_id_, TxCursor{std::move(cursor), bucket_name}});
+
+    // Send the assigned cursor ID back to the client.
+    remote::Pair kv_pair;
+    kv_pair.set_cursorid(cursor_it->first);
+    SILK_INFO << "Tx peer: " << peer() << " opened cursor: " << kv_pair.cursorid();
+    const bool sent = send_response(kv_pair);
+    SILK_TRACE << "TxCall::handle_cursor_open " << this << " open cursor: " << kv_pair.cursorid() << " sent: " << sent;
+}
+
+void TxCall::handle_cursor_operation(const remote::Cursor* request) {
+    const auto cursor_it = cursors_.find(request->cursor());
+    if (cursor_it == cursors_.end()) {
+        const auto error_message = "unknown cursor: " + std::to_string(request->cursor());
+        SILK_ERROR << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " " << error_message;
+        finish_with_error(grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, error_message});
+        return;
+    }
+    db::Cursor& cursor = cursor_it->second.cursor;
+    handle_operation(request, cursor);
+    remote::Pair kv_pair;
+    const bool sent = send_response(kv_pair);
+    SILK_TRACE << "TxCall::handle_cursor_operation " << this << " cursor: " << request->cursor() << " sent: " << sent;
+}
+
+void TxCall::handle_cursor_close(const remote::Cursor* request) {
+    const auto cursor_it = cursors_.find(request->cursor());
+    if (cursor_it == cursors_.end()) {
+        const auto error_message = "unknown cursor: " + std::to_string(request->cursor());
+        SILK_ERROR << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " " << error_message;
+        finish_with_error(grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, error_message});
+        return;
+    }
+    cursors_.erase(cursor_it);
+    SILK_INFO << "Tx peer: " << peer() << " closed cursor: " << request->cursor();
+    const bool sent = send_response(remote::Pair{});
+    SILK_TRACE << "TxCall::handle_cursor_close " << this << " close cursor: " << request->cursor() << " sent: " << sent;
+}
+
+void TxCall::handle_operation(const remote::Cursor* request, const db::Cursor& /*cursor*/) {
+    SILK_INFO << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " cursor=" << request->cursor();
+}
+
+void TxCall::handle_max_ttl_timer_expired(const boost::system::error_code& ec) {
+    SILK_TRACE << "TxCall::handle_max_ttl_timer_expired " << this << " ec: " << ec << " START";
+    if (!ec) {
+        std::vector<CursorPosition> positions{cursors_.size()};
+        const bool save_success = save_cursors(positions);
+        if (!save_success) {
+            const auto error_message = "cannot save state of cursors";
+            SILK_ERROR << "Tx peer: " << peer() << " " << error_message;
+            finish_with_error(grpc::Status{grpc::StatusCode::INTERNAL, error_message});
+        }
+        SILK_DEBUG << "Tx peer: " << peer() << " #cursors: " << cursors_.size() << " saved";
+
+        read_only_txn_.abort();
+        read_only_txn_ = chaindata_env_->start_read();
+
+        const bool restore_success = restore_cursors(positions);
+        if (!restore_success) {
+            const auto error_message = "cannot restore state of cursors";
+            SILK_ERROR << "Tx peer: " << peer() << " " << error_message;
+            finish_with_error(grpc::Status{grpc::StatusCode::INTERNAL, error_message});
+        }
+        SILK_DEBUG << "Tx peer: " << peer() << " #cursors: " << cursors_.size() << " restored";
+
+        max_ttl_timer_.expires_from_now(boost::posix_time::milliseconds(kMaxTxDuration));
+        max_ttl_timer_.async_wait([&](const auto& error_code) { handle_max_ttl_timer_expired(error_code); });
+        SILK_DEBUG << "Tx peer: " << peer() << " max TTL timer expires at: " << max_ttl_timer_.expires_at();
+    }
+    SILK_TRACE << "TxCall::handle_max_ttl_timer_expired " << this << " ec: " << ec << " END";
+}
+
+bool TxCall::save_cursors(std::vector<CursorPosition>& positions) {
+    for (const auto& [_, tx_cursor]: cursors_) {
+        const auto result = tx_cursor.cursor.current(/*throw_notfound=*/false);
+        if (!result) return false;
+        mdbx::slice key = result.key;
+        mdbx::slice value = result.value;
+        positions.emplace_back(CursorPosition{key.as_string(), value.as_string()});
+    }
+
+    return true;
+}
+
+bool TxCall::restore_cursors(std::vector<CursorPosition>& positions) {
+    for (auto& [_, tx_cursor]: cursors_) {
+        const db::MapConfig map_config{tx_cursor.bucket_name.c_str()};
+        db::Cursor cursor{read_only_txn_, map_config};
+
+        const auto& [key, value] = positions.back();
+        positions.pop_back();
+        mdbx::slice key_slice{key.c_str()};
+
+        //TODO(canepat): change db::Cursor and replace with: cursor.map_flags() & MDBX_DUPSORT
+        if (cursor.txn().get_handle_info(cursor.map()).flags & MDBX_DUPSORT) {
+            mdbx::slice value_slice{value.c_str()};
+            const auto result = cursor.lower_bound_multivalue(key_slice, value_slice, /*throw_notfound=*/false);
+            if (!result) return false;
+        } else {
+            const bool found = cursor.seek(key_slice);
+            if (!found) return false;
+        }
+
+        tx_cursor.cursor = std::move(cursor);
+    }
+
+    return true;
+}
+
+TxCallFactory::TxCallFactory(const EthereumBackEnd& backend)
+    : CallFactory<remote::KV::AsyncService, TxCall>(&remote::KV::AsyncService::RequestTx) {
+    TxCall::set_chaindata_env(backend.chaindata_env());
+}
+
+StateChangesCall::StateChangesCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
+    : ServerStreamingRpc<remote::KV::AsyncService, remote::StateChangeRequest, remote::StateChangeBatch>(scheduler, service, queue, handlers) {
 }
 
 void StateChangesCall::process(const remote::StateChangeRequest* request) {
@@ -132,11 +282,11 @@ StateChangesCallFactory::StateChangesCallFactory()
 KvService::KvService(const EthereumBackEnd& backend) : tx_factory_{backend} {
 }
 
-void KvService::register_kv_request_calls(remote::KV::AsyncService* async_service, grpc::ServerCompletionQueue* queue) {
+void KvService::register_kv_request_calls(boost::asio::io_context& scheduler, remote::KV::AsyncService* async_service, grpc::ServerCompletionQueue* queue) {
     // Register one requested call for each RPC factory
-    kv_version_factory_.create_rpc(async_service, queue);
-    tx_factory_.create_rpc(async_service, queue);
-    state_changes_factory_.create_rpc(async_service, queue);
+    kv_version_factory_.create_rpc(scheduler, async_service, queue);
+    tx_factory_.create_rpc(scheduler, async_service, queue);
+    state_changes_factory_.create_rpc(scheduler, async_service, queue);
 }
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -324,6 +324,7 @@ bool TxCall::restore_cursors(std::vector<CursorPosition>& positions) {
         db::Cursor cursor{read_only_txn_, map_config};
 
         const auto& [current_key, current_value] = positions.back();
+        SILK_LOG << "Tx restore cursor " << cursor_id << " current_key: " << current_key << " current_value: " << current_value;
         positions.pop_back();
         mdbx::slice key{current_key.c_str()};
 
@@ -525,8 +526,8 @@ void TxCall::handle_last_dup(const remote::Cursor* request, db::Cursor& cursor) 
         SILK_LOG << "Tx LAST_DUP result: " << detail::dump_mdbx_result(result);
 
         remote::Pair kv_pair;
-        if (result) {
-            kv_pair.set_k(result.key.as_string());
+        // Do not use `operator bool(result)` to avoid MDBX Assertion `!done || (bool(key) && bool(value))' failed
+        if (result.done && result.value) {
             kv_pair.set_v(result.value.as_string());
         }
 

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -205,12 +205,15 @@ void TxCall::handle_operation(const remote::Cursor* request, db::Cursor& cursor)
         }
         break;
         case remote::Op::CURRENT: {
+            handle_current(request, cursor);
         }
         break;
         case remote::Op::LAST: {
+            handle_last(request, cursor);
         }
         break;
         case remote::Op::LAST_DUP: {
+            handle_last_dup(request, cursor);
         }
         break;
         case remote::Op::NEXT: {
@@ -218,9 +221,11 @@ void TxCall::handle_operation(const remote::Cursor* request, db::Cursor& cursor)
         }
         break;
         case remote::Op::NEXT_DUP: {
+            handle_next_dup(request, cursor);
         }
         break;
         case remote::Op::NEXT_NO_DUP: {
+            handle_next_no_dup(request, cursor);
         }
         break;
         case remote::Op::PREV: {
@@ -354,6 +359,42 @@ void TxCall::handle_seek(const remote::Cursor* request, db::Cursor& cursor) {
     }
 }
 
+void TxCall::handle_current(const remote::Cursor* request, db::Cursor& cursor) {
+    SILK_TRACE << "TxCall::handle_current " << this << " START";
+    const mdbx::cursor::move_result result = cursor.to_next_first_multi(/*throw_notfound=*/false);
+    if (result) {
+        const bool sent = send_response_pair(result);
+        SILK_TRACE << "TxCall::handle_current " << this << " sent: " << sent << " END";
+    } else {
+        finish_with_internal_error(request);
+        SILK_TRACE << "TxCall::handle_current " << this << " END";
+    }
+}
+
+void TxCall::handle_last(const remote::Cursor* request, db::Cursor& cursor) {
+    SILK_TRACE << "TxCall::handle_last " << this << " START";
+    const mdbx::cursor::move_result result = cursor.to_last(/*throw_notfound=*/false);
+    if (result) {
+        const bool sent = send_response_pair(result);
+        SILK_TRACE << "TxCall::handle_last " << this << " sent: " << sent << " END";
+    } else {
+        finish_with_internal_error(request);
+        SILK_TRACE << "TxCall::handle_last " << this << " END";
+    }
+}
+
+void TxCall::handle_last_dup(const remote::Cursor* request, db::Cursor& cursor) {
+    SILK_TRACE << "TxCall::handle_last_dup " << this << " START";
+    const mdbx::cursor::move_result result = cursor.to_current_last_multi(/*throw_notfound=*/false);
+    if (result) {
+        const bool sent = send_response_pair(result);
+        SILK_TRACE << "TxCall::handle_last_dup " << this << " sent: " << sent << " END";
+    } else {
+        finish_with_internal_error(request);
+        SILK_TRACE << "TxCall::handle_last_dup " << this << " END";
+    }
+}
+
 void TxCall::handle_next(const remote::Cursor* request, db::Cursor& cursor) {
     SILK_TRACE << "TxCall::handle_next " << this << " START";
     const mdbx::cursor::move_result result = cursor.to_next(/*throw_notfound=*/false);
@@ -363,6 +404,30 @@ void TxCall::handle_next(const remote::Cursor* request, db::Cursor& cursor) {
     } else {
         finish_with_internal_error(request);
         SILK_TRACE << "TxCall::handle_next " << this << " END";
+    }
+}
+
+void TxCall::handle_next_dup(const remote::Cursor* request, db::Cursor& cursor) {
+    SILK_TRACE << "TxCall::handle_next_dup " << this << " START";
+    const mdbx::cursor::move_result result = cursor.to_current_next_multi(/*throw_notfound=*/false);
+    if (result) {
+        const bool sent = send_response_pair(result);
+        SILK_TRACE << "TxCall::handle_next_dup " << this << " sent: " << sent << " END";
+    } else {
+        finish_with_internal_error(request);
+        SILK_TRACE << "TxCall::handle_next_dup " << this << " END";
+    }
+}
+
+void TxCall::handle_next_no_dup(const remote::Cursor* request, db::Cursor& cursor) {
+    SILK_TRACE << "TxCall::handle_next_no_dup " << this << " START";
+    const mdbx::cursor::move_result result = cursor.to_next_first_multi(/*throw_notfound=*/false);
+    if (result) {
+        const bool sent = send_response_pair(result);
+        SILK_TRACE << "TxCall::handle_next_no_dup " << this << " sent: " << sent << " END";
+    } else {
+        finish_with_internal_error(request);
+        SILK_TRACE << "TxCall::handle_next_no_dup " << this << " END";
     }
 }
 

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -25,9 +25,7 @@ namespace silkworm::rpc {
 
 types::VersionReply KvVersionCall::response_;
 
-using Version = std::tuple<uint32_t, uint32_t, uint32_t>;
-
-static auto higher_version(Version lhs, Version rhs) {
+KvVersion higher_version(KvVersion lhs, KvVersion rhs) {
     uint32_t lhs_major = std::get<0>(lhs);
     uint32_t lhs_minor = std::get<1>(lhs);
     uint32_t rhs_major = std::get<0>(rhs);

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -289,7 +289,7 @@ void TxCall::handle_max_ttl_timer_expired(const boost::system::error_code& ec) {
 bool TxCall::save_cursors(std::vector<CursorPosition>& positions) {
     for (const auto& [_, tx_cursor]: cursors_) {
         const auto result = tx_cursor.cursor.current(/*throw_notfound=*/false);
-        SILK_LOG << "TxCall::save_cursors result: " << result;
+        SILK_LOG << "TxCall::save_cursors result: d=" << result.done << " b(k)=" << bool(result.key) << " b(v)=" << bool(result.value);
         if (!result) {
             return false;
         }
@@ -314,14 +314,14 @@ bool TxCall::restore_cursors(std::vector<CursorPosition>& positions) {
         if (cursor.txn().get_handle_info(cursor.map()).flags & MDBX_DUPSORT) {
             mdbx::slice value_slice{value.c_str()};
             const auto lbm_result = cursor.lower_bound_multivalue(key_slice, value_slice, /*throw_notfound=*/false);
-            SILK_LOG << "TxCall::restore_cursors lbm_result: " << lbm_result;
+            SILK_LOG << "TxCall::restore_cursors lbm_result: d=" << lbm_result.done << " b(k)=" << bool(lbm_result.key) << " b(v)=" << bool(lbm_result.value);
             if (!lbm_result) {
                 return false;
             }
             // It may happen that key where we stopped disappeared after transaction reopen, then just move to next key
             if (!lbm_result.value) {
                 const auto next_result = cursor.to_next(/*throw_notfound=*/false);
-                SILK_LOG << "TxCall::restore_cursors next_result: " << next_result;
+                SILK_LOG << "TxCall::restore_cursors next_result: d=" << next_result.done << " b(k)=" << bool(next_result.key) << " b(v)=" << bool(next_result.value);
                 if (!next_result) {
                     return false;
                 }
@@ -365,10 +365,10 @@ void TxCall::handle_first_dup(const remote::Cursor* request, db::Cursor& cursor)
         remote::Pair kv_pair;
 
         const auto first_result = cursor.to_first(/*throw_notfound=*/false);
-        SILK_LOG << "TxCall::handle_first_dup first_result: " << first_result;
+        SILK_LOG << "TxCall::handle_first_dup first_result: d=" << first_result.done << " b(k)=" << bool(first_result.key) << " b(v)=" << bool(first_result.value);
         if (first_result) {
             const auto first_dup_result = cursor.to_current_first_multi(/*throw_notfound=*/false);
-            SILK_LOG << "TxCall::handle_first_dup first_dup_result: " << first_dup_result;
+            SILK_LOG << "TxCall::handle_first_dup first_dup_result: d=" << first_dup_result.done << " b(k)=" << bool(first_dup_result.key) << " b(v)=" << bool(first_dup_result.value);
             if (first_dup_result) {
                 kv_pair.set_v(first_dup_result.value.as_string());
             }

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -328,11 +328,8 @@ bool TxCall::restore_cursors(std::vector<CursorPosition>& positions) {
             mdbx::slice value{current_value.c_str()};
             const auto lbm_result = cursor.lower_bound_multivalue(key, value, /*throw_notfound=*/false);
             SILK_LOG << "Tx restore cursor " << cursor_id << " for: " << bucket_name << " lbm_result: " << detail::dump_mdbx_result(lbm_result);
-            if (!lbm_result) {
-                return false;
-            }
             // It may happen that key where we stopped disappeared after transaction reopen, then just move to next key
-            if (!lbm_result.value) {
+            if (!lbm_result) {
                 const auto next_result = cursor.to_next(/*throw_notfound=*/false);
                 SILK_LOG << "Tx restore cursor " << cursor_id << " for: " << bucket_name << " next_result: " << detail::dump_mdbx_result(next_result);
                 if (!next_result) {

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -334,12 +334,14 @@ bool TxCall::restore_cursors(std::vector<CursorPosition>& positions) {
             SILK_LOG << "Tx restore cursor " << cursor_id << " for: " << bucket_name << " lbm_result: " << detail::dump_mdbx_result(lbm_result);
             // It may happen that key where we stopped disappeared after transaction reopen, then just move to next key
             if (!lbm_result) {
+                SILK_LOG << "Tx restore cursor " << cursor_id << " before to_next";
                 const auto next_result = cursor.to_next(/*throw_notfound=*/false);
                 SILK_LOG << "Tx restore cursor " << cursor_id << " for: " << bucket_name << " next_result: " << detail::dump_mdbx_result(next_result);
                 if (!next_result) {
                     return false;
                 }
             }
+            SILK_LOG << "Tx restore cursor " << cursor_id << " completed";
         } else {
             const auto result = (key.length() == 0) ?
                 cursor.to_first(/*throw_notfound=*/false) :

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -69,10 +69,10 @@ KvVersionCallFactory::KvVersionCallFactory()
     KvVersionCall::fill_predefined_reply();
 }
 
-mdbx::env_managed* TxCall::chaindata_env_{nullptr};
+mdbx::env* TxCall::chaindata_env_{nullptr};
 uint32_t TxCall::next_cursor_id_{0};
 
-void TxCall::set_chaindata_env(mdbx::env_managed* chaindata_env) {
+void TxCall::set_chaindata_env(mdbx::env* chaindata_env) {
     TxCall::chaindata_env_ = chaindata_env;
 }
 

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -104,7 +104,7 @@ void TxCall::start() {
     try {
         SILKWORM_ASSERT(!read_only_txn_);
 
-        SILK_DEBUG << "TxCall::start MDBX info: " << chaindata_env_->get_info().mi_numreaders;
+        SILK_DEBUG << "TxCall::start MDBX readers: " << chaindata_env_->get_info().mi_numreaders;
 
         // Create a new read-only transaction.
         read_only_txn_ = chaindata_env_->start_read();

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -110,22 +110,39 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
 
     bool restore_cursors(std::vector<CursorPosition>& positions);
 
-    void handle_first(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_first_dup(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_seek(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_seek_both(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_seek_exact(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_seek_both_exact(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_current(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_last(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_last_dup(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_next(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_next_dup(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_next_no_dup(const remote::Cursor* request, db::Cursor& cursor);
-    void handle_prev(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_first(db::Cursor& cursor);
 
-    void finish_with_internal_error(const remote::Cursor* request, const std::exception& exc);
-    void finish_with_internal_error(const std::string& error_message);
+    void handle_first_dup(db::Cursor& cursor);
+
+    void handle_seek(const remote::Cursor* request, db::Cursor& cursor);
+
+    void handle_seek_both(const remote::Cursor* request, db::Cursor& cursor);
+
+    void handle_seek_exact(const remote::Cursor* request, db::Cursor& cursor);
+
+    void handle_seek_both_exact(const remote::Cursor* request, db::Cursor& cursor);
+
+    void handle_current(db::Cursor& cursor);
+
+    void handle_last(db::Cursor& cursor);
+
+    void handle_last_dup(db::Cursor& cursor);
+
+    void handle_next(db::Cursor& cursor);
+
+    void handle_next_dup(db::Cursor& cursor);
+
+    void handle_next_no_dup(db::Cursor& cursor);
+
+    void handle_prev(db::Cursor& cursor);
+
+    void handle_prev_dup(db::Cursor& cursor);
+
+    void handle_prev_no_dup(db::Cursor& cursor);
+
+    void close_with_internal_error(const remote::Cursor* request, const std::exception& exc);
+
+    void close_with_internal_error(const std::string& error_message);
 
     static mdbx::env* chaindata_env_;
     static boost::posix_time::milliseconds max_ttl_duration_;

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -106,6 +106,9 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
     void handle_first(const remote::Cursor* request, db::Cursor& cursor);
     void handle_first_dup(const remote::Cursor* request, db::Cursor& cursor);
     void handle_seek(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_seek_both(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_seek_exact(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_seek_both_exact(const remote::Cursor* request, db::Cursor& cursor);
     void handle_current(const remote::Cursor* request, db::Cursor& cursor);
     void handle_last(const remote::Cursor* request, db::Cursor& cursor);
     void handle_last_dup(const remote::Cursor* request, db::Cursor& cursor);

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -17,6 +17,7 @@
 #ifndef SILKWORM_RPC_KV_FACTORIES_HPP_
 #define SILKWORM_RPC_KV_FACTORIES_HPP_
 
+#include <exception>
 #include <map>
 #include <tuple>
 #include <vector>
@@ -123,8 +124,7 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
     void handle_next_no_dup(const remote::Cursor* request, db::Cursor& cursor);
     void handle_prev(const remote::Cursor* request, db::Cursor& cursor);
 
-    bool send_response_pair(const mdbx::cursor::move_result& result);
-    void finish_with_internal_error(const remote::Cursor* request);
+    void finish_with_internal_error(const remote::Cursor* request, const std::exception& exc);
     void finish_with_internal_error(const std::string& error_message);
 
     static mdbx::env* chaindata_env_;

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -37,11 +37,15 @@
 
 namespace silkworm::rpc {
 
+using KvVersion = std::tuple<uint32_t, uint32_t, uint32_t>;
+
+KvVersion higher_version(KvVersion lhs, KvVersion rhs);
+
 //! Current DB schema version.
-constexpr auto kDbSchemaVersion = std::make_tuple<uint32_t, uint32_t, uint32_t>(3, 0, 0);
+constexpr auto kDbSchemaVersion = KvVersion{3, 0, 0};
 
 //! Current KV API protocol version.
-constexpr auto kKvApiVersion = std::make_tuple<uint32_t, uint32_t, uint32_t>(5, 1, 0);
+constexpr auto kKvApiVersion = KvVersion{5, 1, 0};
 
 //! The max life duration for MDBX transactions (long-lived transactions are discouraged).
 constexpr uint32_t kMaxTxDuration{60'000}; // milliseconds

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -116,6 +116,7 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
 
     bool send_response_pair(const mdbx::cursor::move_result& result);
     void finish_with_internal_error(const remote::Cursor* request);
+    void finish_with_internal_error(const std::string& error_message);
 
     static mdbx::env* chaindata_env_;
     static uint32_t next_cursor_id_;

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -95,13 +95,22 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
 
     void handle_cursor_close(const remote::Cursor* request);
 
-    void handle_operation(const remote::Cursor* request, const db::Cursor& cursor);
+    void handle_operation(const remote::Cursor* request, db::Cursor& cursor);
 
     void handle_max_ttl_timer_expired(const boost::system::error_code& ec);
 
     bool save_cursors(std::vector<CursorPosition>& positions);
 
     bool restore_cursors(std::vector<CursorPosition>& positions);
+
+    void handle_first(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_first_dup(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_seek(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_next(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_prev(const remote::Cursor* request, db::Cursor& cursor);
+
+    bool send_response_pair(const mdbx::cursor::move_result& result);
+    void finish_with_internal_error(const remote::Cursor* request);
 
     static mdbx::env_managed* chaindata_env_;
     static uint32_t next_cursor_id_;

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -106,7 +106,12 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
     void handle_first(const remote::Cursor* request, db::Cursor& cursor);
     void handle_first_dup(const remote::Cursor* request, db::Cursor& cursor);
     void handle_seek(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_current(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_last(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_last_dup(const remote::Cursor* request, db::Cursor& cursor);
     void handle_next(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_next_dup(const remote::Cursor* request, db::Cursor& cursor);
+    void handle_next_no_dup(const remote::Cursor* request, db::Cursor& cursor);
     void handle_prev(const remote::Cursor* request, db::Cursor& cursor);
 
     bool send_response_pair(const mdbx::cursor::move_result& result);

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -41,7 +41,7 @@ namespace silkworm::rpc {
 
 using KvVersion = std::tuple<uint32_t, uint32_t, uint32_t>;
 
-KvVersion higher_version(KvVersion lhs, KvVersion rhs);
+KvVersion higher_version_ignoring_patch(KvVersion lhs, KvVersion rhs);
 
 //! Current DB schema version.
 constexpr auto kDbSchemaVersion = KvVersion{3, 0, 0};

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -68,7 +68,7 @@ class KvVersionCallFactory : public CallFactory<remote::KV::AsyncService, KvVers
 //! Bidirectional-streaming RPC for Tx method of 'kv' gRPC protocol.
 class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote::Cursor, remote::Pair> {
   public:
-    static void set_chaindata_env(mdbx::env_managed* chaindata_env);
+    static void set_chaindata_env(mdbx::env* chaindata_env);
 
     TxCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
@@ -117,7 +117,7 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
     bool send_response_pair(const mdbx::cursor::move_result& result);
     void finish_with_internal_error(const remote::Cursor* request);
 
-    static mdbx::env_managed* chaindata_env_;
+    static mdbx::env* chaindata_env_;
     static uint32_t next_cursor_id_;
 
     mdbx::txn_managed read_only_txn_;

--- a/node/silkworm/rpc/kv_calls_test.cpp
+++ b/node/silkworm/rpc/kv_calls_test.cpp
@@ -20,41 +20,41 @@
 
 namespace silkworm::rpc {
 
-TEST_CASE("higher_version", "[silkworm][rpc][kv_calls]") {
+TEST_CASE("higher_version_ignoring_patch", "[silkworm][rpc][kv_calls]") {
     SECTION("lhs.major > rhs.major") {
         KvVersion lhs{2, 0, 0};
         KvVersion rhs{1, 0, 0};
-        CHECK(higher_version(lhs, rhs) == lhs);
+        CHECK(higher_version_ignoring_patch(lhs, rhs) == lhs);
     }
 
     SECTION("rhs.major > lhs.major") {
         KvVersion lhs{2, 0, 0};
         KvVersion rhs{3, 0, 0};
-        CHECK(higher_version(lhs, rhs) == rhs);
+        CHECK(higher_version_ignoring_patch(lhs, rhs) == rhs);
     }
 
     SECTION("lhs.minor > rhs.minor") {
         KvVersion lhs{2, 5, 0};
         KvVersion rhs{2, 2, 0};
-        CHECK(higher_version(lhs, rhs) == lhs);
+        CHECK(higher_version_ignoring_patch(lhs, rhs) == lhs);
     }
 
     SECTION("rhs.minor > lhs.minor") {
         KvVersion lhs{2, 5, 0};
         KvVersion rhs{2, 6, 0};
-        CHECK(higher_version(lhs, rhs) == rhs);
+        CHECK(higher_version_ignoring_patch(lhs, rhs) == rhs);
     }
 
     SECTION("patch not relevant") {
         KvVersion lhs1{2, 5, 0};
         KvVersion rhs1{2, 5, 0};
-        CHECK(higher_version(lhs1, rhs1) == lhs1);
+        CHECK(higher_version_ignoring_patch(lhs1, rhs1) == lhs1);
         KvVersion lhs2{2, 5, 1};
         KvVersion rhs2{2, 5, 0};
-        CHECK(higher_version(lhs2, rhs2) == lhs2);
+        CHECK(higher_version_ignoring_patch(lhs2, rhs2) == lhs2);
         KvVersion lhs3{2, 5, 0};
         KvVersion rhs3{2, 5, 1};
-        CHECK(higher_version(lhs3, rhs3) == lhs3);
+        CHECK(higher_version_ignoring_patch(lhs3, rhs3) == lhs3);
     }
 }
 

--- a/node/silkworm/rpc/kv_calls_test.cpp
+++ b/node/silkworm/rpc/kv_calls_test.cpp
@@ -14,48 +14,46 @@
    limitations under the License.
 */
 
-#include "kv_calls.cpp"
+#include "kv_calls.hpp"
 
 #include <catch2/catch.hpp>
-
-#include <silkworm/common/base.hpp>
 
 namespace silkworm::rpc {
 
 TEST_CASE("higher_version", "[silkworm][rpc][kv_calls]") {
     SECTION("lhs.major > rhs.major") {
-        Version lhs{2, 0, 0};
-        Version rhs{1, 0, 0};
+        KvVersion lhs{2, 0, 0};
+        KvVersion rhs{1, 0, 0};
         CHECK(higher_version(lhs, rhs) == lhs);
     }
 
     SECTION("rhs.major > lhs.major") {
-        Version lhs{2, 0, 0};
-        Version rhs{3, 0, 0};
+        KvVersion lhs{2, 0, 0};
+        KvVersion rhs{3, 0, 0};
         CHECK(higher_version(lhs, rhs) == rhs);
     }
 
     SECTION("lhs.minor > rhs.minor") {
-        Version lhs{2, 5, 0};
-        Version rhs{2, 2, 0};
+        KvVersion lhs{2, 5, 0};
+        KvVersion rhs{2, 2, 0};
         CHECK(higher_version(lhs, rhs) == lhs);
     }
 
     SECTION("rhs.minor > lhs.minor") {
-        Version lhs{2, 5, 0};
-        Version rhs{2, 6, 0};
+        KvVersion lhs{2, 5, 0};
+        KvVersion rhs{2, 6, 0};
         CHECK(higher_version(lhs, rhs) == rhs);
     }
 
     SECTION("patch not relevant") {
-        Version lhs1{2, 5, 0};
-        Version rhs1{2, 5, 0};
+        KvVersion lhs1{2, 5, 0};
+        KvVersion rhs1{2, 5, 0};
         CHECK(higher_version(lhs1, rhs1) == lhs1);
-        Version lhs2{2, 5, 1};
-        Version rhs2{2, 5, 0};
+        KvVersion lhs2{2, 5, 1};
+        KvVersion rhs2{2, 5, 0};
         CHECK(higher_version(lhs2, rhs2) == lhs2);
-        Version lhs3{2, 5, 0};
-        Version rhs3{2, 5, 1};
+        KvVersion lhs3{2, 5, 0};
+        KvVersion rhs3{2, 5, 1};
         CHECK(higher_version(lhs3, rhs3) == lhs3);
     }
 }

--- a/node/silkworm/rpc/kv_calls_test.cpp
+++ b/node/silkworm/rpc/kv_calls_test.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "kv_calls.cpp"
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/common/base.hpp>
+
+namespace silkworm::rpc {
+
+TEST_CASE("higher_version", "[silkworm][rpc][kv_calls]") {
+    SECTION("lhs.major > rhs.major") {
+        Version lhs{2, 0, 0};
+        Version rhs{1, 0, 0};
+        CHECK(higher_version(lhs, rhs) == lhs);
+    }
+
+    SECTION("rhs.major > lhs.major") {
+        Version lhs{2, 0, 0};
+        Version rhs{3, 0, 0};
+        CHECK(higher_version(lhs, rhs) == rhs);
+    }
+
+    SECTION("lhs.minor > rhs.minor") {
+        Version lhs{2, 5, 0};
+        Version rhs{2, 2, 0};
+        CHECK(higher_version(lhs, rhs) == lhs);
+    }
+
+    SECTION("rhs.minor > lhs.minor") {
+        Version lhs{2, 5, 0};
+        Version rhs{2, 6, 0};
+        CHECK(higher_version(lhs, rhs) == rhs);
+    }
+
+    SECTION("patch not relevant") {
+        Version lhs1{2, 5, 0};
+        Version rhs1{2, 5, 0};
+        CHECK(higher_version(lhs1, rhs1) == lhs1);
+        Version lhs2{2, 5, 1};
+        Version rhs2{2, 5, 0};
+        CHECK(higher_version(lhs2, rhs2) == lhs2);
+        Version lhs3{2, 5, 0};
+        Version rhs3{2, 5, 1};
+        CHECK(higher_version(lhs3, rhs3) == lhs3);
+    }
+}
+
+} // namespace silkworm::rpc


### PR DESCRIPTION
This PR introduces the initial implementation of KV Tx bidirectional RPC. Key points:
- every new Tx incoming RPC creates a new MDBX read-only transaction
- one unsolicited message containing the txn ID is notified to the client
- cursor open/close and tracking by pairing `db::Cursor` with table name to support reopening
- one max txn TTL timer protects against long-lived txn by aborting/reopening the txn on behalf of the client, opened cursors are saved/restored transparently
- another idle timer protects against clients which don't send any (more) requests and eventually terminates the RPC

TODOLIST:
- check errors when limits are reached (max number of txns, max number of cursors per txn), if applicable