### PR TITLE
Extend evm tracer

### DIFF
--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -50,8 +50,7 @@ class DelegatingTracer : public evmone::Tracer {
         tracer_.on_instruction_start(pc, stack_top, stack_height, state, intra_block_state_);
     }
 
-    void on_execution_end(const evmc_result& res) noexcept override {
-        CallResult result{res.status_code, static_cast<uint64_t>(res.gas_left), {res.output_data, res.output_size}};
+    void on_execution_end(const evmc_result& result) noexcept override {
         tracer_.on_execution_end(result, intra_block_state_);
     }
 
@@ -227,11 +226,8 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
         }
         // Explicitly notify registered tracers (if any)
         if (!tracers_.empty()) {
-            uint64_t gas_left{static_cast<uint64_t>(res.gas_left)};
-            Bytes data{res.output_data, res.output_size};
-            CallResult result{res.status_code, gas_left, data};
             for (auto tracer : tracers_) {
-                tracer.get().on_precompiled_run(result, static_cast<uint64_t>(message.gas), state_);
+                tracer.get().on_precompiled_run(res, message.gas, state_);
             }
         }
     } else {

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -226,7 +226,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
             }
         }
         // Explicitly notify registered tracers (if any)
-        if (tracers_.size() > 0) {
+        if (!tracers_.empty()) {
             uint64_t gas_left{static_cast<uint64_t>(res.gas_left)};
             Bytes data{res.output_data, res.output_size};
             CallResult result{res.status_code, gas_left, data};
@@ -236,7 +236,7 @@ evmc::result EVM::call(const evmc_message& message) noexcept {
         }
     } else {
         const ByteView code{state_.get_code(message.code_address)};
-        if (code.empty() && tracers_.size() == 0) { // Do not skip execution if there are any tracers
+        if (code.empty() && tracers_.empty()) { // Do not skip execution if there are any tracers
             return res;
         }
 

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -45,9 +45,9 @@ class EvmTracer {
     virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, const evmone::ExecutionState& state,
                                       const IntraBlockState& intra_block_state) noexcept = 0;
 
-    virtual void on_execution_end(const CallResult& result, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_execution_end(const evmc_result& result, const IntraBlockState& intra_block_state) noexcept = 0;
 
-    virtual void on_precompiled_run(const CallResult& result, std::uint64_t gas, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_precompiled_run(const evmc::result& result, int64_t gas, const IntraBlockState& intra_block_state) noexcept = 0;
 
     virtual void on_reward_granted(const CallResult& result, const IntraBlockState& intra_block_state) noexcept = 0;
 };

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -45,9 +45,9 @@ class EvmTracer {
     virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, const evmone::ExecutionState& state,
                                       const IntraBlockState& intra_block_state) noexcept = 0;
 
-    virtual void on_execution_end(const evmc::result& result, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_execution_end(const CallResult& result, const IntraBlockState& intra_block_state) noexcept = 0;
 
-    virtual void on_precompiled_run(const evmc::result& result, std::uint64_t gas, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_precompiled_run(const CallResult& result, std::uint64_t gas, const IntraBlockState& intra_block_state) noexcept = 0;
 
     virtual void on_reward_granted(const CallResult& result, const IntraBlockState& intra_block_state) noexcept = 0;
 };

--- a/core/silkworm/execution/evm.hpp
+++ b/core/silkworm/execution/evm.hpp
@@ -17,6 +17,7 @@
 #ifndef SILKWORM_EXECUTION_EVM_HPP_
 #define SILKWORM_EXECUTION_EVM_HPP_
 
+#include <functional>
 #include <stack>
 #include <vector>
 
@@ -44,7 +45,11 @@ class EvmTracer {
     virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, const evmone::ExecutionState& state,
                                       const IntraBlockState& intra_block_state) noexcept = 0;
 
-    virtual void on_execution_end(const evmc_result& result, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_execution_end(const evmc::result& result, const IntraBlockState& intra_block_state) noexcept = 0;
+
+    virtual void on_precompiled_run(const evmc::result& result, std::uint64_t gas, const IntraBlockState& intra_block_state) noexcept = 0;
+
+    virtual void on_reward_granted(const CallResult& result, const IntraBlockState& intra_block_state) noexcept = 0;
 };
 
 using EvmoneExecutionState = evmone::advanced::AdvancedExecutionState;
@@ -72,6 +77,7 @@ class EVM {
     evmc_revision revision() const noexcept;
 
     void add_tracer(EvmTracer& tracer) noexcept;
+    const std::vector<std::reference_wrapper<EvmTracer>>& tracers() const noexcept {return tracers_;};
 
     // Use for better performance with evmone baseline interpreter
     BaselineAnalysisCache* baseline_analysis_cache{nullptr};
@@ -111,6 +117,7 @@ class EVM {
     const ChainConfig& config_;
     const Transaction* txn_{nullptr};
     std::vector<evmc::bytes32> block_hashes_{};
+    std::vector<std::reference_wrapper<EvmTracer>> tracers_;
 
     evmc_vm* evm1_{nullptr};
 };

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -367,6 +367,68 @@ TEST_CASE("EIP-3541: Reject new contracts starting with the 0xEF byte") {
     CHECK(evm.execute(txn, gas).status == EVMC_SUCCESS);
 }
 
+class TestTracer : public EvmTracer {
+  public:
+    TestTracer(std::optional<evmc::address> contract_address = std::nullopt,
+                std::optional<evmc::bytes32> key = std::nullopt)
+        : contract_address_(contract_address), key_(key) {}
+
+    void on_execution_start(evmc_revision rev, const evmc_message& msg,
+                            evmone::bytes_view bytecode) noexcept override {
+        execution_start_called_ = true;
+        rev_ = rev;
+        msg_ = msg;
+        bytecode_ = Bytes{bytecode};
+    }
+    void on_instruction_start(uint32_t pc, const intx::uint256* /*stack_top*/, int /*stack_height*/, 
+        const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override {
+        pc_stack_.push_back(pc);
+        memory_size_stack_[pc] = state.memory.size();
+        if (contract_address_) {
+            storage_stack_[pc] =
+                intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
+        }
+    }
+    void on_execution_end(const evmc::result& res, const IntraBlockState& intra_block_state) noexcept override {
+        execution_end_called_ = true;
+        result_ = {res.status_code, static_cast<uint64_t>(res.gas_left), {res.output_data, res.output_size}};
+        if (contract_address_ && pc_stack_.size() > 0) {
+            const auto pc = pc_stack_.back();
+            storage_stack_[pc] =
+                intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
+        }
+    }
+    void on_precompiled_run(const evmc::result& /*res*/, std::uint64_t /*gas*/,
+        const IntraBlockState& /*intra_block_state*/) noexcept override {
+    }
+    void on_reward_granted(const CallResult& /*result*/,
+        const IntraBlockState& /*intra_block_state*/) noexcept override {
+    }
+
+    bool execution_start_called() const { return execution_start_called_; }
+    bool execution_end_called() const { return execution_end_called_; }
+    const Bytes& bytecode() const { return bytecode_; }
+    const evmc_revision& rev() const { return rev_; }
+    const evmc_message& msg() const { return msg_; }
+    const std::vector<uint32_t>& pc_stack() const { return pc_stack_; }
+    const std::map<uint32_t, std::size_t>& memory_size_stack() const { return memory_size_stack_; }
+    const std::map<uint32_t, evmc::bytes32>& storage_stack() const { return storage_stack_; }
+    const CallResult& result() const { return result_; }
+
+  private:
+    bool execution_start_called_{false};
+    bool execution_end_called_{false};
+    std::optional<evmc::address> contract_address_;
+    std::optional<evmc::bytes32> key_;
+    evmc_revision rev_;
+    evmc_message msg_;
+    Bytes bytecode_;
+    std::vector<uint32_t> pc_stack_;
+    std::map<uint32_t, std::size_t> memory_size_stack_;
+    std::map<uint32_t, evmc::bytes32> storage_stack_;
+    CallResult result_;
+};
+
 TEST_CASE("Tracing smart contract with storage") {
     Block block{};
     block.header.number = 10'336'006;
@@ -403,59 +465,24 @@ TEST_CASE("Tracing smart contract with storage") {
     txn.from = caller;
     txn.data = code;
 
-    class TestTracer : public EvmTracer {
-      public:
-        TestTracer(std::optional<evmc::address> contract_address = std::nullopt,
-                   std::optional<evmc::bytes32> key = std::nullopt)
-            : contract_address_(contract_address), key_(key) {}
-
-        void on_execution_start(evmc_revision /*rev*/, const evmc_message& /*msg*/,
-                                evmone::bytes_view bytecode) noexcept override {
-            bytecode_ = Bytes{bytecode};
-        }
-        void on_instruction_start(uint32_t pc, const intx::uint256* /*stack_top*/, int /*stack_height*/, 
-            const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override {
-            pc_stack_.push_back(pc);
-            memory_size_stack_[pc] = state.memory.size();
-            if (contract_address_) {
-                storage_stack_[pc] =
-                    intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
-            }
-        }
-        void on_execution_end(const evmc_result& res, const IntraBlockState& intra_block_state) noexcept override {
-            result_ = {res.status_code, static_cast<uint64_t>(res.gas_left), {res.output_data, res.output_size}};
-            if (contract_address_) {
-                const auto pc = pc_stack_.back();
-                storage_stack_[pc] =
-                    intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
-            }
-        }
-
-        const Bytes& bytecode() const { return bytecode_; }
-        const std::vector<uint32_t>& pc_stack() const { return pc_stack_; }
-        const std::map<uint32_t, std::size_t>& memory_size_stack() const { return memory_size_stack_; }
-        const std::map<uint32_t, evmc::bytes32>& storage_stack() const { return storage_stack_; }
-        const CallResult& result() const { return result_; }
-
-      private:
-        std::optional<evmc::address> contract_address_;
-        std::optional<evmc::bytes32> key_;
-        Bytes bytecode_;
-        std::vector<uint32_t> pc_stack_;
-        std::map<uint32_t, std::size_t> memory_size_stack_;
-        std::map<uint32_t, evmc::bytes32> storage_stack_;
-        CallResult result_;
-    };
+    CHECK(evm.tracers().empty());
 
     // First execution: out of gas
     TestTracer tracer1;
     evm.add_tracer(tracer1);
+    CHECK(evm.tracers().size() == 1);
 
     uint64_t gas{0};
     CallResult res{evm.execute(txn, gas)};
     CHECK(res.status == EVMC_OUT_OF_GAS);
     CHECK(res.data.empty());
 
+    CHECK((tracer1.execution_start_called() && tracer1.execution_end_called()));
+    CHECK(tracer1.rev() == evmc_revision::EVMC_ISTANBUL);
+    CHECK(tracer1.msg().kind == evmc_call_kind::EVMC_CALL);
+    CHECK(tracer1.msg().flags == 0);
+    CHECK(tracer1.msg().depth == 0);
+    CHECK(tracer1.msg().gas == 0);
     CHECK(tracer1.bytecode() == code);
     CHECK(tracer1.pc_stack() == std::vector<uint32_t>{0});
     CHECK(tracer1.memory_size_stack() == std::map<uint32_t, std::size_t>{{0, 0}});
@@ -466,12 +493,19 @@ TEST_CASE("Tracing smart contract with storage") {
     // Second execution: success
     TestTracer tracer2;
     evm.add_tracer(tracer2);
+    CHECK(evm.tracers().size() == 2);
 
     gas = 50'000;
     res = evm.execute(txn, gas);
     CHECK(res.status == EVMC_SUCCESS);
     CHECK(res.data == from_hex("600035600055"));
 
+    CHECK((tracer2.execution_start_called() && tracer2.execution_end_called()));
+    CHECK(tracer2.rev() == evmc_revision::EVMC_ISTANBUL);
+    CHECK(tracer2.msg().kind == evmc_call_kind::EVMC_CALL);
+    CHECK(tracer2.msg().flags == 0);
+    CHECK(tracer2.msg().depth == 0);
+    CHECK(tracer2.msg().gas == 50'000);
     CHECK(tracer2.bytecode() == code);
     CHECK(tracer2.pc_stack() == std::vector<uint32_t>{0, 2, 4, 5, 8, 10, 11, 13, 14, 16, 18, 19, 21});
     CHECK(tracer2.memory_size_stack() == std::map<uint32_t, std::size_t>{{0, 0},
@@ -497,6 +531,7 @@ TEST_CASE("Tracing smart contract with storage") {
 
     TestTracer tracer3{contract_address, key0};
     evm.add_tracer(tracer3);
+    CHECK(evm.tracers().size() == 3);
 
     CHECK(to_hex(zeroless_view(state.get_current_storage(contract_address, key0))) == "2a");
     evmc::bytes32 new_val{to_bytes32(*from_hex("f5"))};
@@ -507,18 +542,85 @@ TEST_CASE("Tracing smart contract with storage") {
     CHECK(res.status == EVMC_SUCCESS);
     CHECK(res.data.empty());
     CHECK(state.get_current_storage(contract_address, key0) == new_val);
+
+    CHECK((tracer3.execution_start_called() && tracer3.execution_end_called()));
+    CHECK(tracer3.rev() == evmc_revision::EVMC_ISTANBUL);
+    CHECK(tracer3.msg().kind == evmc_call_kind::EVMC_CALL);
+    CHECK(tracer3.msg().flags == 0);
+    CHECK(tracer3.msg().depth == 0);
+    CHECK(tracer3.msg().gas == 50'000);
     CHECK(tracer3.storage_stack() == std::map<uint32_t, evmc::bytes32>{
                                          {0, to_bytes32(*from_hex("2a"))},
                                          {2, to_bytes32(*from_hex("2a"))},
                                          {3, to_bytes32(*from_hex("2a"))},
                                          {5, to_bytes32(*from_hex("f5"))},
                                      });
-
     CHECK(tracer3.pc_stack() == std::vector<uint32_t>{0, 2, 3, 5});
     CHECK(tracer3.memory_size_stack() == std::map<uint32_t, std::size_t>{{0, 0}, {2, 0}, {3, 0}, {5, 0}});
     CHECK(tracer3.result().status == EVMC_SUCCESS);
     CHECK(tracer3.result().gas_left == 49191);
     CHECK(tracer3.result().data == Bytes{});
+}
+
+TEST_CASE("Tracing smart contract w/o code") {
+    Block block{};
+    block.header.number = 10'336'006;
+
+    InMemoryState db;
+    IntraBlockState state{db};
+    EVM evm{block, state, kMainnetConfig};
+    CHECK(evm.tracers().empty());
+
+    TestTracer tracer1;
+    evm.add_tracer(tracer1);
+    CHECK(evm.tracers().size() == 1);
+
+    // Deploy contract without code
+    evmc::address caller{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
+    Bytes code{};
+
+    Transaction txn{};
+    txn.from = caller;
+    txn.data = code;
+    uint64_t gas{50'000};
+
+    CallResult res{evm.execute(txn, gas)};
+    CHECK(res.status == EVMC_SUCCESS);
+    CHECK(res.data.empty());
+
+    CHECK(tracer1.execution_start_called());
+    CHECK(tracer1.execution_end_called());
+    CHECK(tracer1.rev() == evmc_revision::EVMC_ISTANBUL);
+    CHECK(tracer1.bytecode() == code);
+    CHECK(tracer1.pc_stack() == std::vector<uint32_t>{});
+    CHECK(tracer1.memory_size_stack() == std::map<uint32_t, std::size_t>{});
+    CHECK(tracer1.result().status == EVMC_SUCCESS);
+    CHECK(tracer1.result().gas_left == gas);
+    CHECK(tracer1.result().data == Bytes{});
+
+    // Send message to empty contract
+    evmc::address contract_address{create_address(caller, 1)};
+    evmc::bytes32 key0{};
+
+    TestTracer tracer2{contract_address, key0};
+    evm.add_tracer(tracer2);
+    CHECK(evm.tracers().size() == 2);
+
+    txn.to = contract_address;
+    txn.data = ByteView{to_bytes32(*from_hex("f5"))};
+    res = evm.execute(txn, gas);
+    CHECK(res.status == EVMC_SUCCESS);
+    CHECK(res.data.empty());
+
+    CHECK(tracer2.execution_start_called());
+    CHECK(tracer2.execution_end_called());
+    CHECK(tracer2.rev() == evmc_revision::EVMC_ISTANBUL);
+    CHECK(tracer2.bytecode() == code);
+    CHECK(tracer2.pc_stack() == std::vector<uint32_t>{});
+    CHECK(tracer2.memory_size_stack() == std::map<uint32_t, std::size_t>{});
+    CHECK(tracer2.result().status == EVMC_SUCCESS);
+    CHECK(tracer2.result().gas_left == gas);
+    CHECK(tracer2.result().data == Bytes{});
 }
 
 }  // namespace silkworm

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -389,16 +389,16 @@ class TestTracer : public EvmTracer {
                 intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
         }
     }
-    void on_execution_end(const evmc::result& res, const IntraBlockState& intra_block_state) noexcept override {
+    void on_execution_end(const CallResult& result, const IntraBlockState& intra_block_state) noexcept override {
         execution_end_called_ = true;
-        result_ = {res.status_code, static_cast<uint64_t>(res.gas_left), {res.output_data, res.output_size}};
+        result_ = result;
         if (contract_address_ && pc_stack_.size() > 0) {
             const auto pc = pc_stack_.back();
             storage_stack_[pc] =
                 intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
         }
     }
-    void on_precompiled_run(const evmc::result& /*res*/, std::uint64_t /*gas*/,
+    void on_precompiled_run(const CallResult& /*res*/, std::uint64_t /*gas*/,
         const IntraBlockState& /*intra_block_state*/) noexcept override {
     }
     void on_reward_granted(const CallResult& /*result*/,


### PR DESCRIPTION
This PR improves the `EvmTracer` hooks needed by Silkrpc for `trace_*` API implementation. In particular:
- add new `EvmTracer::on_precompiled_run` and `EvmTracer::on_reward_granted` methods used in Silkworm `EVM::call` and in Silkrpc respectively
- use `CallResult` as the `result` parameter type in `EvmTracer` hooks

The proposed changes maintain and exposes the registered tracers also in `EVM` because:
- the new hooks (`on_precompiled_run`/`on_reward_granted`) are dispatched within Silkworm/Silkrpc, hence accessing the list of registered tracers is necessary;
- obviously `evmone` already maintains the tracers, but they are accessible only inside `evmone` itself. `evmone::VM` has `get_tracer` method exposing the first tracer, but `evmone::Tracer` does not support `next_tracer` method or similar.