### PR TITLE
Add max cursors per txn check in KV Tx RPC

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -22,7 +22,6 @@
 #include <boost/asio/signal_set.hpp>
 #include <boost/process/environment.hpp>
 #include <CLI/CLI.hpp>
-#include <magic_enum.hpp>
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/backend/ethereum_backend.hpp>

--- a/node/silkworm/rpc/backend_calls.hpp
+++ b/node/silkworm/rpc/backend_calls.hpp
@@ -42,7 +42,7 @@ namespace silkworm::rpc {
 constexpr uint64_t kEthDevp2pProtocolVersion = 66;
 
 //! Current ETHBACKEND API protocol version.
-constexpr auto kEthBackEndApiVersion = std::make_tuple<uint32_t, uint32_t, uint32_t>(2, 2, 0);
+constexpr auto kEthBackEndApiVersion = std::make_tuple<uint32_t, uint32_t, uint32_t>(2, 3, 0);
 
 //! Unary RPC for Etherbase method of 'ethbackend' gRPC protocol.
 class EtherbaseCall : public UnaryRpc<remote::ETHBACKEND::AsyncService, remote::EtherbaseRequest, remote::EtherbaseReply> {

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -454,7 +454,7 @@ TEST_CASE("BackEndKvServer E2E: empty node settings", "[silkworm][node][rpc]") {
         const auto status = backend_client.version(&response);
         CHECK(status.ok());
         CHECK(response.major() == 2);
-        CHECK(response.minor() == 2);
+        CHECK(response.minor() == 3);
         CHECK(response.patch() == 0);
     }
 
@@ -494,7 +494,7 @@ TEST_CASE("BackEndKvServer E2E: empty node settings", "[silkworm][node][rpc]") {
         types::VersionReply response;
         const auto status = kv_client.version(&response);
         CHECK(status.ok());
-        CHECK(response.major() == 5);
+        CHECK(response.major() == 4);
         CHECK(response.minor() == 1);
         CHECK(response.patch() == 0);
     }

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -16,8 +16,6 @@
 
 #include "kv_calls.hpp"
 
-#include <limits>
-
 #include <boost/date_time/posix_time/posix_time_io.hpp>
 
 #include <silkworm/common/assert.hpp>
@@ -87,8 +85,6 @@ KvVersionCallFactory::KvVersionCallFactory()
 
 mdbx::env* TxCall::chaindata_env_{nullptr};
 boost::posix_time::milliseconds TxCall::max_ttl_duration_{kMaxTxDuration};
-uint32_t TxCall::next_cursor_id_{0};
-uint32_t TxCall::max_cursor_id_{std::numeric_limits<uint32_t>::max()};
 
 void TxCall::set_chaindata_env(mdbx::env* chaindata_env) {
     TxCall::chaindata_env_ = chaindata_env;
@@ -96,11 +92,6 @@ void TxCall::set_chaindata_env(mdbx::env* chaindata_env) {
 
 void TxCall::set_max_ttl_duration(const boost::posix_time::milliseconds& max_ttl_duration) {
     TxCall::max_ttl_duration_ = max_ttl_duration;
-}
-
-void TxCall::set_max_cursor_id(uint32_t max_cursor_id) {
-    TxCall::max_cursor_id_ = max_cursor_id;
-    TxCall::next_cursor_id_ = 0;
 }
 
 TxCall::TxCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers)
@@ -185,16 +176,10 @@ void TxCall::handle_cursor_open(const remote::Cursor* request) {
     // Create a new database cursor tracking also bucket name (needed for reopening).
     const db::MapConfig map_config{bucket_name.c_str()};
     db::Cursor cursor{read_only_txn_, map_config};
-    next_cursor_id_ = next_cursor_id_ % max_cursor_id_ + 1;
-    const auto [cursor_it, inserted] = cursors_.insert({next_cursor_id_, TxCursor{std::move(cursor), bucket_name}});
+    const auto [cursor_it, inserted] = cursors_.insert({++last_cursor_id_, TxCursor{std::move(cursor), bucket_name}});
 
-    // The assigned cursor ID shall not be already in use (after cursor ID wrapping).
-    if (!inserted) {
-        const auto error_message = "assigned cursor ID already in use: " + std::to_string(next_cursor_id_);
-        SILK_ERROR << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " " << error_message;
-        close_with_error(grpc::Status{grpc::StatusCode::ALREADY_EXISTS, error_message});
-        return;
-    }
+    SILKWORM_ASSERT(cursor_it->first == last_cursor_id_);
+    SILKWORM_ASSERT(inserted);
 
     // Send the assigned cursor ID back to the client.
     remote::Pair kv_pair;

--- a/node/silkworm/rpc/kv_calls.cpp
+++ b/node/silkworm/rpc/kv_calls.cpp
@@ -25,7 +25,7 @@ namespace silkworm::rpc {
 
 namespace detail {
 
-inline std::string dump_mdbx_result(const mdbx::cursor::move_result& result) {
+std::string dump_mdbx_result(const mdbx::cursor::move_result& result) {
     std::string dump{"done="};
     dump.append(std::to_string(result.done));
     dump.append(" bool(key)=");

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -52,6 +52,9 @@ constexpr auto kKvApiVersion = KvVersion{5, 1, 0};
 //! The max life duration for MDBX transactions (long-lived transactions are discouraged).
 constexpr boost::posix_time::milliseconds kMaxTxDuration{60'000};
 
+//! The max number of opened cursors for each remote transaction (arbitrary limit on this KV implementation).
+constexpr std::size_t kMaxTxCursors{100};
+
 //! Unary RPC for Version method of 'ethbackend' gRPC protocol.
 class KvVersionCall : public UnaryRpc<remote::KV::AsyncService, google::protobuf::Empty, types::VersionReply> {
   public:
@@ -76,6 +79,7 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
   public:
     static void set_chaindata_env(mdbx::env* chaindata_env);
     static void set_max_ttl_duration(const boost::posix_time::milliseconds& max_ttl_duration);
+    static void set_max_cursor_id(uint32_t max_cursor_id);
 
     TxCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
@@ -147,6 +151,7 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
     static mdbx::env* chaindata_env_;
     static boost::posix_time::milliseconds max_ttl_duration_;
     static uint32_t next_cursor_id_;
+    static uint32_t max_cursor_id_;
 
     mdbx::txn_managed read_only_txn_;
     boost::asio::deadline_timer max_ttl_timer_;

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -79,7 +79,6 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
   public:
     static void set_chaindata_env(mdbx::env* chaindata_env);
     static void set_max_ttl_duration(const boost::posix_time::milliseconds& max_ttl_duration);
-    static void set_max_cursor_id(uint32_t max_cursor_id);
 
     TxCall(boost::asio::io_context& scheduler, remote::KV::AsyncService* service, grpc::ServerCompletionQueue* queue, Handlers handlers);
 
@@ -150,12 +149,11 @@ class TxCall : public BidirectionalStreamingRpc<remote::KV::AsyncService, remote
 
     static mdbx::env* chaindata_env_;
     static boost::posix_time::milliseconds max_ttl_duration_;
-    static uint32_t next_cursor_id_;
-    static uint32_t max_cursor_id_;
 
     mdbx::txn_managed read_only_txn_;
     boost::asio::deadline_timer max_ttl_timer_;
     std::map<uint32_t, TxCursor> cursors_;
+    uint32_t last_cursor_id_{0};
 };
 
 //! Factory specialization for Tx method.

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -47,7 +47,7 @@ KvVersion higher_version_ignoring_patch(KvVersion lhs, KvVersion rhs);
 constexpr auto kDbSchemaVersion = KvVersion{3, 0, 0};
 
 //! Current KV API protocol version.
-constexpr auto kKvApiVersion = KvVersion{5, 1, 0};
+constexpr auto kKvApiVersion = KvVersion{4, 1, 0};
 
 //! The max life duration for MDBX transactions (long-lived transactions are discouraged).
 constexpr boost::posix_time::milliseconds kMaxTxDuration{60'000};

--- a/node/silkworm/rpc/kv_calls.hpp
+++ b/node/silkworm/rpc/kv_calls.hpp
@@ -189,6 +189,12 @@ class KvService {
     StateChangesCallFactory state_changes_factory_;
 };
 
+namespace detail {
+
+std::string dump_mdbx_result(const mdbx::cursor::move_result& result);
+
+} // namespace detail
+
 } // namespace silkworm::rpc
 
 #endif // SILKWORM_RPC_KV_FACTORIES_HPP_

--- a/node/silkworm/rpc/server_config_test.cpp
+++ b/node/silkworm/rpc/server_config_test.cpp
@@ -44,4 +44,14 @@ TEST_CASE("ServerConfig::set_num_contexts", "[silkworm][rpc][server_config]") {
     CHECK(config.num_contexts() == num_contexts);
 }
 
+TEST_CASE("ServerConfig::set_credentials", "[silkworm][rpc][server_config]") {
+    grpc::SslServerCredentialsOptions ssl_options;
+    const std::shared_ptr<grpc::ServerCredentials> server_credentials{
+        grpc::SslServerCredentials(ssl_options)
+    };
+    ServerConfig config;
+    config.set_credentials(server_credentials);
+    CHECK(config.credentials() == server_credentials);
+}
+
 } // namespace silkworm::rpc


### PR DESCRIPTION
This PR introduces a sanity check on max number of opened cursors per txn in KV Tx RPC.