### PR TITLE
Wait strategies for RPC server

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -68,126 +68,129 @@ struct BackEndKvSettings {
     silkworm::rpc::ServerConfig server_settings;
 };
 
-//! Parse the command-line arguments into the BackEnd and KV server setttings
-int parse_command_line(int argc, char* argv[], BackEndKvSettings& settings) {
-    CLI::App app{"ETHBACKEND & KV servers"};
-
-    try {
-        auto& log_settings = settings.log_settings;
-        auto& node_settings = settings.node_settings;
-        auto& server_settings = settings.server_settings;
-
-        std::string data_dir{silkworm::DataDirectory::get_default_storage_path().string()};
-        std::string etherbase_address{""};
-        uint32_t num_contexts{std::thread::hardware_concurrency() / 2};
-        uint32_t max_readers{silkworm::db::EnvConfig{}.max_readers};
-        app.add_option("--datadir", data_dir, "The path to data directory")->capture_default_str();
-        app.add_option("--etherbase", etherbase_address, "The chain identifier as string")->capture_default_str();
-        // TODO(canepat) add check on etherbase using EthAddressValidator [TBD]
-        app.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
-        app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
-            ->capture_default_str()
-            ->check(CLI::Range(1, 32767));
-
-        // RPC Server options
-        app.add_option("--private.api.addr", node_settings.private_api_addr,
-                       "Private API network address to serve remote database interface\n"
-                       "An empty string means to not start the listener\n"
-                       "Use the endpoint form i.e. ip-address:port\n"
-                       "DO NOT EXPOSE TO THE INTERNET")
-            ->capture_default_str();
-        // TODO(canepat) add check on private.api.addr using IPEndPointValidator
-        app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
-            ->capture_default_str();
-        // TODO(canepat) add check on sentry_api_addr using IPEndPointValidator
-
-        // Chain options
-        auto& chain_opts = *app.add_option_group("Chain", "Chain selection options");
-        auto chain_name = chain_opts.add_option("--chain", "Name of the network to join (default: \"mainnet\")")
-                              ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
-        chain_opts
-            .add_option("--networkid", node_settings.network_id,
-                        "Explicitly set network id\n"
-                        "For known networks: use --chain <testnet_name> instead")
-            ->capture_default_str()
-            ->excludes(chain_name);
-
-        // Logging options
-        auto& log_opts = *app.add_option_group("Log", "Logging options");
-        log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
-            ->capture_default_str()
-            ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical),
-                               static_cast<uint32_t>(silkworm::log::Level::kTrace)))
-            ->default_val(std::to_string(static_cast<uint32_t>(silkworm::log::Level::kCritical)));
-        log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
-        log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines")
-            ->default_val(std::to_string(true));
-        log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");
-        log_opts.add_flag("--log.threads", log_settings.log_threads, "Prints thread ids")
-            ->default_val(std::to_string(true));
-        log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
-
-        app.parse(argc, argv);
-
-        if (chain_name->count()) {
-            node_settings.network_id = chain_name->as<uint32_t>();
-        }
-        const silkworm::ChainConfig* chain_config = silkworm::lookup_chain_config(node_settings.network_id);
-        if (chain_config == nullptr) {
-            SILK_CRIT << "Unknown chain identifier: " << node_settings.network_id;
-            return -1;
-        }
-        node_settings.chain_config = *chain_config;
-
-        if (!etherbase_address.empty()) {
-            const auto etherbase = silkworm::from_hex(etherbase_address);
-            if (!etherbase) {
-                SILK_CRIT << "Invalid etherbase address: " << etherbase_address;
-                return -1;
-            }
-            node_settings.etherbase = silkworm::to_evmc_address(etherbase.value());
-        }
-
-        node_settings.data_directory = std::make_unique<silkworm::DataDirectory>(data_dir, /*create=*/false);
-        node_settings.chaindata_env_config =
-            silkworm::db::EnvConfig{node_settings.data_directory->chaindata().path().string(),
-                                    /*create=*/false,
-                                    /*readonly=*/true};
-        node_settings.chaindata_env_config.max_readers = max_readers;
-
-        server_settings.set_address_uri(node_settings.private_api_addr);
-        server_settings.set_num_contexts(num_contexts);
-
-        return 0;
-    } catch (const CLI::ParseError& pe) {
-        return app.exit(pe);
-    }
-}
-
-int main(int argc, char* argv[]) {
-    BackEndKvSettings settings;
-    int result_code = parse_command_line(argc, argv, settings);
-    if (result_code != 0) {
-        return result_code;
-    }
-
-    const auto pid = boost::this_process::get_id();
-    const auto tid = std::this_thread::get_id();
-
+//! Parse the command-line arguments into the BackEnd and KV server settings
+int parse_command_line(int argc, char* argv[], CLI::App& app, BackEndKvSettings& settings) {
     auto& log_settings = settings.log_settings;
     auto& node_settings = settings.node_settings;
     auto& server_settings = settings.server_settings;
 
-    // Initialize logging with custom settings
-    silkworm::log::init(log_settings);
+    std::string data_dir{silkworm::DataDirectory::get_default_storage_path().string()};
+    std::string etherbase_address{""};
+    uint32_t num_contexts{std::thread::hardware_concurrency() / 2};
+    silkworm::rpc::WaitMode wait_mode;
+    uint32_t max_readers{silkworm::db::EnvConfig{}.max_readers};
+    app.add_option("--datadir", data_dir, "The path to data directory")->capture_default_str();
+    app.add_option("--etherbase", etherbase_address, "The coinbase address as string")->capture_default_str();
+    // TODO(canepat) add check on etherbase using EthAddressValidator [TBD]
+    app.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
+    app.add_option("--wait.mode", wait_mode, "The waiting mode for execution loops during idle cycles")
+        ->capture_default_str()
+        ->check(CLI::Range(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking),
+                            static_cast<uint32_t>(silkworm::rpc::WaitMode::busy_spin)))
+        ->default_val(std::to_string(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking)));
+    app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
+        ->capture_default_str()
+        ->check(CLI::Range(1, 32767));
 
