### PR TITLE
Update Hunter to v0.24.1 and CLI11 to v2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,8 @@ if(NOT SILKWORM_HAS_PARENT)
 
   include(third_party/evmone/cmake/cable/HunterGate.cmake)
   HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.24.0.tar.gz"
-    SHA1 "a3d7f4372b1dcd52faa6ff4a3bd5358e1d0e5efd"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.24.1.tar.gz"
+    SHA1 "4942227a6e6f5e64414c55b97ef98609de199d18"
     LOCAL
     )
 endif()
@@ -49,8 +49,8 @@ include(silkworm/third_party/evmone/cmake/cable/bootstrap.cmake)
 include(CableBuildInfo)
 include(silkworm/third_party/evmone/cmake/cable/HunterGate.cmake)
 HunterGate(
-  URL "https://github.com/cpp-pm/hunter/archive/v0.23.317.tar.gz"
-  SHA1 "fbdd94b1966d351384e27b02c8d134915b1131d6"
+  URL "https://github.com/cpp-pm/hunter/archive/v0.24.1.tar.gz"
+  SHA1 "4942227a6e6f5e64414c55b97ef98609de199d18"
   FILEPATH "${CMAKE_SOURCE_DIR}/silkworm/cmake/Hunter/config.cmake"
 )
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -22,13 +22,6 @@ hunter_config(
 )
 
 hunter_config(
-  intx
-  VERSION 0.8.0
-  URL https://github.com/chfast/intx/archive/v0.8.0.tar.gz
-  SHA1 612c46d636d9e381a8288d96c70b132190a79ca8
-)
-
-hunter_config(
   Microsoft.GSL
   VERSION 3.1.0
   URL https://github.com/microsoft/GSL/archive/v3.1.0.tar.gz
@@ -36,32 +29,10 @@ hunter_config(
 )
 
 hunter_config(
-  ethash
-  VERSION 0.8.0
-  URL https://github.com/chfast/ethash/archive/refs/tags/v0.8.0.tar.gz
-  SHA1 41fd440f70b6a8dfc3fd29b20f471dcbd1345ad0
-  CMAKE_ARGS ETHASH_BUILD_ETHASH=ON ETHASH_BUILD_GLOBAL_CONTEXT=NO ETHASH_BUILD_TESTS=OFF
-)
-
-hunter_config(
   re2
   VERSION 2021.11.01
   URL https://github.com/google/re2/archive/2021-11-01.tar.gz
   SHA1 4c18662f103ef53f106f8f98d7b46b723615e14f
-)
-
-hunter_config(
-  OpenSSL
-  VERSION 1.1.1l
-  URL https://github.com/openssl/openssl/archive/OpenSSL_1_1_1l.tar.gz
-  SHA1 8ef8e71af7f07e2dfe204ce298ac0ff224205f1c
-)
-
-hunter_config(
-  benchmark
-  VERSION 1.6.1
-  URL https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz
-  SHA1 1faaa54195824bbe151c1ebee31623232477d075
 )
 
 # Downgrade Protobuf version due to a CMake error in 3.19.4-p0

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -53,3 +53,10 @@ hunter_config(
   VERSION 1.44.0-p0
   CMAKE_ARGS gRPC_BUILD_TESTS=OFF gRPC_BUILD_CODEGEN=ON gRPC_BUILD_CSHARP_EXT=OFF
 )
+
+hunter_config(
+  CLI11
+  VERSION 2.2.0
+  URL https://github.com/CLIUtils/CLI11/archive/v2.2.0.tar.gz
+  SHA1 8ff2b5ef3436d73ce7f9db0bd94a912e305f0967
+)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -29,6 +29,12 @@ hunter_config(
 )
 
 hunter_config(
+  ethash
+  VERSION 0.9.0
+  CMAKE_ARGS ETHASH_BUILD_ETHASH=ON ETHASH_BUILD_GLOBAL_CONTEXT=NO ETHASH_BUILD_TESTS=OFF
+)
+
+hunter_config(
   re2
   VERSION 2021.11.01
   URL https://github.com/google/re2/archive/2021-11-01.tar.gz

--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -17,14 +17,14 @@
 #include <string>
 #include <thread>
 
+#include <CLI/CLI.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/process/environment.hpp>
-#include <CLI/CLI.hpp>
 
-#include <silkworm/buildinfo.h>
 #include <silkworm/backend/ethereum_backend.hpp>
+#include <silkworm/buildinfo.h>
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/log.hpp>
@@ -81,38 +81,43 @@ int parse_command_line(int argc, char* argv[], BackEndKvSettings& settings) {
         std::string etherbase_address{""};
         uint32_t num_contexts{std::thread::hardware_concurrency() / 2};
         uint32_t max_readers{silkworm::db::EnvConfig{}.max_readers};
-        app.add_option("--datadir", data_dir, "The path to data directory", true);
-        app.add_option("--etherbase", etherbase_address, "The chain identifier as string", true);
+        app.add_option("--datadir", data_dir, "The path to data directory")->capture_default_str();
+        app.add_option("--etherbase", etherbase_address, "The chain identifier as string")->capture_default_str();
         // TODO(canepat) add check on etherbase using EthAddressValidator [TBD]
-        app.add_option("--contexts", num_contexts, "The number of running contexts", true);
-        app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers", true)
+        app.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
+        app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
+            ->capture_default_str()
             ->check(CLI::Range(1, 32767));
 
         // RPC Server options
         app.add_option("--private.api.addr", node_settings.private_api_addr,
-            "Private API network address to serve remote database interface\n"
-            "An empty string means to not start the listener\n"
-            "Use the endpoint form i.e. ip-address:port\n"
-            "DO NOT EXPOSE TO THE INTERNET",
-            true);
+                       "Private API network address to serve remote database interface\n"
+                       "An empty string means to not start the listener\n"
+                       "Use the endpoint form i.e. ip-address:port\n"
+                       "DO NOT EXPOSE TO THE INTERNET")
+            ->capture_default_str();
         // TODO(canepat) add check on private.api.addr using IPEndPointValidator
-        app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint", true);
+        app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
+            ->capture_default_str();
         // TODO(canepat) add check on sentry_api_addr using IPEndPointValidator
 
         // Chain options
         auto& chain_opts = *app.add_option_group("Chain", "Chain selection options");
         auto chain_name = chain_opts.add_option("--chain", "Name of the network to join (default: \"mainnet\")")
-            ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
-        chain_opts.add_option("--networkid", node_settings.network_id,
-            "Explicitly set network id\n"
-            "For known networks: use --chain <testnet_name> instead",
-            true)
+                              ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
+        chain_opts
+            .add_option("--networkid", node_settings.network_id,
+                        "Explicitly set network id\n"
+                        "For known networks: use --chain <testnet_name> instead")
+            ->capture_default_str()
             ->excludes(chain_name);
 
         // Logging options
         auto& log_opts = *app.add_option_group("Log", "Logging options");
-        log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity", true)
-            ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical), static_cast<uint32_t>(silkworm::log::Level::kTrace)))
+        log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
+            ->capture_default_str()
+            ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical),
+                               static_cast<uint32_t>(silkworm::log::Level::kTrace)))
             ->default_val(std::to_string(static_cast<uint32_t>(silkworm::log::Level::kCritical)));
         log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
         log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines")
@@ -144,18 +149,17 @@ int parse_command_line(int argc, char* argv[], BackEndKvSettings& settings) {
         }
 
         node_settings.data_directory = std::make_unique<silkworm::DataDirectory>(data_dir, /*create=*/false);
-        node_settings.chaindata_env_config = silkworm::db::EnvConfig{
-            node_settings.data_directory->chaindata().path().string(),
-            /*create=*/false,
-            /*readonly=*/true
-        };
+        node_settings.chaindata_env_config =
+            silkworm::db::EnvConfig{node_settings.data_directory->chaindata().path().string(),
+                                    /*create=*/false,
+                                    /*readonly=*/true};
         node_settings.chaindata_env_config.max_readers = max_readers;
 
         server_settings.set_address_uri(node_settings.private_api_addr);
         server_settings.set_num_contexts(num_contexts);
 
         return 0;
-    } catch (const CLI::ParseError &pe) {
+    } catch (const CLI::ParseError& pe) {
         return app.exit(pe);
     }
 }
