### PR TITLE
State changes safe consumers

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -207,6 +207,7 @@ int main(int argc, char* argv[]) {
         signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
             std::cout << "\n";
             SILK_INFO << "Signal caught, error: " << error << " number: " << signal_number;
+            backend.close();
             server.shutdown();
         });
 

--- a/node/silkworm/backend/ethereum_backend.cpp
+++ b/node/silkworm/backend/ethereum_backend.cpp
@@ -48,4 +48,8 @@ void EthereumBackEnd::set_node_name(const std::string& node_name) noexcept {
     node_name_ = node_name;
 }
 
+void EthereumBackEnd::close() {
+    state_change_collection_->close();
+}
+
 } // namespace silkworm

--- a/node/silkworm/backend/ethereum_backend.hpp
+++ b/node/silkworm/backend/ethereum_backend.hpp
@@ -48,6 +48,8 @@ class EthereumBackEnd {
 
     void set_node_name(const std::string& node_name) noexcept;
 
+    void close();
+
   protected:
     //! Constructor for testability
     EthereumBackEnd(

--- a/node/silkworm/backend/ethereum_backend_test.cpp
+++ b/node/silkworm/backend/ethereum_backend_test.cpp
@@ -76,6 +76,11 @@ TEST_CASE("EthereumBackEnd", "[silkworm][backend][ethereum_backend]") {
         EthereumBackEnd backend{node_settings, &database_env};
         CHECK(backend.sentry_addresses() == std::vector<std::string>{kTestSentryAddress1, kTestSentryAddress2});
     }
+
+    SECTION("EthereumBackEnd::close", "[silkworm][backend][ethereum_backend]") {
+        EthereumBackEnd backend{node_settings, &database_env};
+        CHECK_NOTHROW(backend.close());
+    }
 }
 
 } // namespace silkworm

--- a/node/silkworm/rpc/client/call_test.cpp
+++ b/node/silkworm/rpc/client/call_test.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "call.hpp"
+
+#include <catch2/catch.hpp>
+
+namespace silkworm::rpc {
+
+TEST_CASE("AsyncCall", "[silkworm][rpc][client][call]") {
+    class FakeCall : public AsyncCall {
+      public:
+        explicit FakeCall(grpc::CompletionQueue* queue) : AsyncCall(queue) {}
+      protected:
+        bool proceed(bool /*ok*/) override { return false; }
+    };
+
+    grpc::CompletionQueue queue;
+
+    SECTION("AsyncCall::AsyncCall") {
+        FakeCall call{&queue};
+        CHECK(call.peer().empty());
+        CHECK(call.start_time() <= std::chrono::steady_clock::now());
+        CHECK(call.status().ok());
+        CHECK_NOTHROW(call.cancel());
+    }
+}
+
+} // namespace silkworm::rpc

--- a/node/silkworm/rpc/server/state_change_collection.cpp
+++ b/node/silkworm/rpc/server/state_change_collection.cpp
@@ -25,12 +25,14 @@
 namespace silkworm::rpc {
 
 std::optional<StateChangeToken> StateChangeCollection::subscribe(StateChangeConsumer consumer, StateChangeFilter /*filter*/) {
+    std::unique_lock subscribed_lock{consumers_mutex_};
     StateChangeToken token = ++next_token_;
     const auto [_, inserted] = consumers_.insert({token, consumer});
     return inserted ? std::make_optional(token) : std::nullopt;
 }
 
 bool StateChangeCollection::unsubscribe(StateChangeToken token) {
+    std::unique_lock subscribed_lock{consumers_mutex_};
     const auto consumer_it = consumers_.erase(token);
     return consumer_it != 0;
 }
@@ -183,6 +185,7 @@ void StateChangeCollection::delete_account(const evmc::address& address) {
 }
 
 void StateChangeCollection::notify_batch(uint64_t pending_base_fee, uint64_t gas_limit) {
+    std::unique_lock subscribed_lock{consumers_mutex_};
     SILK_TRACE << "StateChangeCollection::notify_batch " << this << " pending_base_fee: " << pending_base_fee << " gas_limit:" << gas_limit << " START";
 
     state_changes_.set_pendingblockbasefee(pending_base_fee);
@@ -202,6 +205,7 @@ void StateChangeCollection::notify_batch(uint64_t pending_base_fee, uint64_t gas
 }
 
 void StateChangeCollection::close() {
+    std::unique_lock subscribed_lock{consumers_mutex_};
     for (const auto& [_, batch_callback] : consumers_) {
         SILK_DEBUG << "Notify close to callback=" << &batch_callback;
         batch_callback(std::nullopt);

--- a/node/silkworm/rpc/server/state_change_collection.hpp
+++ b/node/silkworm/rpc/server/state_change_collection.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 
 #include <evmc/evmc.hpp>
@@ -100,6 +101,9 @@ class StateChangeCollection : public StateChangeSource {
 
     //! The registered batch consumers.
     std::map<StateChangeToken, StateChangeConsumer> consumers_;
+
+    //! The mutual exclusion protecting access to the registered consumers.
+    std::mutex consumers_mutex_;
 };
 
 } // namespace silkworm::rpc


### PR DESCRIPTION
This PR makes the state-change collection point thread-safe. This is required because:
- the staged loop thread will act as state-change source, creating new state-change batches and notifying them to registered consumers
- the threaded schedulers running the RPC server-side calls will concurrently register state-change consumers