### PR TITLE
Extract transaction_root & ommers_hash algorithms

### DIFF
--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "engine.hpp"
+#include "silkworm/common/cast.hpp"
 
 #include <silkworm/chain/protocol_param.hpp>
 #include <silkworm/common/as_range.hpp>
@@ -32,11 +33,7 @@ ValidationResult EngineBase::pre_validate_block(const Block& block, const BlockS
         return err;
     }
 
-    static constexpr auto kEncoder = [](Bytes& to, const Transaction& txn) {
-        rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_string=*/false);
-    };
-
-    evmc::bytes32 txn_root{trie::root_hash(block.transactions, kEncoder)};
+    evmc::bytes32 txn_root = compute_transaction_root(block);
     if (txn_root != header.transactions_root) {
         return ValidationResult::kWrongTransactionsRoot;
     }
@@ -54,9 +51,7 @@ ValidationResult EngineBase::pre_validate_block(const Block& block, const BlockS
         return ValidationResult::kTooManyOmmers;
     }
 
-    Bytes ommers_rlp;
-    rlp::encode(ommers_rlp, block.ommers);
-    ethash::hash256 ommers_hash{keccak256(ommers_rlp)};
+    evmc::bytes32 ommers_hash = compute_ommers_hash(block);
     if (ByteView{ommers_hash.bytes} != ByteView{header.ommers_hash}) {
         return ValidationResult::kWrongOmmersHash;
     }
@@ -233,6 +228,28 @@ std::optional<intx::uint256> EngineBase::expected_base_fee_per_gas(const BlockHe
             return 0;
         }
     }
+}
+
+evmc::bytes32 EngineBase::compute_transaction_root(const BlockBody& body) {
+    if (body.transactions.empty())
+        return kEmptyRoot;
+
+    static constexpr auto kEncoder = [](Bytes& to, const Transaction& txn) {
+        rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_string=*/false);
+    };
+
+    evmc::bytes32 txn_root{trie::root_hash(body.transactions, kEncoder)};
+
+    return txn_root;
+}
+
+evmc::bytes32 EngineBase::compute_ommers_hash(const BlockBody& body) {
+    if (body.ommers.empty()) {
+        return kEmptyListHash;
+    }
+    Bytes ommers_rlp;
+    rlp::encode(ommers_rlp, body.ommers);
+    return bit_cast<evmc_bytes32>(keccak256(ommers_rlp));
 }
 
 }  // namespace silkworm::consensus

--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -231,8 +231,9 @@ std::optional<intx::uint256> EngineBase::expected_base_fee_per_gas(const BlockHe
 }
 
 evmc::bytes32 EngineBase::compute_transaction_root(const BlockBody& body) {
-    if (body.transactions.empty())
+    if (body.transactions.empty()) {
         return kEmptyRoot;
+    }
 
     static constexpr auto kEncoder = [](Bytes& to, const Transaction& txn) {
         rlp::encode(to, txn, /*for_signing=*/false, /*wrap_eip2718_into_string=*/false);
@@ -247,6 +248,7 @@ evmc::bytes32 EngineBase::compute_ommers_hash(const BlockBody& body) {
     if (body.ommers.empty()) {
         return kEmptyListHash;
     }
+
     Bytes ommers_rlp;
     rlp::encode(ommers_rlp, body.ommers);
     return bit_cast<evmc_bytes32>(keccak256(ommers_rlp));

--- a/core/silkworm/consensus/base/engine.hpp
+++ b/core/silkworm/consensus/base/engine.hpp
@@ -55,6 +55,12 @@ class EngineBase : public IEngine {
     //! \brief Returns parent header (if any) of provided header
     static std::optional<BlockHeader> get_parent_header(const BlockState& state, const BlockHeader& header);
 
+    //! \brief Calculate the transaction root of a block body
+    static evmc::bytes32 compute_transaction_root(const BlockBody& body);
+
+    //! \brief Calculate the hash of ommers of a block body
+    static evmc::bytes32 compute_ommers_hash(const BlockBody& body);
+
   protected:
     const ChainConfig& chain_config_;
     bool prohibit_ommers_{false};

--- a/core/silkworm/consensus/base/engine.hpp
+++ b/core/silkworm/consensus/base/engine.hpp
@@ -56,10 +56,10 @@ class EngineBase : public IEngine {
     static std::optional<BlockHeader> get_parent_header(const BlockState& state, const BlockHeader& header);
 
     //! \brief Calculate the transaction root of a block body
-    virtual evmc::bytes32 compute_transaction_root(const BlockBody& body);
+    static evmc::bytes32 compute_transaction_root(const BlockBody& body);
 
     //! \brief Calculate the hash of ommers of a block body
-    virtual evmc::bytes32 compute_ommers_hash(const BlockBody& body);
+    static evmc::bytes32 compute_ommers_hash(const BlockBody& body);
 
   protected:
     const ChainConfig& chain_config_;

--- a/core/silkworm/consensus/base/engine.hpp
+++ b/core/silkworm/consensus/base/engine.hpp
@@ -56,10 +56,10 @@ class EngineBase : public IEngine {
     static std::optional<BlockHeader> get_parent_header(const BlockState& state, const BlockHeader& header);
 
     //! \brief Calculate the transaction root of a block body
-    static evmc::bytes32 compute_transaction_root(const BlockBody& body);
+    virtual evmc::bytes32 compute_transaction_root(const BlockBody& body);
 
     //! \brief Calculate the hash of ommers of a block body
-    static evmc::bytes32 compute_ommers_hash(const BlockBody& body);
+    virtual evmc::bytes32 compute_ommers_hash(const BlockBody& body);
 
   protected:
     const ChainConfig& chain_config_;


### PR DESCRIPTION
The body downloader needs to compute the transaction root and the hash of ommers.
This PR extracts the relevant code from pre_validate_block() and puts it in common.