@@ -177,14 +181,15 @@ int main(int argc, char* argv[]) {
     // Initialize logging with custom settings
     silkworm::log::init(log_settings);
 
-    //TODO(canepat): this could be an option in Silkworm logging facility
+    // TODO(canepat): this could be an option in Silkworm logging facility
     silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
 
     const auto node_name{get_node_name_from_build_info()};
     SILK_LOG << "BackEndKvServer build info: " << node_name << " " << get_library_versions();
 
     try {
-        SILK_LOG << "BackEndKvServer launched with address: " << server_settings.address_uri() << ", contexts: " << server_settings.num_contexts();
+        SILK_LOG << "BackEndKvServer launched with address: " << server_settings.address_uri()
+                 << ", contexts: " << server_settings.num_contexts();
 
         auto database_env = silkworm::db::open_env(node_settings.chaindata_env_config);
         silkworm::EthereumBackEnd backend{node_settings, &database_env};

--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -17,14 +17,14 @@
 #include <string>
 #include <thread>
 
-#include <CLI/CLI.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/process/environment.hpp>
+#include <CLI/CLI.hpp>
 
-#include <silkworm/backend/ethereum_backend.hpp>
 #include <silkworm/buildinfo.h>
+#include <silkworm/backend/ethereum_backend.hpp>
 #include <silkworm/chain/config.hpp>
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/log.hpp>
@@ -81,43 +81,38 @@ int parse_command_line(int argc, char* argv[], BackEndKvSettings& settings) {
         std::string etherbase_address{""};
         uint32_t num_contexts{std::thread::hardware_concurrency() / 2};
         uint32_t max_readers{silkworm::db::EnvConfig{}.max_readers};
-        app.add_option("--datadir", data_dir, "The path to data directory")->capture_default_str();
-        app.add_option("--etherbase", etherbase_address, "The chain identifier as string")->capture_default_str();
+        app.add_option("--datadir", data_dir, "The path to data directory", true);
+        app.add_option("--etherbase", etherbase_address, "The chain identifier as string", true);
         // TODO(canepat) add check on etherbase using EthAddressValidator [TBD]
-        app.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
-        app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
-            ->capture_default_str()
+        app.add_option("--contexts", num_contexts, "The number of running contexts", true);
+        app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers", true)
             ->check(CLI::Range(1, 32767));
 
         // RPC Server options
         app.add_option("--private.api.addr", node_settings.private_api_addr,
-                       "Private API network address to serve remote database interface\n"
-                       "An empty string means to not start the listener\n"
-                       "Use the endpoint form i.e. ip-address:port\n"
-                       "DO NOT EXPOSE TO THE INTERNET")
-            ->capture_default_str();
+            "Private API network address to serve remote database interface\n"
+            "An empty string means to not start the listener\n"
+            "Use the endpoint form i.e. ip-address:port\n"
+            "DO NOT EXPOSE TO THE INTERNET",
+            true);
         // TODO(canepat) add check on private.api.addr using IPEndPointValidator
-        app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
-            ->capture_default_str();
+        app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint", true);
         // TODO(canepat) add check on sentry_api_addr using IPEndPointValidator
 
         // Chain options
         auto& chain_opts = *app.add_option_group("Chain", "Chain selection options");
         auto chain_name = chain_opts.add_option("--chain", "Name of the network to join (default: \"mainnet\")")
-                              ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
-        chain_opts
-            .add_option("--networkid", node_settings.network_id,
-                        "Explicitly set network id\n"
-                        "For known networks: use --chain <testnet_name> instead")
-            ->capture_default_str()
+            ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
+        chain_opts.add_option("--networkid", node_settings.network_id,
+            "Explicitly set network id\n"
+            "For known networks: use --chain <testnet_name> instead",
+            true)
             ->excludes(chain_name);
 
         // Logging options
         auto& log_opts = *app.add_option_group("Log", "Logging options");
-        log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
-            ->capture_default_str()
-            ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical),
-                               static_cast<uint32_t>(silkworm::log::Level::kTrace)))
+        log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity", true)
+            ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical), static_cast<uint32_t>(silkworm::log::Level::kTrace)))
             ->default_val(std::to_string(static_cast<uint32_t>(silkworm::log::Level::kCritical)));
         log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
         log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines")
@@ -149,17 +144,18 @@ int parse_command_line(int argc, char* argv[], BackEndKvSettings& settings) {
         }
 
         node_settings.data_directory = std::make_unique<silkworm::DataDirectory>(data_dir, /*create=*/false);
-        node_settings.chaindata_env_config =
-            silkworm::db::EnvConfig{node_settings.data_directory->chaindata().path().string(),
-                                    /*create=*/false,
-                                    /*readonly=*/true};
+        node_settings.chaindata_env_config = silkworm::db::EnvConfig{
+            node_settings.data_directory->chaindata().path().string(),
+            /*create=*/false,
+            /*readonly=*/true
+        };
         node_settings.chaindata_env_config.max_readers = max_readers;
 
         server_settings.set_address_uri(node_settings.private_api_addr);
         server_settings.set_num_contexts(num_contexts);
 
         return 0;
-    } catch (const CLI::ParseError& pe) {
+    } catch (const CLI::ParseError &pe) {
         return app.exit(pe);
     }
 }
