### PR TITLE
Exclude more gRPC tests from sanitizer builds

### DIFF
--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -652,4 +652,25 @@ TEST_CASE("Tracing precompiled contract failure") {
     CHECK(res.status == EVMC_PRECOMPILE_FAILURE);
 }
 
+TEST_CASE("Smart contract creation w/ insufficient balance") {
+    Block block{};
+    block.header.number = 1;
+    evmc::address caller{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
+
+    Bytes code{*from_hex("602a5f556101c960015560048060135f395ff35f355f55")};
+
+    InMemoryState db;
+    IntraBlockState state{db};
+    EVM evm{block, state, test::kShanghaiConfig};
+
+    Transaction txn{};
+    txn.from = caller;
+    txn.data = code;
+    txn.value = intx::uint256{1};
+
+    uint64_t gas = 50'000;
+    CallResult res = evm.execute(txn, gas);
+    CHECK(res.status == EVMC_INSUFFICIENT_BALANCE);
+}
+
 }  // namespace silkworm

--- a/node/silkworm/rpc/client/call_test.cpp
+++ b/node/silkworm/rpc/client/call_test.cpp
@@ -37,7 +37,7 @@ inline std::ostream& null_stream() {
     return null_strm;
 }
 
-// Exclude gRPC tests from sanitizer builds due to data race warnings
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("AsyncCall", "[silkworm][rpc][client][call]") {
     class FakeCall : public AsyncCall {

--- a/node/silkworm/rpc/completion_end_point_test.cpp
+++ b/node/silkworm/rpc/completion_end_point_test.cpp
@@ -31,6 +31,8 @@ namespace silkworm::rpc {
 using Catch::Matchers::Message;
 using namespace std::chrono_literals;
 
+// Exclude gRPC test from sanitizer builds due to data race warnings
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]") {
     silkworm::log::set_verbosity(silkworm::log::Level::kNone);
     grpc::CompletionQueue queue;
@@ -46,8 +48,6 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
         CHECK_NOTHROW(completion_end_point_thread.join());
     }
 
-// Exclude gRPC test from sanitizer builds due to data race warnings
-#ifndef SILKWORM_SANITIZE
     SECTION("executing completion handler") {
         bool executed{false};
         TagProcessor tag_processor = [&completion_end_point, &executed](bool) {
@@ -62,7 +62,6 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
         }
         CHECK(executed);
     }
-#endif // SILKWORM_SANITIZE
 
     SECTION("exiting on completion queue already shutdown") {
         completion_end_point.shutdown();
@@ -104,8 +103,6 @@ TEST_CASE("CompletionEndPoint::post_one", "[silkworm][rpc][completion_end_point]
         CHECK_NOTHROW(completion_runner_thread.join());
     }
 
-// Exclude gRPC test from sanitizer builds due to data race warnings
-#ifndef SILKWORM_SANITIZE
     SECTION("executing completion handler") {
         bool executed{false};
 
@@ -133,7 +130,6 @@ TEST_CASE("CompletionEndPoint::post_one", "[silkworm][rpc][completion_end_point]
         CHECK_NOTHROW(completion_runner_thread.join());
         CHECK(executed);
     }
-#endif // SILKWORM_SANITIZE
 
     SECTION("exiting on completion queue already shutdown") {
         completion_end_point.shutdown();
@@ -158,5 +154,6 @@ TEST_CASE("CompletionEndPoint::post_one", "[silkworm][rpc][completion_end_point]
         CHECK_NOTHROW(completion_end_point.shutdown());
     }
 }
+#endif // SILKWORM_SANITIZE
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/completion_end_point_test.cpp
+++ b/node/silkworm/rpc/completion_end_point_test.cpp
@@ -31,7 +31,7 @@ namespace silkworm::rpc {
 using Catch::Matchers::Message;
 using namespace std::chrono_literals;
 
-// Exclude gRPC test from sanitizer builds due to data race warnings
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]") {
     silkworm::log::set_verbosity(silkworm::log::Level::kNone);

--- a/node/silkworm/rpc/server/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/server/backend_kv_server_test.cpp
@@ -410,7 +410,7 @@ struct BackEndKvE2eTest {
 
 namespace silkworm::rpc {
 
-// Exclude gRPC tests from sanitizer builds due to data race warnings
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("BackEndKvServer", "[silkworm][node][rpc]") {
     silkworm::log::set_verbosity(silkworm::log::Level::kNone);

--- a/node/silkworm/rpc/server/server_config_test.cpp
+++ b/node/silkworm/rpc/server/server_config_test.cpp
@@ -24,7 +24,7 @@
 
 namespace silkworm::rpc {
 
-// Exclude gRPC tests from sanitizer builds due to data race warnings
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerConfig::ServerConfig", "[silkworm][rpc][server_config]") {
     ServerConfig config;

--- a/node/silkworm/rpc/server/server_config_test.cpp
+++ b/node/silkworm/rpc/server/server_config_test.cpp
@@ -24,6 +24,8 @@
 
 namespace silkworm::rpc {
 
+// Exclude gRPC tests from sanitizer builds due to data race warnings
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerConfig::ServerConfig", "[silkworm][rpc][server_config]") {
     ServerConfig config;
     CHECK(config.address_uri() == kDefaultAddressUri);
@@ -53,5 +55,6 @@ TEST_CASE("ServerConfig::set_credentials", "[silkworm][rpc][server_config]") {
     config.set_credentials(server_credentials);
     CHECK(config.credentials() == server_credentials);
 }
+#endif // SILKWORM_SANITIZE
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/server/server_context_pool_test.cpp
+++ b/node/silkworm/rpc/server/server_context_pool_test.cpp
@@ -40,7 +40,7 @@ inline std::ostream& null_stream() {
 
 namespace silkworm::rpc {
 
-// Exclude gRPC tests from sanitizer builds due to data race warnings
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerContext", "[silkworm][rpc][server_context]") {
     grpc::ServerBuilder builder;

--- a/node/silkworm/rpc/server/server_test.cpp
+++ b/node/silkworm/rpc/server/server_test.cpp
@@ -51,7 +51,7 @@ class EmptyServer : public Server {
 // TODO(canepat): better copy grpc_pick_unused_port_or_die to generate unused port
 static const std::string kTestAddressUri{"localhost:12345"};
 
-// Exclude gRPC tests from sanitizer builds due to data race warnings
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("Barebone gRPC Server", "[silkworm][node][rpc]") {
     grpc::ServerBuilder builder;


### PR DESCRIPTION
This PR excludes gRPC tests from ASAN/TSAN builds because even simple test cases containing only gRPC code trigger errors [like this one](https://app.circleci.com/pipelines/github/torquem-ch/silkworm/4562/workflows/2a0687a4-89f4-4ee6-b423-137146d62a96/jobs/15065)