### PR TITLE
Skip test causing gRPC data race in sanitizer build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       CLANG_COVERAGE: OFF
       SANITIZE: OFF
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:202010-01
     resource_class: xlarge
     steps:
       - checkout_with_submodules
@@ -173,7 +173,7 @@ jobs:
 
   linux-wasm-build:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:202010-01
     steps:
       - checkout_with_submodules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       CLANG_COVERAGE: OFF
       SANITIZE: OFF
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202201-02
     resource_class: xlarge
     steps:
       - checkout_with_submodules
@@ -173,7 +173,7 @@ jobs:
 
   linux-wasm-build:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202201-02
     steps:
       - checkout_with_submodules
       - run:

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -70,8 +70,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
   if(SILKWORM_SANITIZE)
-    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
-    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -86,8 +86,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   endif()
 
   if(SILKWORM_SANITIZE)
-    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
-    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE})
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -784,6 +784,7 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry all status KO", "[silkworm]
     }
 }
 
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
     {
         const uint32_t kNumTxs{1000};
@@ -807,6 +808,7 @@ TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][no
     }
     // Server-side lifecyle of Tx calls must be OK.
 }
+#endif // SILKWORM_SANITIZE
 
 TEST_CASE("BackEndKvServer E2E: exceed max simultaneous readers", "[silkworm][node][rpc]") {
     NodeSettings node_settings;


### PR DESCRIPTION
This PR skips one specific test in TSAN build because such test triggers some data race within the gRPC library in a very specific scenario.

The "BackEndKvServer E2E: trigger server-side write error" test is purposely written to cause write-errors on Tx RPC server-side implementation by using the bidirectional-streaming API in an unorthodox way, i.e. not reading responses after sending requests and making the Tx call end abruptly on client-side by `grpc::ClientContext` destruction.

Repeating this pattern many times triggers write-errors on Tx RPC server-side implementation and allows to check that server-side lifecycle management for Tx calls is OK but seems to result also in a frequent data race detection during sanitizer builds.