@@ -181,15 +177,14 @@ int main(int argc, char* argv[]) {
     // Initialize logging with custom settings
     silkworm::log::init(log_settings);
 
-    // TODO(canepat): this could be an option in Silkworm logging facility
+    //TODO(canepat): this could be an option in Silkworm logging facility
     silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
 
     const auto node_name{get_node_name_from_build_info()};
     SILK_LOG << "BackEndKvServer build info: " << node_name << " " << get_library_versions();
 
     try {
-        SILK_LOG << "BackEndKvServer launched with address: " << server_settings.address_uri()
-                 << ", contexts: " << server_settings.num_contexts();
+        SILK_LOG << "BackEndKvServer launched with address: " << server_settings.address_uri() << ", contexts: " << server_settings.num_contexts();
 
         auto database_env = silkworm::db::open_env(node_settings.chaindata_env_config);
         silkworm::EthereumBackEnd backend{node_settings, &database_env};

--- a/cmd/check_blockhashes.cpp
+++ b/cmd/check_blockhashes.cpp
@@ -34,8 +34,7 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Check Blockhashes => BlockNumber mapping in database"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
     CLI11_PARSE(app, argc, argv);
 

--- a/cmd/check_blockhashes.cpp
+++ b/cmd/check_blockhashes.cpp
@@ -34,7 +34,8 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Check Blockhashes => BlockNumber mapping in database"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
     CLI11_PARSE(app, argc, argv);
 

--- a/cmd/check_changes.cpp
+++ b/cmd/check_changes.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Executes Ethereum blocks and compares resulting change sets against DB"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")->capture_default_str()
         ->check(CLI::ExistingDirectory);
 
     uint64_t from{1};

--- a/cmd/check_changes.cpp
+++ b/cmd/check_changes.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Executes Ethereum blocks and compares resulting change sets against DB"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
     uint64_t from{1};

--- a/cmd/check_hashstate.cpp
+++ b/cmd/check_hashstate.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ void check(mdbx::txn& txn, Operation operation) {
             }
             if (actual_value.value != data.value) {
                 log::Error() << "Expected: " << to_hex(db::from_slice(data.value)) << ", Actual: << "
-                                    << to_hex(db::from_slice(actual_value.value));
+                             << to_hex(db::from_slice(actual_value.value));
                 return;
             }
             data = source_table.to_next(false);
@@ -114,7 +114,7 @@ void check(mdbx::txn& txn, Operation operation) {
             }
             if (actual_value.value != data.value) {
                 log::Error() << "Expected: " << to_hex(db::from_slice(data.value)) << ", Actual: << "
-                                    << to_hex(db::from_slice(actual_value.value));
+                             << to_hex(db::from_slice(actual_value.value));
                 return;
             }
             data = source_table.to_next(false);
@@ -126,7 +126,8 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Check Hashed state"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
     CLI11_PARSE(app, argc, argv);
     log::Info() << "Checking HashState";

--- a/cmd/check_hashstate.cpp
+++ b/cmd/check_hashstate.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ void check(mdbx::txn& txn, Operation operation) {
             }
             if (actual_value.value != data.value) {
                 log::Error() << "Expected: " << to_hex(db::from_slice(data.value)) << ", Actual: << "
-                             << to_hex(db::from_slice(actual_value.value));
+                                    << to_hex(db::from_slice(actual_value.value));
                 return;
             }
             data = source_table.to_next(false);
@@ -114,7 +114,7 @@ void check(mdbx::txn& txn, Operation operation) {
             }
             if (actual_value.value != data.value) {
                 log::Error() << "Expected: " << to_hex(db::from_slice(data.value)) << ", Actual: << "
-                             << to_hex(db::from_slice(actual_value.value));
+                                    << to_hex(db::from_slice(actual_value.value));
                 return;
             }
             data = source_table.to_next(false);
@@ -126,8 +126,7 @@ int main(int argc, char* argv[]) {
     CLI::App app{"Check Hashed state"};
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
     CLI11_PARSE(app, argc, argv);
     log::Info() << "Checking HashState";

--- a/cmd/check_pow.cpp
+++ b/cmd/check_pow.cpp
@@ -46,15 +46,11 @@ int main(int argc, char* argv[]) {
     options.datadir = DataDirectory{}.chaindata().path().string();  // Default chain data db path
 
     // Command line arguments
-    app.add_option("--chaindata", options.datadir, "Path to chain db")
-        ->capture_default_str()
-        ->check(CLI::ExistingDirectory);
+    app.add_option("--chaindata", options.datadir, "Path to chain db", true)->check(CLI::ExistingDirectory);
 
-    app.add_option("--from", options.block_from, "Initial block number to process (inclusive)")
-        ->capture_default_str()
+    app.add_option("--from", options.block_from, "Initial block number to process (inclusive)", true)
         ->check(CLI::Range(1u, UINT32_MAX));
-    app.add_option("--to", options.block_to, "Final block number to process (inclusive)")
-        ->capture_default_str()
+    app.add_option("--to", options.block_to, "Final block number to process (inclusive)", true)
         ->check(CLI::Range(1u, UINT32_MAX));
 
     app.add_flag("--debug", options.debug, "May print some debug/trace info.");

--- a/cmd/check_pow.cpp
+++ b/cmd/check_pow.cpp
@@ -46,11 +46,15 @@ int main(int argc, char* argv[]) {
     options.datadir = DataDirectory{}.chaindata().path().string();  // Default chain data db path
 
     // Command line arguments
-    app.add_option("--chaindata", options.datadir, "Path to chain db", true)->check(CLI::ExistingDirectory);
+    app.add_option("--chaindata", options.datadir, "Path to chain db")
+        ->capture_default_str()
+        ->check(CLI::ExistingDirectory);
 
-    app.add_option("--from", options.block_from, "Initial block number to process (inclusive)", true)
+    app.add_option("--from", options.block_from, "Initial block number to process (inclusive)")
+        ->capture_default_str()
         ->check(CLI::Range(1u, UINT32_MAX));
-    app.add_option("--to", options.block_to, "Final block number to process (inclusive)", true)
+    app.add_option("--to", options.block_to, "Final block number to process (inclusive)")
+        ->capture_default_str()
         ->check(CLI::Range(1u, UINT32_MAX));
 
     app.add_flag("--debug", options.debug, "May print some debug/trace info.");

--- a/cmd/check_tx_lookup.cpp
+++ b/cmd/check_tx_lookup.cpp
@@ -39,9 +39,11 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     size_t block_from;
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
-    app.add_option("--from", block_from, "Initial block number to process (inclusive)", true)
+    app.add_option("--from", block_from, "Initial block number to process (inclusive)")
+        ->capture_default_str()
         ->check(CLI::Range(1u, UINT32_MAX));
 
     CLI11_PARSE(app, argc, argv);

--- a/cmd/check_tx_lookup.cpp
+++ b/cmd/check_tx_lookup.cpp
@@ -39,11 +39,9 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     size_t block_from;
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
-    app.add_option("--from", block_from, "Initial block number to process (inclusive)")
-        ->capture_default_str()
+    app.add_option("--from", block_from, "Initial block number to process (inclusive)", true)
         ->check(CLI::Range(1u, UINT32_MAX));
 
     CLI11_PARSE(app, argc, argv);

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -99,44 +99,37 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     std::string chaindata_growth_size{human_size(node_settings.chaindata_env_config.growth_size)};
     std::string batch_size{human_size(node_settings.batch_size)};
     std::string etl_buffer_size{human_size(node_settings.etl_buffer_size)};
-    cli.add_option("--datadir", datadir, "Path to data directory")->capture_default_str();
+    cli.add_option("--datadir", datadir, "Path to data directory", true);
     cli.add_flag("--chaindata.exclusive", node_settings.chaindata_env_config.exclusive,
                  "Chaindata database opened in exclusive mode");
     cli.add_flag("--chaindata.readahead", node_settings.chaindata_env_config.read_ahead,
                  "Chaindata database enable readahead");
     cli.add_flag("--chaindata.writemap", node_settings.chaindata_env_config.write_map,
                  "Chaindata database enable writemap");
-    cli.add_option("--chaindata.growthsize", chaindata_growth_size, "Chaindata database growth size")
-        ->capture_default_str()
+    cli.add_option("--chaindata.growthsize", chaindata_growth_size, "Chaindata database growth size", true)
         ->check(HumanSizeParserValidator("64MB"));
-    cli.add_option("--chaindata.maxsize", chaindata_max_size, "Chaindata database max size")
-        ->capture_default_str()
+    cli.add_option("--chaindata.maxsize", chaindata_max_size, "Chaindata database max size", true)
         ->check(HumanSizeParserValidator("64MB", {"4TB"}));
-    cli.add_option("--batchsize", batch_size, "Batch size for stage execution")
-        ->capture_default_str()
+    cli.add_option("--batchsize", batch_size, "Batch size for stage execution", true)
         ->check(HumanSizeParserValidator("64MB", {"16GB"}));
-    cli.add_option("--etl.buffersize", etl_buffer_size, "Buffer size for ETL operations")
-        ->capture_default_str()
+    cli.add_option("--etl.buffersize", etl_buffer_size, "Buffer size for ETL operations", true)
         ->check(HumanSizeParserValidator("64MB", {"1GB"}));
     cli.add_option("--private.api.addr", node_settings.private_api_addr,
                    "Private API network address to serve remote database interface\n"
                    "An empty string means to not start the listener\n"
                    "Use the endpoint form i.e. ip-address:port\n"
-                   "DO NOT EXPOSE TO THE INTERNET")
-        ->capture_default_str()
+                   "DO NOT EXPOSE TO THE INTERNET",
+                   true)
         ->check(IPEndPointValidator(/*allow_empty=*/false));
 
-    cli.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
-        ->capture_default_str()
+    cli.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint", true)
         ->check(IPEndPointValidator(/*allow_empty=*/true));
 
     cli.add_option("--sync.loop.throttle", node_settings.sync_loop_throttle_seconds,
-                   "Sets the minimum time between sync loop starts (in seconds)")
-        ->capture_default_str();
+                   "Sets the minimum time between sync loop starts (in seconds)", true);
 
     cli.add_option("--sync.loop.log.interval", node_settings.sync_loop_log_interval_seconds,
-                   "Sets the minimum time between sync loop logs (in seconds)")
-        ->capture_default_str()
+                   "Sets the minimum time between sync loop logs (in seconds)", true)
         ->check(CLI::Range(5u, 600u));
 
     cli.add_flag("--fakepow", node_settings.fake_pow, "Disables proof-of-work verification");
@@ -148,8 +141,8 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     chain_opts
         .add_option("--networkid", node_settings.network_id,
                     "Explicitly set network id\n"
-                    "For known networks: use --chain <testnet_name> instead")
-        ->capture_default_str()
+                    "For known networks: use --chain <testnet_name> instead",
+                    true)
         ->excludes(chain_opts_chain_name);
 
     // Prune options
@@ -165,8 +158,8 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
                     "t - prune transaction by it's hash index\n"
                     "c - prune call traces (used by trace_* methods)\n"
                     "If item is NOT in the list - means NO pruning for this data.\n"
-                    "Example: --prune=hrtc (default: none)")
-        ->capture_default_str()
+                    "Example: --prune=hrtc (default: none)",
+                    true)
         ->check(PruneModeValidator());
 
     prune_opts.add_option("--prune.h.older", "Override default 90k blocks of history to prune")
@@ -192,8 +185,7 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
 
     // Logging options
     auto& log_opts = *cli.add_option_group("Log", "Logging options");
-    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
-        ->capture_default_str()
+    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity", true)
         ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)))
         ->default_val(std::to_string(static_cast<uint32_t>(log_settings.log_verbosity)));
     log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -99,37 +99,44 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     std::string chaindata_growth_size{human_size(node_settings.chaindata_env_config.growth_size)};
     std::string batch_size{human_size(node_settings.batch_size)};
     std::string etl_buffer_size{human_size(node_settings.etl_buffer_size)};
-    cli.add_option("--datadir", datadir, "Path to data directory", true);
+    cli.add_option("--datadir", datadir, "Path to data directory")->capture_default_str();
     cli.add_flag("--chaindata.exclusive", node_settings.chaindata_env_config.exclusive,
                  "Chaindata database opened in exclusive mode");
     cli.add_flag("--chaindata.readahead", node_settings.chaindata_env_config.read_ahead,
                  "Chaindata database enable readahead");
     cli.add_flag("--chaindata.writemap", node_settings.chaindata_env_config.write_map,
                  "Chaindata database enable writemap");
-    cli.add_option("--chaindata.growthsize", chaindata_growth_size, "Chaindata database growth size", true)
+    cli.add_option("--chaindata.growthsize", chaindata_growth_size, "Chaindata database growth size")
+        ->capture_default_str()
         ->check(HumanSizeParserValidator("64MB"));
-    cli.add_option("--chaindata.maxsize", chaindata_max_size, "Chaindata database max size", true)
+    cli.add_option("--chaindata.maxsize", chaindata_max_size, "Chaindata database max size")
+        ->capture_default_str()
         ->check(HumanSizeParserValidator("64MB", {"4TB"}));
-    cli.add_option("--batchsize", batch_size, "Batch size for stage execution", true)
+    cli.add_option("--batchsize", batch_size, "Batch size for stage execution")
+        ->capture_default_str()
         ->check(HumanSizeParserValidator("64MB", {"16GB"}));
-    cli.add_option("--etl.buffersize", etl_buffer_size, "Buffer size for ETL operations", true)
+    cli.add_option("--etl.buffersize", etl_buffer_size, "Buffer size for ETL operations")
+        ->capture_default_str()
         ->check(HumanSizeParserValidator("64MB", {"1GB"}));
     cli.add_option("--private.api.addr", node_settings.private_api_addr,
                    "Private API network address to serve remote database interface\n"
                    "An empty string means to not start the listener\n"
                    "Use the endpoint form i.e. ip-address:port\n"
-                   "DO NOT EXPOSE TO THE INTERNET",
-                   true)
+                   "DO NOT EXPOSE TO THE INTERNET")
+        ->capture_default_str()
         ->check(IPEndPointValidator(/*allow_empty=*/false));
 