-    // TODO(canepat): this could be an option in Silkworm logging facility
-    silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
+    // RPC Server options
+    app.add_option("--private.api.addr", node_settings.private_api_addr,
+                    "Private API network address to serve remote database interface\n"
+                    "An empty string means to not start the listener\n"
+                    "Use the endpoint form i.e. ip-address:port\n"
+                    "DO NOT EXPOSE TO THE INTERNET")
+        ->capture_default_str();
+    // TODO(canepat) add check on private.api.addr using IPEndPointValidator
+    app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
+        ->capture_default_str();
+    // TODO(canepat) add check on sentry_api_addr using IPEndPointValidator
 
-    const auto node_name{get_node_name_from_build_info()};
-    SILK_LOG << "BackEndKvServer build info: " << node_name << " " << get_library_versions();
+    // Chain options
+    auto& chain_opts = *app.add_option_group("Chain", "Chain selection options");
+    auto chain_name = chain_opts.add_option("--chain", "Name of the network to join (default: \"mainnet\")")
+                            ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
+    chain_opts
+        .add_option("--networkid", node_settings.network_id,
+                    "Explicitly set network id\n"
+                    "For known networks: use --chain <testnet_name> instead")
+        ->capture_default_str()
+        ->excludes(chain_name);
+
+    // Logging options
+    auto& log_opts = *app.add_option_group("Log", "Logging options");
+    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
+        ->capture_default_str()
+        ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical),
+                            static_cast<uint32_t>(silkworm::log::Level::kTrace)))
+        ->default_val(std::to_string(static_cast<uint32_t>(silkworm::log::Level::kCritical)));
+    log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
+    log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines")
+        ->default_val(std::to_string(true));
+    log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");
+    log_opts.add_flag("--log.threads", log_settings.log_threads, "Prints thread ids")
+        ->default_val(std::to_string(true));
+    log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
+
+    app.parse(argc, argv);
+
+    if (chain_name->count()) {
+        node_settings.network_id = chain_name->as<uint32_t>();
+    }
+    const silkworm::ChainConfig* chain_config = silkworm::lookup_chain_config(node_settings.network_id);
+    if (chain_config == nullptr) {
+        SILK_CRIT << "Unknown chain identifier: " << node_settings.network_id;
+        return -1;
+    }
+    node_settings.chain_config = *chain_config;
+
+    if (!etherbase_address.empty()) {
+        const auto etherbase = silkworm::from_hex(etherbase_address);
+        if (!etherbase) {
+            SILK_CRIT << "Invalid etherbase address: " << etherbase_address;
+            return -1;
+        }
+        node_settings.etherbase = silkworm::to_evmc_address(etherbase.value());
+    }
+
+    node_settings.data_directory = std::make_unique<silkworm::DataDirectory>(data_dir, /*create=*/false);
+    node_settings.chaindata_env_config =
+        silkworm::db::EnvConfig{node_settings.data_directory->chaindata().path().string(),
+                                /*create=*/false,
+                                /*readonly=*/true};
+    node_settings.chaindata_env_config.max_readers = max_readers;
+
+    server_settings.set_address_uri(node_settings.private_api_addr);
+    server_settings.set_num_contexts(num_contexts);
+    server_settings.set_wait_mode(wait_mode);
+
+    return 0;
+}
+
+int main(int argc, char* argv[]) {
+    CLI::App app{"ETHBACKEND & KV server"};
 
     try {
+        BackEndKvSettings settings;
+        int result_code = parse_command_line(argc, argv, app, settings);
+        if (result_code != 0) {
+            return result_code;
+        }
+
+        const auto node_name{get_node_name_from_build_info()};
+        SILK_LOG << "BackEndKvServer build info: " << node_name << " " << get_library_versions();
+
+        const auto pid = boost::this_process::get_id();
+        const auto tid = std::this_thread::get_id();
+
+        auto& log_settings = settings.log_settings;
+        auto& node_settings = settings.node_settings;
+        auto& server_settings = settings.server_settings;
+
+        // Initialize logging with custom settings
+        silkworm::log::init(log_settings);
+
+        // TODO(canepat): this could be an option in Silkworm logging facility
+        silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
+
         SILK_LOG << "BackEndKvServer launched with address: " << server_settings.address_uri()
                  << ", contexts: " << server_settings.num_contexts();
 
@@ -216,6 +219,8 @@ int main(int argc, char* argv[]) {
 
         SILK_LOG << "BackEndKvServer exiting [pid=" << pid << ", main thread=" << tid << "]";
         return 0;
+    } catch (const CLI::ParseError& pe) {
+        return app.exit(pe);
     } catch (const std::exception& e) {
         SILK_CRIT << "BackEndKvServer exiting due to exception: " << e.what();
         return -2;

--- a/node/silkworm/rpc/completion_end_point.cpp
+++ b/node/silkworm/rpc/completion_end_point.cpp
@@ -25,8 +25,8 @@
 
 namespace silkworm::rpc {
 
-int CompletionEndPoint::poll_one() {
-    int num_completed{0}; // returned when next_status == grpc::CompletionQueue::TIMEOUT
+std::size_t CompletionEndPoint::poll_one() {
+    std::size_t num_completed{0};
 
     void* tag{nullptr};
     bool ok{false};
@@ -38,7 +38,8 @@ int CompletionEndPoint::poll_one() {
         SILK_DEBUG << "CompletionEndPoint::poll_one post operation: " << completion_tag.processor;
         (*completion_tag.processor)(completion_tag.ok);
     } else if (next_status == grpc::CompletionQueue::SHUTDOWN) {
-        num_completed = -1;
+        closed_ = true;
+        SILK_DEBUG << "CompletionEndPoint::poll_one shutdown";
     }
 
     return num_completed;

--- a/node/silkworm/rpc/completion_end_point.hpp
+++ b/node/silkworm/rpc/completion_end_point.hpp
@@ -17,6 +17,8 @@
 #ifndef SILKWORM_RPC_COMPLETION_END_POINT_HPP_
 #define SILKWORM_RPC_COMPLETION_END_POINT_HPP_
 
+#include <cstddef>
+
 #include <boost/asio/io_context.hpp>
 #include <grpcpp/grpcpp.h>
 
@@ -30,14 +32,21 @@ class CompletionEndPoint {
     CompletionEndPoint(const CompletionEndPoint&) = delete;
     CompletionEndPoint& operator=(const CompletionEndPoint&) = delete;
 
+    //! Check if the end-point has been shut down or not.
+    bool closed() const { return closed_; }
+
     //! Run at most one execution cycle polling gRPC completion queue for one event.
-    int poll_one();
+    std::size_t poll_one();
 
     //! Post to scheduler at most one execution task polling gRPC completion queue for one event.
     bool post_one(boost::asio::io_context& scheduler);
 
     //! Shutdown and drain the gRPC completion queue.
     void shutdown();
+
+  protected:
+    //! Flag indicating if the end-point has been shut down or not.
+    bool closed_{false};
 
   private:
     //! The gRPC completion queue to read async completion notifications from.

--- a/node/silkworm/rpc/completion_end_point_test.cpp
+++ b/node/silkworm/rpc/completion_end_point_test.cpp
@@ -40,7 +40,8 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
 
     SECTION("waiting on empty completion queue") {
         auto completion_end_point_thread = std::thread([&]() {
-            while (completion_end_point.poll_one() >= 0) {
+            while (!completion_end_point.closed()) {
+                completion_end_point.poll_one();
                 std::this_thread::sleep_for(100us);
             }
         });
@@ -57,7 +58,8 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
         auto alarm_deadline = gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC), gpr_time_from_millis(50, GPR_TIMESPAN));
         grpc::Alarm alarm;
         alarm.Set(&queue, alarm_deadline, &tag_processor);
-        while (completion_end_point.poll_one() >= 0) {
+        while (!completion_end_point.closed()) {
+            completion_end_point.poll_one();
             std::this_thread::sleep_for(100us);
         }
         CHECK(executed);
@@ -66,7 +68,8 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
     SECTION("exiting on completion queue already shutdown") {
         completion_end_point.shutdown();
         auto completion_end_point_thread = std::thread([&]() {
-            while (completion_end_point.poll_one() >= 0) {
+            while (!completion_end_point.closed()) {
+                completion_end_point.poll_one();
                 std::this_thread::sleep_for(100us);
             }
         });
@@ -75,7 +78,8 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
 
     SECTION("stopping again after already stopped") {
         auto completion_end_point_thread = std::thread([&]() {
-            while (completion_end_point.poll_one() >= 0) {
+            while (!completion_end_point.closed()) {
+                completion_end_point.poll_one();
                 std::this_thread::sleep_for(100us);
             }
         });

--- a/node/silkworm/rpc/server/server.hpp
+++ b/node/silkworm/rpc/server/server.hpp
@@ -65,7 +65,7 @@ class Server {
 
         // Add one server-side gRPC completion queue for each execution context.
         for (std::size_t i{0}; i < config_.num_contexts(); ++i) {
-            context_pool_.add_context(builder.AddCompletionQueue());
+            context_pool_.add_context(builder.AddCompletionQueue(), config_.wait_mode());
         }
 
         // gRPC async model requires the server to register one responded call for each RPC in advance.

--- a/node/silkworm/rpc/server/server_config.cpp
+++ b/node/silkworm/rpc/server/server_config.cpp
@@ -21,7 +21,8 @@ namespace silkworm::rpc {
 ServerConfig::ServerConfig(std::shared_ptr<grpc::ServerCredentials> credentials)
     : address_uri_{kDefaultAddressUri},
       credentials_(credentials),
-      num_contexts_{kDefaultNumContexts} {
+      num_contexts_{kDefaultNumContexts},
+      wait_mode_{WaitMode::blocking} {
 }
 
 void ServerConfig::set_address_uri(const std::string& address_uri) noexcept {
@@ -34,6 +35,10 @@ void ServerConfig::set_credentials(std::shared_ptr<grpc::ServerCredentials> cred
 
 void ServerConfig::set_num_contexts(uint32_t num_contexts) noexcept {
     num_contexts_ = num_contexts;
+}
+
+void ServerConfig::set_wait_mode(WaitMode wait_mode) noexcept {
+    wait_mode_ = wait_mode;
 }
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/server/server_config.hpp
+++ b/node/silkworm/rpc/server/server_config.hpp
@@ -23,6 +23,8 @@
 
 #include <grpcpp/grpcpp.h>
 
+#include <silkworm/rpc/server/wait_strategy.hpp>
+
 namespace silkworm::rpc {
 
 constexpr const char* kDefaultAddressUri{"localhost:9090"};
@@ -36,15 +38,20 @@ class ServerConfig {
     void set_address_uri(const std::string& address_uri) noexcept;
     void set_credentials(std::shared_ptr<grpc::ServerCredentials> credentials) noexcept;
     void set_num_contexts(uint32_t num_contexts) noexcept;
+    void set_wait_mode(WaitMode wait_mode) noexcept;
 
     const std::string& address_uri() const noexcept { return address_uri_; }
     std::shared_ptr<grpc::ServerCredentials> credentials() const noexcept { return credentials_; }
     uint32_t num_contexts() const noexcept { return num_contexts_; }
+    WaitMode wait_mode() const noexcept { return wait_mode_; }
 
   private:
     std::string address_uri_;
     std::shared_ptr<grpc::ServerCredentials> credentials_;
     uint32_t num_contexts_;
+
+    //! The waiting mode used by execution loops during idle cycles.
+    WaitMode wait_mode_;
 };
 
 } // namespace silkworm::rpc

--- a/node/silkworm/rpc/server/wait_strategy.cpp
+++ b/node/silkworm/rpc/server/wait_strategy.cpp
@@ -1,0 +1,61 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "wait_strategy.hpp"
+
+#include <utility>
+
+#include <absl/strings/str_cat.h>
+
+namespace silkworm::rpc {
+
+bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* error) {
+    if (text == "blocking") {
+        *wait_mode = WaitMode::blocking;
+        return true;
+    }
+    if (text == "sleeping") {
+        *wait_mode = WaitMode::sleeping;
+        return true;
+    }
+    if (text == "yielding") {
+        *wait_mode = WaitMode::yielding;
+        return true;
+    }
+    if (text == "spin_wait") {
+        *wait_mode = WaitMode::spin_wait;
+        return true;
+    }
+    if (text == "busy_spin") {
+        *wait_mode = WaitMode::busy_spin;
+        return true;
+    }
+    *error = "unknown value for WaitMode";
+    return false;
+}
+
+std::string AbslUnparseFlag(WaitMode wait_mode) {
+    switch (wait_mode) {
+        case WaitMode::blocking: return "blocking";
+        case WaitMode::sleeping: return "sleeping";
+        case WaitMode::yielding: return "yielding";
+        case WaitMode::spin_wait: return "spin_wait";
+        case WaitMode::busy_spin: return "busy_spin";
+        default: return absl::StrCat(wait_mode);
+    }
+}
+
+}  // namespace silkworm::rpc

--- a/node/silkworm/rpc/server/wait_strategy.cpp
+++ b/node/silkworm/rpc/server/wait_strategy.cpp
@@ -35,10 +35,6 @@ bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* err
         *wait_mode = WaitMode::yielding;
         return true;
     }
-    if (text == "spin_wait") {
-        *wait_mode = WaitMode::spin_wait;
-        return true;
-    }
     if (text == "busy_spin") {
         *wait_mode = WaitMode::busy_spin;
         return true;
@@ -52,7 +48,6 @@ std::string AbslUnparseFlag(WaitMode wait_mode) {
         case WaitMode::blocking: return "blocking";
         case WaitMode::sleeping: return "sleeping";
         case WaitMode::yielding: return "yielding";
-        case WaitMode::spin_wait: return "spin_wait";
         case WaitMode::busy_spin: return "busy_spin";
         default: return absl::StrCat(wait_mode);
     }

--- a/node/silkworm/rpc/server/wait_strategy.hpp
+++ b/node/silkworm/rpc/server/wait_strategy.hpp
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Portions of the following code are inspired by Aeron [https://github.com/real-logic/aeron]
+// Portions of the following code are based on Aeron [https://github.com/real-logic/aeron]
 
 /*
  * Copyright 2014-2022 Real Logic Limited.
@@ -32,8 +32,6 @@
  * limitations under the License.
  */
 
-// Portions of the following code are based on Disruptor-cpp [https://github.com/Abc-Arbitrage/Disruptor-cpp]
-
 #ifndef SILKWORM_RPC_SERVER_WAIT_STRATEGY_HPP_
 #define SILKWORM_RPC_SERVER_WAIT_STRATEGY_HPP_
 
@@ -46,8 +44,6 @@
 #include <absl/strings/string_view.h>
 
 namespace silkworm::rpc {
-
-// These wait strategies are experimental for performance tests and not yet production-ready.
 
 using namespace std::chrono_literals; // NOLINT(build/namespaces)
 

--- a/node/silkworm/rpc/server/wait_strategy.hpp
+++ b/node/silkworm/rpc/server/wait_strategy.hpp
@@ -1,0 +1,169 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Portions of the following code are inspired by Aeron [https://github.com/real-logic/aeron]
+
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Portions of the following code are based on Disruptor-cpp [https://github.com/Abc-Arbitrage/Disruptor-cpp]
+
+#ifndef SILKWORM_RPC_SERVER_WAIT_STRATEGY_HPP_
+#define SILKWORM_RPC_SERVER_WAIT_STRATEGY_HPP_
+
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <absl/strings/string_view.h>
+
+namespace silkworm::rpc {
+
+// These wait strategies are experimental for performance tests and not yet production-ready.
+
+class SleepingWaitStrategy {
+  public:
+    inline void idle(int work_count) {
+        if (work_count > 0) {
+            if (counter_ != kRetries) {
+                counter_ = kRetries;
+            }
+            return;
+        }
+
+        if (counter_ > 100) {
+            --counter_;
+        } else if (counter_ > 0) {
+            --counter_;
+            std::this_thread::yield();
+        } else {
+            std::this_thread::sleep_for(duration_);
+        }
+    }
+
+  private:
+    inline static const int kRetries{200};
+
+    int counter_{kRetries};
+    std::chrono::milliseconds duration_{1};
+};
+
+class YieldingWaitStrategy {
+  public:
+    inline void idle(int work_count) {
+        if (work_count > 0) {
+            if (counter_ != kSpinTries) {
+                counter_ = kSpinTries;
+            }
+            return;
+        }
+
+        if (counter_ == 0) {
+            std::this_thread::yield();
+        } else {
+            --counter_;
+        }
+    }
+
+  private:
+    inline static const int kSpinTries{100};
+
+    int counter_{kSpinTries};
+};
+
+class SpinWaitWaitStrategy {
+  public:
+    inline void idle(int work_count) {
+        if (work_count > 0) {
+            if (counter_ != 0) {
+                counter_ = 0;
+            }
+            return;
+        }
+
+        if (counter_ > kYieldThreshold) {
+            auto delta = counter_ - kYieldThreshold;
+            if (delta % kSleep1EveryHowManyTimes == kSleep1EveryHowManyTimes - 1) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            } else if (delta % kSleep0EveryHowManyTimes == kSleep0EveryHowManyTimes - 1) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(0));
+            } else {
+                std::this_thread::yield();
+            }
+        } else {
+            for (auto i{0}; i < (4 << counter_); i++) {
+                spin_wait();
+            }
+        }
+
+        if (counter_ == std::numeric_limits<int32_t>::max()) {
+            counter_ = kYieldThreshold;
+        } else {
+            ++counter_;
+        }
+    }
+
+  private:
+    inline void spin_wait() {
+        asm volatile
+        (
+            "rep\n"
+            "nop"
+        );
+    }
+
+    inline static const int32_t kYieldThreshold{10};
+    inline static const int32_t kSleep0EveryHowManyTimes{5};
+    inline static const int32_t kSleep1EveryHowManyTimes{20};
+
+    int32_t counter_{0};
+};
+
+class BusySpinWaitStrategy {
+  public:
+    inline void idle(int /*work_count*/) {
+    }
+};
+
+enum class WaitMode {
+    blocking,
+    sleeping,
+    yielding,
+    spin_wait,
+    busy_spin
+};
+
+bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* error);
+std::string AbslUnparseFlag(WaitMode wait_mode);
+
+}  // namespace silkworm::rpc
+
+#endif  // SILKWORM_RPC_SERVER_WAIT_STRATEGY_HPP_

--- a/node/silkworm/rpc/server/wait_strategy.hpp
+++ b/node/silkworm/rpc/server/wait_strategy.hpp
@@ -49,102 +49,33 @@ namespace silkworm::rpc {
 
 // These wait strategies are experimental for performance tests and not yet production-ready.
 
+using namespace std::chrono_literals; // NOLINT(build/namespaces)
+
 class SleepingWaitStrategy {
   public:
+    explicit SleepingWaitStrategy(std::chrono::milliseconds duration = 1ms) : duration_(duration) {}
+
     inline void idle(int work_count) {
         if (work_count > 0) {
-            if (counter_ != kRetries) {
-                counter_ = kRetries;
-            }
             return;
         }
 
-        if (counter_ > 100) {
-            --counter_;
-        } else if (counter_ > 0) {
-            --counter_;
-            std::this_thread::yield();
-        } else {
-            std::this_thread::sleep_for(duration_);
-        }
+        std::this_thread::sleep_for(duration_);
     }
 
   private:
-    inline static const int kRetries{200};
-
-    int counter_{kRetries};
-    std::chrono::milliseconds duration_{1};
+    std::chrono::milliseconds duration_;
 };
 
 class YieldingWaitStrategy {
   public:
     inline void idle(int work_count) {
         if (work_count > 0) {
-            if (counter_ != kSpinTries) {
-                counter_ = kSpinTries;
-            }
             return;
         }
 
-        if (counter_ == 0) {
-            std::this_thread::yield();
-        } else {
-            --counter_;
-        }
+        std::this_thread::yield();
     }
-
-  private:
-    inline static const int kSpinTries{100};
-
-    int counter_{kSpinTries};
-};
-
-class SpinWaitWaitStrategy {
-  public:
-    inline void idle(int work_count) {
-        if (work_count > 0) {
-            if (counter_ != 0) {
-                counter_ = 0;
-            }
-            return;
-        }
-
-        if (counter_ > kYieldThreshold) {
-            auto delta = counter_ - kYieldThreshold;
-            if (delta % kSleep1EveryHowManyTimes == kSleep1EveryHowManyTimes - 1) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
-            } else if (delta % kSleep0EveryHowManyTimes == kSleep0EveryHowManyTimes - 1) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(0));
-            } else {
-                std::this_thread::yield();
-            }
-        } else {
-            for (auto i{0}; i < (4 << counter_); i++) {
-                spin_wait();
-            }
-        }
-
-        if (counter_ == std::numeric_limits<int32_t>::max()) {
-            counter_ = kYieldThreshold;
-        } else {
-            ++counter_;
-        }
-    }
-
-  private:
-    inline void spin_wait() {
-        asm volatile
-        (
-            "rep\n"
-            "nop"
-        );
-    }
-
-    inline static const int32_t kYieldThreshold{10};
-    inline static const int32_t kSleep0EveryHowManyTimes{5};
-    inline static const int32_t kSleep1EveryHowManyTimes{20};
-
-    int32_t counter_{0};
 };
 
 class BusySpinWaitStrategy {
@@ -157,7 +88,6 @@ enum class WaitMode {
     blocking,
     sleeping,
     yielding,
-    spin_wait,
     busy_spin
 };
 

--- a/node/silkworm/rpc/server/wait_strategy_test.cpp
+++ b/node/silkworm/rpc/server/wait_strategy_test.cpp
@@ -1,0 +1,119 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "wait_strategy.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <catch2/catch.hpp>
+#include <grpcpp/grpcpp.h>
+
+using namespace std::chrono_literals; // NOLINT(build/namespaces)
+
+namespace silkworm::rpc {
+
+using Catch::Matchers::Message;
+
+TEST_CASE("parse wait mode", "[silkrpc][common][log]") {
+    std::vector<absl::string_view> input_texts{
+        "blocking", "sleeping", "yielding", "spin_wait", "busy_spin"
+    };
+    std::vector<WaitMode> expected_wait_modes{
+        WaitMode::blocking,
+        WaitMode::sleeping,
+        WaitMode::yielding,
+        WaitMode::spin_wait,
+        WaitMode::busy_spin,
+    };
+    for (std::size_t i{0}; i < input_texts.size(); i++) {
+        WaitMode wait_mode;
+        std::string error;
+        const auto success{AbslParseFlag(input_texts[i], &wait_mode, &error)};
+        CHECK(success == true);
+        CHECK(error.empty());
+        CHECK(wait_mode == expected_wait_modes[i]);
+    }
+}
+
+TEST_CASE("parse invalid wait mode", "[silkrpc][common][log]") {
+    WaitMode wait_mode;
+    std::string error;
+    const auto success{AbslParseFlag("abc", &wait_mode, &error)};
+    CHECK(success == false);
+    CHECK(!error.empty());
+}
+
+TEST_CASE("unparse wait mode", "[silkrpc][common][log]") {
+    std::vector<WaitMode> input_wait_modes{
+        WaitMode::blocking,
+        WaitMode::sleeping,
+        WaitMode::yielding,
+        WaitMode::spin_wait,
+        WaitMode::busy_spin,
+    };
+    std::vector<absl::string_view> expected_texts{
+        "blocking", "sleeping", "yielding", "spin_wait", "busy_spin"
+    };
+    for (std::size_t i{0}; i < input_wait_modes.size(); i++) {
+        const auto text{AbslUnparseFlag(input_wait_modes[i])};
+        CHECK(text == expected_texts[i]);
+    }
+}
+
+template<typename W, typename R, typename P>
+inline void sleep_then_check_wait(W& w, const std::chrono::duration<R, P>& t, int executed_count) {
+    std::this_thread::sleep_for(t);
+    CHECK_NOTHROW(w.idle(executed_count));
+}
+
+TEST_CASE("SleepingWaitStrategy", "[silkrpc][context_pool]") {
+    SleepingWaitStrategy wait_strategy;
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+}
+
+TEST_CASE("YieldingWaitStrategy", "[silkrpc][context_pool]") {
+    YieldingWaitStrategy wait_strategy;
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+}
+
+TEST_CASE("SpinWaitWaitStrategy", "[silkrpc][context_pool]") {
+    SpinWaitWaitStrategy wait_strategy;
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+}
+
+TEST_CASE("BusySpinWaitStrategy", "[silkrpc][context_pool]") {
+    BusySpinWaitStrategy wait_strategy;
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 20ms, 0);
+    sleep_then_check_wait(wait_strategy, 10ms, 1);
+}
+
+} // namespace silkworm::rpc

--- a/node/silkworm/rpc/server/wait_strategy_test.cpp
+++ b/node/silkworm/rpc/server/wait_strategy_test.cpp
@@ -34,13 +34,12 @@ using Catch::Matchers::Message;
 
 TEST_CASE("parse wait mode", "[silkrpc][common][log]") {
     std::vector<absl::string_view> input_texts{
-        "blocking", "sleeping", "yielding", "spin_wait", "busy_spin"
+        "blocking", "sleeping", "yielding", "busy_spin"
     };
     std::vector<WaitMode> expected_wait_modes{
         WaitMode::blocking,
         WaitMode::sleeping,
         WaitMode::yielding,
-        WaitMode::spin_wait,
         WaitMode::busy_spin,
     };
     for (std::size_t i{0}; i < input_texts.size(); i++) {
@@ -66,11 +65,10 @@ TEST_CASE("unparse wait mode", "[silkrpc][common][log]") {
         WaitMode::blocking,
         WaitMode::sleeping,
         WaitMode::yielding,
-        WaitMode::spin_wait,
         WaitMode::busy_spin,
     };
     std::vector<absl::string_view> expected_texts{
-        "blocking", "sleeping", "yielding", "spin_wait", "busy_spin"
+        "blocking", "sleeping", "yielding", "busy_spin"
     };
     for (std::size_t i{0}; i < input_wait_modes.size(); i++) {
         const auto text{AbslUnparseFlag(input_wait_modes[i])};
@@ -85,7 +83,7 @@ inline void sleep_then_check_wait(W& w, const std::chrono::duration<R, P>& t, in
 }
 
 TEST_CASE("SleepingWaitStrategy", "[silkrpc][context_pool]") {
-    SleepingWaitStrategy wait_strategy;
+    SleepingWaitStrategy wait_strategy{1ms};
     sleep_then_check_wait(wait_strategy, 10ms, 1);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
@@ -94,14 +92,6 @@ TEST_CASE("SleepingWaitStrategy", "[silkrpc][context_pool]") {
 
 TEST_CASE("YieldingWaitStrategy", "[silkrpc][context_pool]") {
     YieldingWaitStrategy wait_strategy;
-    sleep_then_check_wait(wait_strategy, 10ms, 1);
-    sleep_then_check_wait(wait_strategy, 20ms, 0);
-    sleep_then_check_wait(wait_strategy, 20ms, 0);
-    sleep_then_check_wait(wait_strategy, 10ms, 1);
-}
-
-TEST_CASE("SpinWaitWaitStrategy", "[silkrpc][context_pool]") {
-    SpinWaitWaitStrategy wait_strategy;
     sleep_then_check_wait(wait_strategy, 10ms, 1);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 20ms, 0);


### PR DESCRIPTION
This PR plugs different wait strategies to handle idle cycles in the RPC server execution loop.

Also changes the BackEnd & KV standalone server to avoid logs when printing usage.