### PR TITLE
Update consensus tests to 10.4

### DIFF
--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -169,6 +169,27 @@ static const std::map<std::string, ChainConfig> kNetworkConfig{
          0,             // muir_glacier_block
      }},
     {"London", test::kLondonConfig},
+    {"Merge",
+     {
+         1,  // chain_id
+         SealEngineType::kNoProof,
+         {
+             0,  // homestead_block
+             0,  // tangerine_whistle_block
+             0,  // spurious_dragon_block
+             0,  // byzantium_block
+             0,  // constantinople_block
+             0,  // petersburg_block
+             0,  // istanbul_block
+             0,  // berlin_block
+             0,  // london_block
+             0,  // FORK_NEXT_VALUE (EIP-3675)
+         },
+         std::nullopt,  // dao_block
+         0,             // muir_glacier_block
+         0,             // arrow_glacier_block
+         0,             // terminal_total_difficulty
+     }},
     {"FrontierToHomesteadAt5",
      {
          1,  // chain_id
@@ -542,7 +563,7 @@ RunResults transaction_test(const nlohmann::json& j) {
     std::optional<Bytes> rlp{from_hex(j["txbytes"].get<std::string>())};
     if (rlp) {
         ByteView view{*rlp};
-        if (rlp::decode(view, txn) == DecodingResult::kOk) {
+        if (rlp::decode_transaction(view, txn, rlp::Eip2718Wrapping::kNone) == DecodingResult::kOk) {
             decoded = view.empty();
         }
     }
@@ -684,7 +705,9 @@ int main(int argc, char* argv[]) {
     std::string evm_path{};
     app.add_option("--evm", evm_path, "Path to EVMC-compliant VM");
     std::string tests_path{SILKWORM_CONSENSUS_TEST_DIR};
-    app.add_option("--tests", tests_path, "Path to consensus tests")->capture_default_str()->check(CLI::ExistingDirectory);
+    app.add_option("--tests", tests_path, "Path to consensus tests")
+        ->capture_default_str()
+        ->check(CLI::ExistingDirectory);
     unsigned num_threads{std::thread::hardware_concurrency()};
     app.add_option("--threads", num_threads, "Number of parallel threads")->capture_default_str();
     bool include_slow_tests{false};

--- a/core/silkworm/common/decoding_result.hpp
+++ b/core/silkworm/common/decoding_result.hpp
@@ -33,6 +33,7 @@ enum class [[nodiscard]] DecodingResult{
     kInvalidVInSignature,         // v != 27 && v != 28 && v < 35, see EIP-155
     kUnsupportedTransactionType,  // EIP-2718
     kInvalidFieldset,
+    kUnexpectedEip2718Serialization,
 };
 
 }  // namespace silkworm

--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -33,7 +33,7 @@ ValidationResult EngineBase::pre_validate_block(const Block& block, const BlockS
     }
 
     static constexpr auto kEncoder = [](Bytes& to, const Transaction& txn) {
-        rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_array=*/false);
+        rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_string=*/false);
     };
 
     evmc::bytes32 txn_root{trie::root_hash(block.transactions, kEncoder)};

--- a/core/silkworm/trie/prefix_set.cpp
+++ b/core/silkworm/trie/prefix_set.cpp
@@ -47,17 +47,16 @@ bool PrefixSet::contains(ByteView prefix) {
         --index_;
     }
 
-    for (;; ++index_) {
+    for (; index_ < keys_.size(); ++index_) {
         if (keys_[index_].starts_with(prefix)) {
             return true;
         }
         if (keys_[index_] > prefix) {
             return false;
         }
-        if (index_ == keys_.size() - 1) {
-            return false;
-        }
     }
+
+    return false;
 }
 
 }  // namespace silkworm::trie

--- a/core/silkworm/trie/prefix_set.cpp
+++ b/core/silkworm/trie/prefix_set.cpp
@@ -47,16 +47,17 @@ bool PrefixSet::contains(ByteView prefix) {
         --index_;
     }
 
-    for (; index_ < keys_.size(); ++index_) {
+    for (;; ++index_) {
         if (keys_[index_].starts_with(prefix)) {
             return true;
         }
         if (keys_[index_] > prefix) {
             return false;
         }
+        if (index_ == keys_.size() - 1) {
+            return false;
+        }
     }
-
-    return false;
 }
 
 }  // namespace silkworm::trie

--- a/core/silkworm/trie/vector_root_test.cpp
+++ b/core/silkworm/trie/vector_root_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ namespace silkworm::trie {
 
 TEST_CASE("Empty root hash") {
     static constexpr auto kEncoder = [](Bytes& to, const Transaction& txn) {
-        rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_array=*/false);
+        rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_string=*/false);
     };
     CHECK(root_hash(std::vector<Transaction>{}, kEncoder) == kEmptyRoot);
 }

--- a/node/silkworm/stagedsync/stage_senders/recovery_farm.cpp
+++ b/node/silkworm/stagedsync/stage_senders/recovery_farm.cpp
@@ -335,7 +335,7 @@ StageResult RecoveryFarm::transform_and_fill_batch(uint64_t block_num, const std
         }
 
         Bytes rlp{};
-        rlp::encode(rlp, transaction, /*for_signing=*/true, /*wrap_eip2718_into_array=*/false);
+        rlp::encode(rlp, transaction, /*for_signing=*/true, /*wrap_eip2718_into_string=*/false);
 
         auto tx_hash{keccak256(rlp)};
         batch_.push_back(RecoveryPackage{block_num, tx_hash, transaction.odd_y_parity});
@@ -480,7 +480,6 @@ StageResult RecoveryFarm::fill_canonical_headers(BlockNum from, BlockNum to) noe
 }
 
 void RecoveryFarm::task_completed_handler(RecoveryWorker* sender) {
-
     std::scoped_lock lck(workers_mtx_);
     harvestable_workers_.push(sender->get_id());
     if (workers_in_flight_) {
@@ -490,7 +489,6 @@ void RecoveryFarm::task_completed_handler(RecoveryWorker* sender) {
 }
 
 void RecoveryFarm::worker_completed_handler(Worker* sender) {
-
     std::scoped_lock lck(workers_mtx_);
     if (workers_in_flight_) {
         workers_in_flight_--;


### PR DESCRIPTION
Update consensus tests to [v10.4](https://github.com/ethereum/tests/releases/tag/v10.4).

Also support decoding of typed transactions not wrapped into an RLP string.