-    cli.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint", true)
+    cli.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
+        ->capture_default_str()
         ->check(IPEndPointValidator(/*allow_empty=*/true));
 
     cli.add_option("--sync.loop.throttle", node_settings.sync_loop_throttle_seconds,
-                   "Sets the minimum time between sync loop starts (in seconds)", true);
+                   "Sets the minimum time between sync loop starts (in seconds)")
+        ->capture_default_str();
 
     cli.add_option("--sync.loop.log.interval", node_settings.sync_loop_log_interval_seconds,
-                   "Sets the minimum time between sync loop logs (in seconds)", true)
+                   "Sets the minimum time between sync loop logs (in seconds)")
+        ->capture_default_str()
         ->check(CLI::Range(5u, 600u));
 
     cli.add_flag("--fakepow", node_settings.fake_pow, "Disables proof-of-work verification");
@@ -141,8 +148,8 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     chain_opts
         .add_option("--networkid", node_settings.network_id,
                     "Explicitly set network id\n"
-                    "For known networks: use --chain <testnet_name> instead",
-                    true)
+                    "For known networks: use --chain <testnet_name> instead")
+        ->capture_default_str()
         ->excludes(chain_opts_chain_name);
 
     // Prune options
@@ -158,8 +165,8 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
                     "t - prune transaction by it's hash index\n"
                     "c - prune call traces (used by trace_* methods)\n"
                     "If item is NOT in the list - means NO pruning for this data.\n"
-                    "Example: --prune=hrtc (default: none)",
-                    true)
+                    "Example: --prune=hrtc (default: none)")
+        ->capture_default_str()
         ->check(PruneModeValidator());
 
     prune_opts.add_option("--prune.h.older", "Override default 90k blocks of history to prune")
@@ -185,7 +192,8 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
 
     // Logging options
     auto& log_opts = *cli.add_option_group("Log", "Logging options");
-    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity", true)
+    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
+        ->capture_default_str()
         ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)))
         ->default_val(std::to_string(static_cast<uint32_t>(log_settings.log_verbosity)));
     log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");

--- a/cmd/download_headers.cpp
+++ b/cmd/download_headers.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/downloader/internals/header_retrieval.hpp>
-#include <silkworm/downloader/stage_bodies.hpp>
 #include <silkworm/downloader/stage_headers.hpp>
+#include "silkworm/downloader/stage_bodies.hpp"
 
 using namespace silkworm;
 
@@ -47,17 +47,15 @@ int main(int argc, char* argv[]) {
     settings.log_verbosity = log::Level::kInfo;
     settings.log_thousands_sep = '\'';
 
-    app.add_option("--chaindata", db_path, "Path to the chain database")
-        ->capture_default_str()
+    app.add_option("--chaindata", db_path, "Path to the chain database", true)
         ->check(CLI::ExistingDirectory);
-    app.add_option("--chain", chain_name, "Network name")->capture_default_str()->needs("--chaindata");
-    app.add_option("-s,--sentryaddr", sentry_addr, "address:port of sentry")->capture_default_str();
-    //  todo ->check?
-    app.add_option("-f,--filesdir", temporary_file_path, "Path to a temp files dir")
-        ->capture_default_str()
+    app.add_option("--chain", chain_name, "Network name", true)
+        ->needs("--chaindata");
+    app.add_option("-s,--sentryaddr", sentry_addr, "address:port of sentry", true);
+        //  todo ->check?
+    app.add_option("-f,--filesdir", temporary_file_path, "Path to a temp files dir", true)
         ->check(CLI::ExistingDirectory);
-    app.add_option("-v,--verbosity", settings.log_verbosity, "Verbosity")
-        ->capture_default_str()
+    app.add_option("-v,--verbosity", settings.log_verbosity, "Verbosity", true)
         ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)));
 
     CLI11_PARSE(app, argc, argv);
@@ -121,8 +119,8 @@ int main(int argc, char* argv[]) {
         } while (stage_result.status != Stage::Result::Error);
 
         // Wait for user termination request
-        std::cin.get();           // wait for user press "enter"
-        block_downloader.stop();  // signal exiting
+        std::cin.get();            // wait for user press "enter"
+        block_downloader.stop();     // signal exiting
 
         // wait threads termination
         message_receiving.join();

--- a/cmd/download_headers.cpp
+++ b/cmd/download_headers.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/downloader/internals/header_retrieval.hpp>
+#include <silkworm/downloader/stage_bodies.hpp>
 #include <silkworm/downloader/stage_headers.hpp>
-#include "silkworm/downloader/stage_bodies.hpp"
 
 using namespace silkworm;
 
@@ -47,15 +47,17 @@ int main(int argc, char* argv[]) {
     settings.log_verbosity = log::Level::kInfo;
     settings.log_thousands_sep = '\'';
 
-    app.add_option("--chaindata", db_path, "Path to the chain database", true)
+    app.add_option("--chaindata", db_path, "Path to the chain database")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
-    app.add_option("--chain", chain_name, "Network name", true)
-        ->needs("--chaindata");
-    app.add_option("-s,--sentryaddr", sentry_addr, "address:port of sentry", true);
-        //  todo ->check?
-    app.add_option("-f,--filesdir", temporary_file_path, "Path to a temp files dir", true)
+    app.add_option("--chain", chain_name, "Network name")->capture_default_str()->needs("--chaindata");
+    app.add_option("-s,--sentryaddr", sentry_addr, "address:port of sentry")->capture_default_str();
+    //  todo ->check?
+    app.add_option("-f,--filesdir", temporary_file_path, "Path to a temp files dir")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
-    app.add_option("-v,--verbosity", settings.log_verbosity, "Verbosity", true)
+    app.add_option("-v,--verbosity", settings.log_verbosity, "Verbosity")
+        ->capture_default_str()
         ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)));
 
     CLI11_PARSE(app, argc, argv);
@@ -119,8 +121,8 @@ int main(int argc, char* argv[]) {
         } while (stage_result.status != Stage::Result::Error);
 
         // Wait for user termination request
-        std::cin.get();            // wait for user press "enter"
-        block_downloader.stop();     // signal exiting
+        std::cin.get();           // wait for user press "enter"
+        block_downloader.stop();  // signal exiting
 
         // wait threads termination
         message_receiving.join();

