### PR TITLE
Exclude gRPC server tests from sanitizer builds

### DIFF
--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -325,6 +325,8 @@ struct BackEndKvE2eTest {
 
 namespace silkworm::rpc {
 
+// Exclude gRPC tests from sanitizer builds due to data race warnings
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("BackEndKvServer", "[silkworm][node][rpc]") {
     silkworm::log::set_verbosity(silkworm::log::Level::kNone);
     Grpc2SilkwormLogGuard log_guard;
@@ -784,7 +786,7 @@ TEST_CASE("BackEndKvServer E2E: more than one Sentry all status KO", "[silkworm]
     }
 }
 
-#ifndef SILKWORM_SANITIZE
+
 TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
     {
         const uint32_t kNumTxs{1000};
@@ -882,7 +884,6 @@ TEST_CASE("BackEndKvServer E2E: Tx max opened cursors exceeded", "[silkworm][nod
     CHECK(status.error_code() == grpc::StatusCode::RESOURCE_EXHAUSTED);
     CHECK(status.error_message().find("maximum cursors per txn") != std::string::npos);
 }
-#endif // SILKWORM_SANITIZE
 
 class TxIdleTimeoutGuard {
   public:
@@ -2120,5 +2121,6 @@ TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][nod
         CHECK(status.ok());
     }
 }
+#endif // SILKWORM_SANITIZE
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -808,7 +808,6 @@ TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][no
     }
     // Server-side lifecyle of Tx calls must be OK.
 }
-#endif // SILKWORM_SANITIZE
 
 TEST_CASE("BackEndKvServer E2E: Tx max simultaneous readers exceeded", "[silkworm][node][rpc]") {
     NodeSettings node_settings;
@@ -845,7 +844,7 @@ TEST_CASE("BackEndKvServer E2E: Tx max simultaneous readers exceeded", "[silkwor
     }
 }
 
-/*TEST_CASE("BackEndKvServer E2E: Tx max opened cursors exceeded", "[silkworm][node][rpc]") {
+TEST_CASE("BackEndKvServer E2E: Tx max opened cursors exceeded", "[silkworm][node][rpc]") {
     NodeSettings node_settings;
     BackEndKvE2eTest test{silkworm::log::Level::kNone, node_settings};
     test.fill_tables();
@@ -882,7 +881,8 @@ TEST_CASE("BackEndKvServer E2E: Tx max simultaneous readers exceeded", "[silkwor
     CHECK(!status.ok());
     CHECK(status.error_code() == grpc::StatusCode::RESOURCE_EXHAUSTED);
     CHECK(status.error_message().find("maximum cursors per txn") != std::string::npos);
-}*/
+}
+#endif // SILKWORM_SANITIZE
 
 class TxIdleTimeoutGuard {
   public:

--- a/node/silkworm/rpc/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/backend_kv_server_test.cpp
@@ -845,7 +845,7 @@ TEST_CASE("BackEndKvServer E2E: Tx max simultaneous readers exceeded", "[silkwor
     }
 }
 
-TEST_CASE("BackEndKvServer E2E: Tx max opened cursors exceeded", "[silkworm][node][rpc]") {
+/*TEST_CASE("BackEndKvServer E2E: Tx max opened cursors exceeded", "[silkworm][node][rpc]") {
     NodeSettings node_settings;
     BackEndKvE2eTest test{silkworm::log::Level::kNone, node_settings};
     test.fill_tables();
@@ -882,7 +882,7 @@ TEST_CASE("BackEndKvServer E2E: Tx max opened cursors exceeded", "[silkworm][nod
     CHECK(!status.ok());
     CHECK(status.error_code() == grpc::StatusCode::RESOURCE_EXHAUSTED);
     CHECK(status.error_message().find("maximum cursors per txn") != std::string::npos);
-}
+}*/
 
 class TxIdleTimeoutGuard {
   public:

--- a/node/silkworm/rpc/server.hpp
+++ b/node/silkworm/rpc/server.hpp
@@ -109,9 +109,9 @@ class Server {
 
         SILK_DEBUG << "Server::shutdown " << this << " shutting down server immediately";
 
-        // Order matters here: 1) shutdown the server
+        // Order matters here: 1) shutdown the server (immediate deadline)
         if (server_) {
-            server_->Shutdown();
+            server_->Shutdown(gpr_time_0(GPR_CLOCK_REALTIME));
             server_->Wait();
         }
 

--- a/node/silkworm/rpc/server.hpp
+++ b/node/silkworm/rpc/server.hpp
@@ -109,9 +109,9 @@ class Server {
 
         SILK_DEBUG << "Server::shutdown " << this << " shutting down server immediately";
 
-        // Order matters here: 1) shutdown the server (immediate deadline)
+        // Order matters here: 1) shutdown the server
         if (server_) {
-            server_->Shutdown(gpr_time_0(GPR_CLOCK_REALTIME));
+            server_->Shutdown();
             server_->Wait();
         }
 

--- a/node/silkworm/rpc/server_context_pool_test.cpp
+++ b/node/silkworm/rpc/server_context_pool_test.cpp
@@ -39,6 +39,8 @@ inline std::ostream& null_stream() {
 
 namespace silkworm::rpc {
 
+// Exclude gRPC tests from sanitizer builds due to data race warnings
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerContext", "[silkworm][rpc][server_context]") {
     grpc::ServerBuilder builder;
     std::unique_ptr<grpc::ServerCompletionQueue> scq = builder.AddCompletionQueue();
@@ -95,5 +97,6 @@ TEST_CASE("ServerContextPool", "[silkworm][rpc][server_context]") {
         CHECK(server_context_pool.num_contexts() == 2);
     }
 }
+#endif // SILKWORM_SANITIZE
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/server_test.cpp
+++ b/node/silkworm/rpc/server_test.cpp
@@ -51,6 +51,8 @@ class EmptyServer : public Server {
 // TODO(canepat): better copy grpc_pick_unused_port_or_die to generate unused port
 constexpr const char* kTestAddressUri = "localhost:12345";
 
+// Exclude gRPC tests from sanitizer builds due to data race warnings
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("Barebone gRPC Server", "[silkworm][node][rpc]") {
     grpc::ServerBuilder builder;
     // Add *at least one non-empty* ServerCompletionQueue (otherwise: ASAN SEGV error in Shutdown)
@@ -191,5 +193,6 @@ TEST_CASE("Server::join", "[silkworm][node][rpc]") {
         server_thread.join();
     }
 }
+#endif // SILKWORM_SANITIZE
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/server_test.cpp
+++ b/node/silkworm/rpc/server_test.cpp
@@ -49,7 +49,7 @@ class EmptyServer : public Server {
 };
 
 // TODO(canepat): better copy grpc_pick_unused_port_or_die to generate unused port
-constexpr const char* kTestAddressUri = "localhost:12345";
+static const std::string kTestAddressUri{"localhost:12345"};
 
 // Exclude gRPC tests from sanitizer builds due to data race warnings
 #ifndef SILKWORM_SANITIZE


### PR DESCRIPTION
This PR excludes the gRPC server tests from the sanitizer builds.