### PR TITLE
Remove unnecessary mutexes in RPC server

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -203,10 +203,7 @@ int main(int argc, char* argv[]) {
         signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
             std::cout << "\n";
             SILK_INFO << "Signal caught, error: " << error << " number: " << signal_number;
-            std::thread shutdown_thread{[&server]() {
-                server.shutdown();
-            }};
-            shutdown_thread.detach();
+            server.shutdown();
         });
 
         SILK_LOG << "BackEndKvServer is now running [pid=" << pid << ", main thread=" << tid << "]";

--- a/node/silkworm/rpc/server_context_pool.cpp
+++ b/node/silkworm/rpc/server_context_pool.cpp
@@ -83,7 +83,6 @@ void ServerContextPool::add_context(std::unique_ptr<grpc::ServerCompletionQueue>
 void ServerContextPool::start() {
     SILK_TRACE << "ServerContextPool::start START";
 
-    std::unique_lock<std::mutex> lock(mutex_);
     if (!stopped_) {
         // Create a pool of threads to run all the contexts (each context having 1 thread)
         for (std::size_t i{0}; i < contexts_.size(); ++i) {
@@ -113,7 +112,6 @@ void ServerContextPool::join() {
 void ServerContextPool::stop() {
     SILK_TRACE << "ServerContextPool::stop START";
 
-    std::lock_guard<std::mutex> guard(mutex_);
     if (!stopped_) {
         // Explicitly stop all context runnable components
         for (std::size_t i{0}; i < contexts_.size(); ++i) {

--- a/node/silkworm/rpc/server_context_pool.hpp
+++ b/node/silkworm/rpc/server_context_pool.hpp
@@ -21,7 +21,6 @@
 #include <ostream>
 #include <list>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include <boost/asio/io_context.hpp>
@@ -96,9 +95,6 @@ class ServerContextPool {
 
     //! The index for obtaining next context to use (round-robin).
     std::size_t next_index_;
-
-    //! Mutual exclusion to synchronize run/stop operations.
-    std::mutex mutex_;
 
     //! Flag indicating if pool has been stopped.
     bool stopped_{false};


### PR DESCRIPTION
This PR removes unnecessary synchronization code:
- mutexes and scoped lockes in `rpc::Server` startup/shutdown and
- shutdown thread in BackEnd and KV server main