### PR TITLE
Update chain config for mainnet

### DIFF
--- a/core/silkworm/chain/config.hpp
+++ b/core/silkworm/chain/config.hpp
@@ -136,6 +136,7 @@ inline constexpr ChainConfig kMainnetConfig{
         9'069'000,   // Istanbul
         12'244'000,  // Berlin
         12'965'000,  // London
+        13'773'000,  // Arrow Glacier
     },
 
     1'920'000,   // dao_block


### PR DESCRIPTION
The downloader requests (via set_status rpc) the sentry to send a Status message to peers (see [here](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#status-0x00)) This message carries the "Fork identifier for chain compatibility checks" as stated here https://eips.ethereum.org/EIPS/eip-2124. 

This PR updates the ChainConfig for Mainnet adding Arrow Glacier block number.