### PR TITLE
Add asio::io_context integration in gRPC completion end point

### DIFF
--- a/node/silkworm/rpc/completion_end_point.hpp
+++ b/node/silkworm/rpc/completion_end_point.hpp
@@ -17,6 +17,7 @@
 #ifndef SILKWORM_RPC_COMPLETION_END_POINT_HPP_
 #define SILKWORM_RPC_COMPLETION_END_POINT_HPP_
 
+#include <boost/asio/io_context.hpp>
 #include <grpcpp/grpcpp.h>
 
 namespace silkworm::rpc {
@@ -31,6 +32,9 @@ class CompletionEndPoint {
 
     //! Run at most one execution cycle polling gRPC completion queue for one event.
     int poll_one();
+
+    //! Post to scheduler at most one execution task polling gRPC completion queue for one event.
+    bool post_one(boost::asio::io_context& scheduler);
 
     //! Shutdown and drain the gRPC completion queue.
     void shutdown();

--- a/node/silkworm/rpc/completion_end_point_test.cpp
+++ b/node/silkworm/rpc/completion_end_point_test.cpp
@@ -31,12 +31,12 @@ namespace silkworm::rpc {
 using Catch::Matchers::Message;
 using namespace std::chrono_literals;
 
-TEST_CASE("CompletionEndPoint", "[silkworm][rpc][completion_end_point]") {
+TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]") {
     silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    grpc::CompletionQueue queue;
+    CompletionEndPoint completion_end_point{queue};
 
     SECTION("waiting on empty completion queue") {
-        grpc::CompletionQueue queue;
-        CompletionEndPoint completion_end_point{queue};
         auto completion_end_point_thread = std::thread([&]() {
             while (completion_end_point.poll_one() >= 0) {
                 std::this_thread::sleep_for(100us);
@@ -49,8 +49,6 @@ TEST_CASE("CompletionEndPoint", "[silkworm][rpc][completion_end_point]") {
 // Exclude gRPC test from sanitizer builds due to data race warnings
 #ifndef SILKWORM_SANITIZE
     SECTION("executing completion handler") {
-        grpc::CompletionQueue queue;
-        CompletionEndPoint completion_end_point{queue};
         bool executed{false};
         TagProcessor tag_processor = [&completion_end_point, &executed](bool) {
             executed = true;
@@ -67,8 +65,6 @@ TEST_CASE("CompletionEndPoint", "[silkworm][rpc][completion_end_point]") {
 #endif // SILKWORM_SANITIZE
 
     SECTION("exiting on completion queue already shutdown") {
-        grpc::CompletionQueue queue;
-        CompletionEndPoint completion_end_point{queue};
         completion_end_point.shutdown();
         auto completion_end_point_thread = std::thread([&]() {
             while (completion_end_point.poll_one() >= 0) {
@@ -79,8 +75,6 @@ TEST_CASE("CompletionEndPoint", "[silkworm][rpc][completion_end_point]") {
     }
 
     SECTION("stopping again after already stopped") {
-        grpc::CompletionQueue queue;
-        CompletionEndPoint completion_end_point{queue};
         auto completion_end_point_thread = std::thread([&]() {
             while (completion_end_point.poll_one() >= 0) {
                 std::this_thread::sleep_for(100us);
@@ -89,6 +83,42 @@ TEST_CASE("CompletionEndPoint", "[silkworm][rpc][completion_end_point]") {
         completion_end_point.shutdown();
         CHECK_NOTHROW(completion_end_point_thread.join());
         CHECK_NOTHROW(completion_end_point.shutdown());
+    }
+}
+
+TEST_CASE("CompletionEndPoint::post_one", "[silkworm][rpc][completion_end_point]") {
+    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    grpc::CompletionQueue queue;
+    CompletionEndPoint completion_end_point{queue};
+    boost::asio::io_context io_context;
+    boost::asio::io_context::work work{io_context};
+
+    SECTION("executing completion handler") {
+        bool executed{false};
+
+        // Setup the alarm notification delivered through gRPC queue
+        TagProcessor tag_processor = [&](bool) {
+            executed = true;
+            completion_end_point.shutdown();
+            io_context.stop();
+        };
+        auto alarm_deadline = gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC), gpr_time_from_millis(50, GPR_TIMESPAN));
+        grpc::Alarm alarm;
+        alarm.Set(&queue, alarm_deadline, &tag_processor);
+
+        // Start the thread polling the gRPC queue
+        auto completion_runner_thread = std::thread([&]() {
+            bool stopped{false};
+            while (!stopped) {
+                stopped = completion_end_point.post_one(io_context);
+            }
+        });
+
+        // Run the Asio scheduler executing the completion handler
+        io_context.run();
+
+        CHECK_NOTHROW(completion_runner_thread.join());
+        CHECK(executed);
     }
 }
 


### PR DESCRIPTION
This PR includes support in RPC `CompletionEndPoint` for posting completion handlers to `asio::io_context` scheduler (as part of the changes to add wait policies to `ServerContext` execution loop) 