### PR TITLE
Adapting EvmTracer to evmone::Tracer

### DIFF
--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -45,9 +45,9 @@ class DelegatingTracer : public evmone::Tracer {
         tracer_.on_execution_start(rev, msg, code);
     }
 
-    void on_instruction_start(uint32_t pc, const intx::uint256*, int,
+    void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height,
                               const evmone::ExecutionState& state) noexcept override {
-        tracer_.on_instruction_start(pc, state, intra_block_state_);
+        tracer_.on_instruction_start(pc, stack_top, stack_height, state, intra_block_state_);
     }
 
     void on_execution_end(const evmc_result& result) noexcept override {

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -41,7 +41,7 @@ class EvmTracer {
   public:
     virtual void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept = 0;
 
-    virtual void on_instruction_start(uint32_t pc, const evmone::ExecutionState& state,
+    virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, const evmone::ExecutionState& state,
                                       const IntraBlockState& intra_block_state) noexcept = 0;
 
     virtual void on_execution_end(const evmc_result& result, const IntraBlockState& intra_block_state) noexcept = 0;

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -411,7 +411,7 @@ TEST_CASE("Tracing smart contract with storage") {
                                 evmone::bytes_view bytecode) noexcept override {
             bytecode_ = Bytes{bytecode};
         }
-        void on_instruction_start(uint32_t pc, const intx::uint256*, int, 
+        void on_instruction_start(uint32_t pc, const intx::uint256* /*stack_top*/, int /*stack_height*/, 
             const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override {
             pc_stack_.push_back(pc);
             memory_size_stack_[pc] = state.memory.size();

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -411,8 +411,8 @@ TEST_CASE("Tracing smart contract with storage") {
                                 evmone::bytes_view bytecode) noexcept override {
             bytecode_ = Bytes{bytecode};
         }
-        void on_instruction_start(uint32_t pc, const evmone::ExecutionState& state,
-                                  const IntraBlockState& intra_block_state) noexcept override {
+        void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, 
+            const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override {
             pc_stack_.push_back(pc);
             memory_size_stack_[pc] = state.memory.size();
             if (contract_address_) {

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -411,7 +411,7 @@ TEST_CASE("Tracing smart contract with storage") {
                                 evmone::bytes_view bytecode) noexcept override {
             bytecode_ = Bytes{bytecode};
         }
-        void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, 
+        void on_instruction_start(uint32_t pc, const intx::uint256*, int, 
             const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override {
             pc_stack_.push_back(pc);
             memory_size_stack_[pc] = state.memory.size();


### PR DESCRIPTION
Adding stack_height and stack_top to get the stack values, since evmone::ExecutionState doesn't have the evmone::Stack inside itself anymore.