--- a/cmd/genesistool.cpp
+++ b/cmd/genesistool.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2022 The Silkworm Authors
+   Copyright 2020-2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -84,10 +84,10 @@ int main(int argc, char* argv[]) {
     std::string output_dir{};
     bool overwrite{false};
 
-    app_main.add_option("-i,--input", input_dir, "Input directory for genesis json files")
+    app_main.add_option("-i,--input", input_dir, "Input directory for genesis json files", false)
         ->required()
         ->check(CLI::ExistingDirectory);
-    app_main.add_option("-o,--output", output_dir, "Output directory for generated cpp byte arrays")
+    app_main.add_option("-o,--output", output_dir, "Output directory for generated cpp byte arrays", false)
         ->required()
         ->check(CLI::ExistingDirectory);
 

--- a/cmd/genesistool.cpp
+++ b/cmd/genesistool.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -84,10 +84,10 @@ int main(int argc, char* argv[]) {
     std::string output_dir{};
     bool overwrite{false};
 
-    app_main.add_option("-i,--input", input_dir, "Input directory for genesis json files", false)
+    app_main.add_option("-i,--input", input_dir, "Input directory for genesis json files")
         ->required()
         ->check(CLI::ExistingDirectory);
-    app_main.add_option("-o,--output", output_dir, "Output directory for generated cpp byte arrays", false)
+    app_main.add_option("-o,--output", output_dir, "Output directory for generated cpp byte arrays")
         ->required()
         ->check(CLI::ExistingDirectory);
 

--- a/cmd/history_index.cpp
+++ b/cmd/history_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -36,8 +36,7 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool full{false}, storage{false};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
     app.add_flag("--full", full, "Start making history indexes from block 0");

--- a/cmd/history_index.cpp
+++ b/cmd/history_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool full{false}, storage{false};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
 
     app.add_flag("--full", full, "Start making history indexes from block 0");

--- a/cmd/log_index.cpp
+++ b/cmd/log_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool full{false};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
     app.add_flag("--full", full, "Start making history indexes from block 0");

--- a/cmd/log_index.cpp
+++ b/cmd/log_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool full{false};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
 
     app.add_flag("--full", full, "Start making history indexes from block 0");

--- a/cmd/scan_txs.cpp
+++ b/cmd/scan_txs.cpp
@@ -29,8 +29,7 @@ int main(int argc, char* argv[]) {
     using namespace silkworm;
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
     uint64_t from{1};

--- a/cmd/scan_txs.cpp
+++ b/cmd/scan_txs.cpp
@@ -29,7 +29,8 @@ int main(int argc, char* argv[]) {
     using namespace silkworm;
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
 
     uint64_t from{1};

--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -23,14 +23,12 @@
 #include <mutex>
 #include <thread>
 
-#include <CLI/CLI.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/process/environment.hpp>
+#include <CLI/CLI.hpp>
 #include <grpcpp/grpcpp.h>
 #include <magic_enum.hpp>
-#include <remote/ethbackend.grpc.pb.h>
-#include <remote/kv.grpc.pb.h>
 
 #include <silkworm/common/assert.hpp>
 #include <silkworm/common/endian.hpp>
@@ -38,6 +36,8 @@
 #include <silkworm/common/util.hpp>
 #include <silkworm/rpc/conversion.hpp>
 #include <silkworm/rpc/util.hpp>
+#include <remote/ethbackend.grpc.pb.h>
+#include <remote/kv.grpc.pb.h>
 
 using namespace std::literals;
 
@@ -49,8 +49,8 @@ struct UnaryStats {
 };
 
 std::ostream& operator<<(std::ostream& out, const UnaryStats& stats) {
-    out << "started=" << stats.started_count << " completed=" << stats.completed_count << " [OK=" << stats.ok_count
-        << " KO=" << stats.ko_count << "]";
+    out << "started=" << stats.started_count << " completed=" << stats.completed_count
+        << " [OK=" << stats.ok_count << " KO=" << stats.ko_count << "]";
     return out;
 }
 
@@ -65,8 +65,8 @@ struct ServerStreamingStats {
 };
 
 std::ostream& operator<<(std::ostream& out, const ServerStreamingStats& stats) {
-    out << "started=" << stats.started_count << " received=" << stats.received_count
-        << " completed=" << stats.completed_count << " [OK=" << stats.ok_count << " KO=" << stats.ko_count << "]";
+    out << "started=" << stats.started_count << " received=" << stats.received_count << " completed=" << stats.completed_count
+        << " [OK=" << stats.ok_count << " KO=" << stats.ko_count << "]";
     return out;
 }
 
@@ -114,14 +114,17 @@ using StubFactory = std::function<std::unique_ptr<Stub>(std::shared_ptr<grpc::Ch
 template <typename Reply>
 using AsyncResponseReaderPtr = std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<Reply>>;
 
-template <typename Request, typename Reply, typename StubInterface, typename Stub,
-          AsyncResponseReaderPtr<Reply> (StubInterface::*PrepareAsyncUnary)(grpc::ClientContext*, const Request&,
-                                                                            grpc::CompletionQueue*)>
+template<
+    typename Request,
+    typename Reply,
+    typename StubInterface,
+    typename Stub,
+    AsyncResponseReaderPtr<Reply>(StubInterface::*PrepareAsyncUnary)(grpc::ClientContext*, const Request&, grpc::CompletionQueue*)
+>
 class AsyncUnaryCall : public AsyncCall {
   public:
-    explicit AsyncUnaryCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue,
-                            StubFactory<Stub> newStub)
-        : AsyncCall(queue), stub_(newStub(channel, grpc::StubOptions{})) {}
+    explicit AsyncUnaryCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue, StubFactory<Stub> newStub)
+    : AsyncCall(queue), stub_(newStub(channel, grpc::StubOptions{})) {}
 
     void start_async(const Request& request) {
         SILK_TRACE << "AsyncUnaryCall::start_async START";
@@ -142,14 +145,17 @@ class AsyncUnaryCall : public AsyncCall {
 template <typename Reply>
 using AsyncReaderPtr = std::unique_ptr<grpc::ClientAsyncReaderInterface<Reply>>;
 
-template <typename Request, typename Reply, typename StubInterface, typename Stub,
-          AsyncReaderPtr<Reply> (StubInterface::*PrepareAsyncServerStreaming)(grpc::ClientContext*, const Request&,
-                                                                              grpc::CompletionQueue*)>
+template<
+    typename Request,
+    typename Reply,
+    typename StubInterface,
+    typename Stub,
+    AsyncReaderPtr<Reply>(StubInterface::*PrepareAsyncServerStreaming)(grpc::ClientContext*, const Request&, grpc::CompletionQueue*)
+>
 class AsyncServerStreamingCall : public AsyncCall {
   public:
-    explicit AsyncServerStreamingCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue,
-                                      StubFactory<Stub> newStub)
-        : AsyncCall(queue), stub_(newStub(channel, grpc::StubOptions{})) {}
+    explicit AsyncServerStreamingCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue, StubFactory<Stub> newStub)
+    : AsyncCall(queue), stub_(newStub(channel, grpc::StubOptions{})) {}
 
     void start_async(const Request& request) {
         SILK_TRACE << "AsyncServerStreamingCall::start_async START";
@@ -188,8 +194,7 @@ class AsyncServerStreamingCall : public AsyncCall {
                 if (started_) {
                     handle_read();
                     ++server_streaming_stats.received_count;
-                    SILK_DEBUG << "AsyncServerStreamingCall new message received: "
-                               << server_streaming_stats.received_count;
+                    SILK_DEBUG << "AsyncServerStreamingCall new message received: " << server_streaming_stats.received_count;
                 } else {
                     started_ = true;
                     SILK_DEBUG << "AsyncServerStreamingCall call started";
@@ -222,14 +227,17 @@ class AsyncServerStreamingCall : public AsyncCall {
 template <typename Request, typename Reply>
 using AsyncReaderWriterPtr = std::unique_ptr<grpc::ClientAsyncReaderWriterInterface<Request, Reply>>;
 
-template <typename Request, typename Reply, typename StubInterface, typename Stub,
-          AsyncReaderWriterPtr<Request, Reply> (StubInterface::*PrepareAsyncBidirectionalStreaming)(
-              grpc::ClientContext*, grpc::CompletionQueue*)>
+template<
+    typename Request,
+    typename Reply,
+    typename StubInterface,
+    typename Stub,
+    AsyncReaderWriterPtr<Request, Reply>(StubInterface::*PrepareAsyncBidirectionalStreaming)(grpc::ClientContext*, grpc::CompletionQueue*)
+>
 class AsyncBidirectionalStreamingCall : public AsyncCall {
   public:
-    explicit AsyncBidirectionalStreamingCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue,
-                                             StubFactory<Stub> newStub)
-        : AsyncCall(queue), stub_(newStub(channel, grpc::StubOptions{})) {}
+    explicit AsyncBidirectionalStreamingCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue, StubFactory<Stub> newStub)
+    : AsyncCall(queue), stub_(newStub(channel, grpc::StubOptions{})) {}
 
     void start_async() {
         SILK_TRACE << "AsyncBidirectionalStreamingCall::start_async START";
@@ -274,45 +282,38 @@ class AsyncBidirectionalStreamingCall : public AsyncCall {
                     // Schedule first async WRITE event.
                     state_ = State::kWriting;
                     write();
-                    SILK_DEBUG << "AsyncBidirectionalStreamingCall schedule write state: "
-                               << magic_enum::enum_name(state_);
+                    SILK_DEBUG << "AsyncBidirectionalStreamingCall schedule write state: " << magic_enum::enum_name(state_);
                     return false;
                 }
                 case State::kWriting: {
                     ++bidi_streaming_stats.sent_count;
-                    SILK_DEBUG << "AsyncBidirectionalStreamingCall new request sent: "
-                               << bidi_streaming_stats.sent_count;
+                    SILK_DEBUG << "AsyncBidirectionalStreamingCall new request sent: " << bidi_streaming_stats.sent_count;
                     const bool done = handle_write();
                     if (done) {
                         state_ = State::kClosed;
-                        SILK_DEBUG << "AsyncBidirectionalStreamingCall closed by us state: "
-                                   << magic_enum::enum_name(state_);
+                        SILK_DEBUG << "AsyncBidirectionalStreamingCall closed by us state: " << magic_enum::enum_name(state_);
                         writes_done();
                     } else {
                         // Schedule next async READ event.
                         state_ = State::kReading;
                         read();
-                        SILK_DEBUG << "AsyncBidirectionalStreamingCall schedule read state: "
-                                   << magic_enum::enum_name(state_);
+                        SILK_DEBUG << "AsyncBidirectionalStreamingCall schedule read state: " << magic_enum::enum_name(state_);
                     }
                     return false;
                 }
                 case State::kReading: {
                     ++bidi_streaming_stats.received_count;
-                    SILK_DEBUG << "AsyncBidirectionalStreamingCall new response received: "
-                               << bidi_streaming_stats.received_count;
+                    SILK_DEBUG << "AsyncBidirectionalStreamingCall new response received: " << bidi_streaming_stats.received_count;
                     const bool done = handle_read();
                     if (done) {
                         state_ = State::kClosed;
-                        SILK_DEBUG << "AsyncBidirectionalStreamingCall closed by us state: "
-                                   << magic_enum::enum_name(state_);
+                        SILK_DEBUG << "AsyncBidirectionalStreamingCall closed by us state: " << magic_enum::enum_name(state_);
                         writes_done();
                     } else {
                         // Schedule next async WRITE event.
                         state_ = State::kWriting;
                         write();
-                        SILK_DEBUG << "AsyncBidirectionalStreamingCall schedule write state: "
-                                   << magic_enum::enum_name(state_);
+                        SILK_DEBUG << "AsyncBidirectionalStreamingCall schedule write state: " << magic_enum::enum_name(state_);
                     }
                     return false;
                 }
@@ -358,7 +359,7 @@ class AsyncBidirectionalStreamingCall : public AsyncCall {
         kWriting,
         kReading,
         kClosed,
-        kDone,
+        kDone
     };
 
     std::unique_ptr<Stub> stub_;
@@ -372,12 +373,15 @@ class AsyncBidirectionalStreamingCall : public AsyncCall {
     bool server_streaming_done_{false};
 };
 
-class AsyncEtherbaseCall
-    : public AsyncUnaryCall<remote::EtherbaseRequest, remote::EtherbaseReply, remote::ETHBACKEND::StubInterface,
-                            remote::ETHBACKEND::Stub, &remote::ETHBACKEND::StubInterface::PrepareAsyncEtherbase> {
+class AsyncEtherbaseCall : public AsyncUnaryCall<
+    remote::EtherbaseRequest,
+    remote::EtherbaseReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncEtherbase> {
   public:
     explicit AsyncEtherbaseCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncEtherbaseCall::handle_completion ok: " << ok << " status: " << status_;
@@ -397,12 +401,15 @@ class AsyncEtherbaseCall
     }
 };
 
-class AsyncNetVersionCall
-    : public AsyncUnaryCall<remote::NetVersionRequest, remote::NetVersionReply, remote::ETHBACKEND::StubInterface,
-                            remote::ETHBACKEND::Stub, &remote::ETHBACKEND::StubInterface::PrepareAsyncNetVersion> {
+class AsyncNetVersionCall : public AsyncUnaryCall<
+    remote::NetVersionRequest,
+    remote::NetVersionReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncNetVersion> {
   public:
     explicit AsyncNetVersionCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncNetVersionCall::handle_completion ok: " << ok << " status: " << status_;
@@ -417,12 +424,15 @@ class AsyncNetVersionCall
     }
 };
 
-class AsyncNetPeerCountCall
-    : public AsyncUnaryCall<remote::NetPeerCountRequest, remote::NetPeerCountReply, remote::ETHBACKEND::StubInterface,
-                            remote::ETHBACKEND::Stub, &remote::ETHBACKEND::StubInterface::PrepareAsyncNetPeerCount> {
+class AsyncNetPeerCountCall : public AsyncUnaryCall<
+    remote::NetPeerCountRequest,
+    remote::NetPeerCountReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncNetPeerCount> {
   public:
     explicit AsyncNetPeerCountCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncNetPeerCountCall::handle_completion ok: " << ok << " status: " << status_;
@@ -437,12 +447,15 @@ class AsyncNetPeerCountCall
     }
 };
 
-class AsyncBackEndVersionCall
-    : public AsyncUnaryCall<google::protobuf::Empty, types::VersionReply, remote::ETHBACKEND::StubInterface,
-                            remote::ETHBACKEND::Stub, &remote::ETHBACKEND::StubInterface::PrepareAsyncVersion> {
+class AsyncBackEndVersionCall : public AsyncUnaryCall<
+    google::protobuf::Empty,
+    types::VersionReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncVersion> {
   public:
     explicit AsyncBackEndVersionCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncBackEndVersionCall::handle_completion ok: " << ok << " status: " << status_;
@@ -460,13 +473,15 @@ class AsyncBackEndVersionCall
     }
 };
 
-class AsyncProtocolVersionCall
-    : public AsyncUnaryCall<remote::ProtocolVersionRequest, remote::ProtocolVersionReply,
-                            remote::ETHBACKEND::StubInterface, remote::ETHBACKEND::Stub,
-                            &remote::ETHBACKEND::StubInterface::PrepareAsyncProtocolVersion> {
+class AsyncProtocolVersionCall : public AsyncUnaryCall<
+    remote::ProtocolVersionRequest,
+    remote::ProtocolVersionReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncProtocolVersion> {
   public:
     explicit AsyncProtocolVersionCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncProtocolVersionCall::handle_completion ok: " << ok << " status: " << status_;
@@ -481,12 +496,15 @@ class AsyncProtocolVersionCall
     }
 };
 
-class AsyncClientVersionCall
-    : public AsyncUnaryCall<remote::ClientVersionRequest, remote::ClientVersionReply, remote::ETHBACKEND::StubInterface,
-                            remote::ETHBACKEND::Stub, &remote::ETHBACKEND::StubInterface::PrepareAsyncClientVersion> {
+class AsyncClientVersionCall : public AsyncUnaryCall<
+    remote::ClientVersionRequest,
+    remote::ClientVersionReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncClientVersion> {
   public:
     explicit AsyncClientVersionCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncClientVersionCall::handle_completion ok: " << ok << " status: " << status_;
@@ -501,24 +519,34 @@ class AsyncClientVersionCall
     }
 };
 
-class AsyncSubscribeCall : public AsyncServerStreamingCall<remote::SubscribeRequest, remote::SubscribeReply,
-                                                           remote::ETHBACKEND::StubInterface, remote::ETHBACKEND::Stub,
-                                                           &remote::ETHBACKEND::StubInterface::PrepareAsyncSubscribe> {
+class AsyncSubscribeCall : public AsyncServerStreamingCall<
+    remote::SubscribeRequest,
+    remote::SubscribeReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncSubscribe> {
   public:
     explicit AsyncSubscribeCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncServerStreamingCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncServerStreamingCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
-    void handle_read() override { SILK_INFO << "Subscribe reply: type=" << reply_.type() << " data=" << reply_.data(); }
+    void handle_read() override {
+        SILK_INFO << "Subscribe reply: type=" << reply_.type() << " data=" << reply_.data();
+    }
 
-    void handle_finish() override { SILK_INFO << "Subscribe completed status: " << status_; }
+    void handle_finish() override {
+        SILK_INFO << "Subscribe completed status: " << status_;
+    }
 };
 
-class AsyncNodeInfoCall
-    : public AsyncUnaryCall<remote::NodesInfoRequest, remote::NodesInfoReply, remote::ETHBACKEND::StubInterface,
-                            remote::ETHBACKEND::Stub, &remote::ETHBACKEND::StubInterface::PrepareAsyncNodeInfo> {
+class AsyncNodeInfoCall : public AsyncUnaryCall<
+    remote::NodesInfoRequest,
+    remote::NodesInfoReply,
+    remote::ETHBACKEND::StubInterface,
+    remote::ETHBACKEND::Stub,
+    &remote::ETHBACKEND::StubInterface::PrepareAsyncNodeInfo> {
   public:
     explicit AsyncNodeInfoCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::ETHBACKEND::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncNodeInfoCall::handle_completion ok: " << ok << " status: " << status_;
@@ -533,12 +561,15 @@ class AsyncNodeInfoCall
     }
 };
 
-class AsyncKvVersionCall
-    : public AsyncUnaryCall<google::protobuf::Empty, types::VersionReply, remote::KV::StubInterface, remote::KV::Stub,
-                            &remote::KV::StubInterface::PrepareAsyncVersion> {
+class AsyncKvVersionCall : public AsyncUnaryCall<
+    google::protobuf::Empty,
+    types::VersionReply,
+    remote::KV::StubInterface,
+    remote::KV::Stub,
+    &remote::KV::StubInterface::PrepareAsyncVersion> {
   public:
     explicit AsyncKvVersionCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncUnaryCall(channel, queue, &remote::KV::NewStub) {}
+    : AsyncUnaryCall(channel, queue, &remote::KV::NewStub) {}
 
     bool handle_completion(bool ok) override {
         SILK_DEBUG << "AsyncKvVersionCall::handle_completion ok: " << ok << " status: " << status_;
@@ -556,12 +587,15 @@ class AsyncKvVersionCall
     }
 };
 
-class AsyncTxCall
-    : public AsyncBidirectionalStreamingCall<remote::Cursor, remote::Pair, remote::KV::StubInterface, remote::KV::Stub,
-                                             &remote::KV::StubInterface::PrepareAsyncTx> {
+class AsyncTxCall : public AsyncBidirectionalStreamingCall<
+    remote::Cursor,
+    remote::Pair,
+    remote::KV::StubInterface,
+    remote::KV::Stub,
+    &remote::KV::StubInterface::PrepareAsyncTx> {
   public:
     explicit AsyncTxCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncBidirectionalStreamingCall(channel, queue, &remote::KV::NewStub) {}
+    : AsyncBidirectionalStreamingCall(channel, queue, &remote::KV::NewStub) {}
 
     void handle_start() override {
         SILK_INFO << "Tx started: opening cursor";
@@ -573,7 +607,7 @@ class AsyncTxCall
         if (query_count_ == 0) {
             if (cursor_id_ == kInvalidCursorId) {
                 SILK_DEBUG << "Tx cursor closed, closing tx";
-                return true;  // reads done, close tx
+                return true; // reads done, close tx
             } else {
                 SILK_INFO << "Tx queried: k=" << reply_.k() << " v= " << reply_.v() << ", queries done closing cursor";
                 request_.set_op(remote::Op::CLOSE);
@@ -602,7 +636,9 @@ class AsyncTxCall
         return false;
     }
 
-    void handle_finish() override { SILK_INFO << "Tx completed: status: " << status_; }
+    void handle_finish() override {
+        SILK_INFO << "Tx completed: status: " << status_;
+    }
 
   private:
     inline static const uint32_t kInvalidCursorId{std::numeric_limits<uint32_t>::max()};
@@ -612,30 +648,33 @@ class AsyncTxCall
     uint32_t cursor_id_{kInvalidCursorId};
 };
 
-class AsyncStateChangesCall
-    : public AsyncServerStreamingCall<remote::StateChangeRequest, remote::StateChangeBatch, remote::KV::StubInterface,
-                                      remote::KV::Stub, &remote::KV::StubInterface::PrepareAsyncStateChanges> {
+class AsyncStateChangesCall : public AsyncServerStreamingCall<
+    remote::StateChangeRequest,
+    remote::StateChangeBatch,
+    remote::KV::StubInterface,
+    remote::KV::Stub,
+    &remote::KV::StubInterface::PrepareAsyncStateChanges> {
   public:
     explicit AsyncStateChangesCall(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : AsyncServerStreamingCall(channel, queue, &remote::KV::NewStub) {}
+    : AsyncServerStreamingCall(channel, queue, &remote::KV::NewStub) {}
 
     void handle_read() override {
         SILK_INFO << "StateChanges batch: changebatch_size=" << reply_.changebatch_size()
-                  << " databaseviewid=" << reply_.databaseviewid()
-                  << " pendingblockbasefee=" << reply_.pendingblockbasefee()
-                  << " blockgaslimit=" << reply_.blockgaslimit();
+            << " databaseviewid=" << reply_.databaseviewid() << " pendingblockbasefee=" << reply_.pendingblockbasefee()
+            << " blockgaslimit=" << reply_.blockgaslimit();
     }
 
-    void handle_finish() override { SILK_INFO << "StateChanges completed status: " << status_; }
+    void handle_finish() override {
+        SILK_INFO << "StateChanges completed status: " << status_;
+    }
 };
 
 class AsyncCallFactory {
   public:
-    AsyncCallFactory(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-        : channel_(channel), queue_(queue) {}
+    AsyncCallFactory(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue) : channel_(channel), queue_(queue) {}
 
     void start_batch(std::atomic_bool& stop, int batch_size) {
-        for (auto i{0}; i < batch_size && !stop; ++i) {
+        for (auto i{0}; i<batch_size && !stop; i++) {
             auto* etherbase = new AsyncEtherbaseCall(channel_, queue_);
             etherbase->start_async(remote::EtherbaseRequest{});
             SILK_DEBUG << "New Etherbase async call started: " << etherbase;
@@ -703,17 +742,11 @@ int main(int argc, char* argv[]) {
     int64_t interval_between_calls{100};
     int batch_size{1};
     silkworm::log::Level log_level{silkworm::log::Level::kCritical};
-    app.add_option("--target", target_uri, "The address to connect to the ETHBACKEND & KV services")
-        ->capture_default_str();
-    app.add_option("--interval", interval_between_calls,
-                   "The interval to wait between successive call batches as milliseconds")
-        ->capture_default_str();
-    app.add_option("--batch", batch_size, "The number of async calls for each RPC in each batch as integer")
-        ->capture_default_str();
-    app.add_option("--logLevel", log_level, "The log level identifier as string")
-        ->capture_default_str()
-        ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical),
-                           static_cast<uint32_t>(silkworm::log::Level::kTrace)))
+    app.add_option("--target", target_uri, "The address to connect to the ETHBACKEND & KV services", true);
+    app.add_option("--interval", interval_between_calls, "The interval to wait between successive call batches as milliseconds", true);
+    app.add_option("--batch", batch_size, "The number of async calls for each RPC in each batch as integer", true);
+    app.add_option("--logLevel", log_level, "The log level identifier as string", true)
+        ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical), static_cast<uint32_t>(silkworm::log::Level::kTrace)))
         ->default_val(std::to_string(static_cast<uint32_t>(log_level)));
 
     CLI11_PARSE(app, argc, argv);
@@ -724,7 +757,7 @@ int main(int argc, char* argv[]) {
     log_settings.log_verbosity = log_level;
     silkworm::log::init(log_settings);
 
-    // TODO(canepat): this could be an option in Silkworm logging facility
+    //TODO(canepat): this could be an option in Silkworm logging facility
     silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
 
     try {
@@ -732,7 +765,7 @@ int main(int argc, char* argv[]) {
         boost::asio::signal_set signals{scheduler, SIGINT, SIGTERM};
 
         auto channel = grpc::CreateChannel(target_uri, grpc::InsecureChannelCredentials());
-        // TODO(canepat): create list of channels for round-robin batch pump
+        //TODO(canepat): create list of channels for round-robin batch pump
         grpc::CompletionQueue queue;
 
         std::mutex mutex;

--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -684,9 +684,9 @@ int main(int argc, char* argv[]) {
     std::string evm_path{};
     app.add_option("--evm", evm_path, "Path to EVMC-compliant VM");
     std::string tests_path{SILKWORM_CONSENSUS_TEST_DIR};
-    app.add_option("--tests", tests_path, "Path to consensus tests")->capture_default_str()->check(CLI::ExistingDirectory);
+    app.add_option("--tests", tests_path, "Path to consensus tests", /*defaulted=*/true)->check(CLI::ExistingDirectory);
     unsigned num_threads{std::thread::hardware_concurrency()};
-    app.add_option("--threads", num_threads, "Number of parallel threads")->capture_default_str();
+    app.add_option("--threads", num_threads, "Number of parallel threads", /*defaulted=*/true);
     bool include_slow_tests{false};
     app.add_flag("--slow", include_slow_tests, "Run slow tests");
 

--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -684,9 +684,9 @@ int main(int argc, char* argv[]) {
     std::string evm_path{};
     app.add_option("--evm", evm_path, "Path to EVMC-compliant VM");
     std::string tests_path{SILKWORM_CONSENSUS_TEST_DIR};
-    app.add_option("--tests", tests_path, "Path to consensus tests", /*defaulted=*/true)->check(CLI::ExistingDirectory);
+    app.add_option("--tests", tests_path, "Path to consensus tests")->capture_default_str()->check(CLI::ExistingDirectory);
     unsigned num_threads{std::thread::hardware_concurrency()};
-    app.add_option("--threads", num_threads, "Number of parallel threads", /*defaulted=*/true);
+    app.add_option("--threads", num_threads, "Number of parallel threads")->capture_default_str();
     bool include_slow_tests{false};
     app.add_flag("--slow", include_slow_tests, "Run slow tests");
 

--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -935,19 +935,18 @@ void do_extract_headers(db::EnvConfig& config, const std::string& file_name, uin
         const uint64_t* chuncks{reinterpret_cast<const uint64_t*>(db::from_slice(data.value).data())};
         out_stream << "   ";
         for (int i = 0; i < 4; ++i) {
-            std::string hex{to_hex(chuncks[i], true)};
+            std::string hex{ to_hex(chuncks[i], true)};
             out_stream << hex << ",";
         }
         out_stream << std::endl;
         max_height = block_num;
     }
 
-    out_stream
-        << "};\n"
-        << "const uint64_t* preverified_hashes_mainnet_data(){return &preverified_hashes_mainnet_internal[0];}\n"
-        << "size_t sizeof_preverified_hashes_mainnet_data(){return sizeof(preverified_hashes_mainnet_internal);}\n"
-        << "uint64_t preverified_hashes_mainnet_height(){return " << max_height << "ull;}\n"
-        << std::endl;
+    out_stream << "};\n"
+               << "const uint64_t* preverified_hashes_mainnet_data(){return &preverified_hashes_mainnet_internal[0];}\n"
+               << "size_t sizeof_preverified_hashes_mainnet_data(){return sizeof(preverified_hashes_mainnet_internal);}\n"
+               << "uint64_t preverified_hashes_mainnet_height(){return " << max_height << "ull;}\n"
+               << std::endl;
     out_stream.close();
 }
 
@@ -1019,10 +1018,8 @@ int main(int argc, char* argv[]) {
     auto cmd_copy_target_create_opt = cmd_copy->add_flag("--create", "Create target db if not exists");
     auto cmd_copy_target_noempty_opt = cmd_copy->add_flag("--noempty", "Skip copy of empty tables");
     std::vector<std::string> cmd_copy_names, cmd_copy_xnames;
-    cmd_copy->add_option("--tables", cmd_copy_names, "Copy only tables matching this list of names")
-        ->capture_default_str();
-    cmd_copy->add_option("--xtables", cmd_copy_xnames, "Don't copy tables matching this list of names")
-        ->capture_default_str();
+    cmd_copy->add_option("--tables", cmd_copy_names, "Copy only tables matching this list of names", true);
+    cmd_copy->add_option("--xtables", cmd_copy_xnames, "Don't copy tables matching this list of names", true);
 
     // Stages tool
     auto cmd_stageset = app_main.add_subcommand("stage-set", "Sets a stage to a new height");

--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -935,18 +935,19 @@ void do_extract_headers(db::EnvConfig& config, const std::string& file_name, uin
         const uint64_t* chuncks{reinterpret_cast<const uint64_t*>(db::from_slice(data.value).data())};
         out_stream << "   ";
         for (int i = 0; i < 4; ++i) {
-            std::string hex{ to_hex(chuncks[i], true)};
+            std::string hex{to_hex(chuncks[i], true)};
             out_stream << hex << ",";
         }
         out_stream << std::endl;
         max_height = block_num;
     }
 
-    out_stream << "};\n"
-               << "const uint64_t* preverified_hashes_mainnet_data(){return &preverified_hashes_mainnet_internal[0];}\n"
-               << "size_t sizeof_preverified_hashes_mainnet_data(){return sizeof(preverified_hashes_mainnet_internal);}\n"
-               << "uint64_t preverified_hashes_mainnet_height(){return " << max_height << "ull;}\n"
-               << std::endl;
+    out_stream
+        << "};\n"
+        << "const uint64_t* preverified_hashes_mainnet_data(){return &preverified_hashes_mainnet_internal[0];}\n"
+        << "size_t sizeof_preverified_hashes_mainnet_data(){return sizeof(preverified_hashes_mainnet_internal);}\n"
+        << "uint64_t preverified_hashes_mainnet_height(){return " << max_height << "ull;}\n"
+        << std::endl;
     out_stream.close();
 }
 
@@ -1018,8 +1019,10 @@ int main(int argc, char* argv[]) {
     auto cmd_copy_target_create_opt = cmd_copy->add_flag("--create", "Create target db if not exists");
     auto cmd_copy_target_noempty_opt = cmd_copy->add_flag("--noempty", "Skip copy of empty tables");
     std::vector<std::string> cmd_copy_names, cmd_copy_xnames;
-    cmd_copy->add_option("--tables", cmd_copy_names, "Copy only tables matching this list of names", true);
-    cmd_copy->add_option("--xtables", cmd_copy_xnames, "Don't copy tables matching this list of names", true);
+    cmd_copy->add_option("--tables", cmd_copy_names, "Copy only tables matching this list of names")
+        ->capture_default_str();
+    cmd_copy->add_option("--xtables", cmd_copy_xnames, "Don't copy tables matching this list of names")
+        ->capture_default_str();
 
     // Stages tool
     auto cmd_stageset = app_main.add_subcommand("stage-set", "Sets a stage to a new height");

--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -1089,8 +1089,8 @@ int main(int argc, char* argv[]) {
         }
 
         db::EnvConfig src_config{data_dir.chaindata().path().string()};
-        src_config.shared = *shared_opt;
-        src_config.exclusive = *exclusive_opt;
+        src_config.shared = static_cast<bool>(*shared_opt);
+        src_config.exclusive = static_cast<bool>(*exclusive_opt);
 
         // Execute subcommand actions
         if (*cmd_tables) {
@@ -1100,7 +1100,7 @@ int main(int argc, char* argv[]) {
                 do_tables(src_config);
             }
         } else if (*cmd_freelist) {
-            do_freelist(src_config, *freelist_detail_opt);
+            do_freelist(src_config, static_cast<bool>(*freelist_detail_opt));
         } else if (*cmd_schema) {
             do_schema(src_config);
         } else if (*cmd_stages) {
@@ -1108,19 +1108,22 @@ int main(int argc, char* argv[]) {
         } else if (*cmd_migrations) {
             do_migrations(src_config);
         } else if (*cmd_clear) {
-            do_clear(src_config, *app_dry_opt, *app_yes_opt, cmd_clear_names, *cmd_clear_drop_opt);
+            do_clear(src_config, static_cast<bool>(*app_dry_opt), static_cast<bool>(*app_yes_opt), cmd_clear_names,
+                     static_cast<bool>(*cmd_clear_drop_opt));
         } else if (*cmd_compact) {
-            do_compact(src_config, cmd_compact_workdir_opt->as<std::string>(), *cmd_compact_replace_opt,
-                       *cmd_compact_nobak_opt);
+            do_compact(src_config, cmd_compact_workdir_opt->as<std::string>(),
+                       static_cast<bool>(*cmd_compact_replace_opt), static_cast<bool>(*cmd_compact_nobak_opt));
         } else if (*cmd_copy) {
-            do_copy(src_config, cmd_copy_targetdir_opt->as<std::string>(), *cmd_copy_target_create_opt,
-                    *cmd_copy_target_noempty_opt, cmd_copy_names, cmd_copy_xnames);
+            do_copy(src_config, cmd_copy_targetdir_opt->as<std::string>(),
+                    static_cast<bool>(*cmd_copy_target_create_opt), static_cast<bool>(*cmd_copy_target_noempty_opt),
+                    cmd_copy_names, cmd_copy_xnames);
         } else if (*cmd_stageset) {
             do_stage_set(src_config, cmd_stageset_name_opt->as<std::string>(), cmd_stageset_height_opt->as<uint32_t>(),
-                         *app_dry_opt);
+                         static_cast<bool>(*app_dry_opt));
         } else if (*cmd_initgenesis) {
             do_init_genesis(data_dir, cmd_initgenesis_json_opt->as<std::string>(),
-                            *cmd_initgenesis_chain_opt ? cmd_initgenesis_chain_opt->as<uint32_t>() : 0u, *app_dry_opt);
+                            *cmd_initgenesis_chain_opt ? cmd_initgenesis_chain_opt->as<uint32_t>() : 0u,
+                            static_cast<bool>(*app_dry_opt));
             if (*app_dry_opt) {
                 std::cout << "\nGenesis initialization succeeded. Due to --dry flag no data is persisted\n"
                           << std::endl;

--- a/cmd/trie.cpp
+++ b/cmd/trie.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -37,8 +37,7 @@ int main(int argc, char* argv[]) {
     using namespace silkworm;
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
     CLI11_PARSE(app, argc, argv);

--- a/cmd/trie.cpp
+++ b/cmd/trie.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ int main(int argc, char* argv[]) {
     using namespace silkworm;
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
 
     CLI11_PARSE(app, argc, argv);

--- a/cmd/tx_lookup.cpp
+++ b/cmd/tx_lookup.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -33,8 +33,7 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool full{false};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
 
     app.add_flag("--full", full, "Start making lookups from block 0");

--- a/cmd/tx_lookup.cpp
+++ b/cmd/tx_lookup.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -33,7 +33,8 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool full{false};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
 
     app.add_flag("--full", full, "Start making lookups from block 0");

--- a/cmd/unwind_history_index.cpp
+++ b/cmd/unwind_history_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@ int main(int argc, char* argv[]) {
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool storage{false};
     uint64_t unwind_to{0};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
     app.add_option("--unwind-to", unwind_to, "Unwind to");
     app.add_flag("--storage", storage, "Do history of storages");

--- a/cmd/unwind_history_index.cpp
+++ b/cmd/unwind_history_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ int main(int argc, char* argv[]) {
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     bool storage{false};
     uint64_t unwind_to{0};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
     app.add_option("--unwind-to", unwind_to, "Unwind to");
     app.add_flag("--storage", storage, "Do history of storages");

--- a/cmd/unwind_log_index.cpp
+++ b/cmd/unwind_log_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     uint64_t unwind_to{0};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
     app.add_option("--unwind-to", unwind_to, "Unwind point");
 

--- a/cmd/unwind_log_index.cpp
+++ b/cmd/unwind_log_index.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     uint64_t unwind_to{0};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Erigon", true)
         ->check(CLI::ExistingDirectory);
     app.add_option("--unwind-to", unwind_to, "Unwind point");
 

--- a/cmd/unwind_tx_lookup.cpp
+++ b/cmd/unwind_tx_lookup.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 The Silkworm Authors
+   Copyright 2021 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,10 +31,11 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     uint32_t unwind_to{UINT32_MAX};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Turbo-Geth")
-        ->capture_default_str()
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Turbo-Geth", true)
         ->check(CLI::ExistingDirectory);
-    app.add_option("--unwind-to", unwind_to, "Specify unwinding point")->required()->check(CLI::Range(0u, UINT32_MAX));
+    app.add_option("--unwind-to", unwind_to, "Specify unwinding point", false)
+        ->required()
+        ->check(CLI::Range(0u, UINT32_MAX));
 
     CLI11_PARSE(app, argc, argv);
 

--- a/cmd/unwind_tx_lookup.cpp
+++ b/cmd/unwind_tx_lookup.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,11 +31,10 @@ int main(int argc, char* argv[]) {
 
     std::string chaindata{DataDirectory{}.chaindata().path().string()};
     uint32_t unwind_to{UINT32_MAX};
-    app.add_option("--chaindata", chaindata, "Path to a database populated by Turbo-Geth", true)
+    app.add_option("--chaindata", chaindata, "Path to a database populated by Turbo-Geth")
+        ->capture_default_str()
         ->check(CLI::ExistingDirectory);
-    app.add_option("--unwind-to", unwind_to, "Specify unwinding point", false)
-        ->required()
-        ->check(CLI::Range(0u, UINT32_MAX));
+    app.add_option("--unwind-to", unwind_to, "Specify unwinding point")->required()->check(CLI::Range(0u, UINT32_MAX));
 
     CLI11_PARSE(app, argc, argv);
 


### PR DESCRIPTION
OpenSSL, intx, benchmark were updated in Hunter [v0.24.1](https://github.com/cpp-pm/hunter/releases/tag/v0.24.1), so no need to override them.

To update CLI11 I had to make quite a few code changes because
`.add_option(..., true)`
should be replaced by
`.add_option(...)->capture_default_str()`