### PR TITLE
Reduce body downloader validation expense

### DIFF
--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -55,6 +55,12 @@ ValidationResult EngineBase::pre_validate_block(const Block& block, const BlockS
         return ValidationResult::kWrongOmmersHash;
     }
 
+    return validate_ommers(block, state);
+}
+
+ValidationResult EngineBase::validate_ommers(const Block& block, const BlockState& state) {
+    const BlockHeader& header{block.header};
+
     if (block.ommers.size() > 2) {
         return ValidationResult::kTooManyOmmers;
     }
@@ -63,14 +69,14 @@ ValidationResult EngineBase::pre_validate_block(const Block& block, const BlockS
         return ValidationResult::kDuplicateOmmer;
     }
 
-    std::optional<BlockHeader> parent{get_parent_header(state, header)};
+    std::__1::optional<BlockHeader> parent{get_parent_header(state, header)};
 
     for (const BlockHeader& ommer : block.ommers) {
         if (ValidationResult err{validate_block_header(ommer, state, /*with_future_timestamp_check=*/false)};
             err != ValidationResult::kOk) {
             return ValidationResult::kInvalidOmmerHeader;
         }
-        std::vector<BlockHeader> old_ommers;
+        std::__1::vector<BlockHeader> old_ommers;
         if (!is_kin(ommer, *parent, header.parent_hash, 6, state, old_ommers)) {
             return ValidationResult::kNotAnOmmer;
         }

--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -69,14 +69,14 @@ ValidationResult EngineBase::validate_ommers(const Block& block, const BlockStat
         return ValidationResult::kDuplicateOmmer;
     }
 
-    std::__1::optional<BlockHeader> parent{get_parent_header(state, header)};
+    std::optional<BlockHeader> parent{get_parent_header(state, header)};
 
     for (const BlockHeader& ommer : block.ommers) {
         if (ValidationResult err{validate_block_header(ommer, state, /*with_future_timestamp_check=*/false)};
             err != ValidationResult::kOk) {
             return ValidationResult::kInvalidOmmerHeader;
         }
-        std::__1::vector<BlockHeader> old_ommers;
+        std::vector<BlockHeader> old_ommers;
         if (!is_kin(ommer, *parent, header.parent_hash, 6, state, old_ommers)) {
             return ValidationResult::kNotAnOmmer;
         }

--- a/core/silkworm/consensus/base/engine.hpp
+++ b/core/silkworm/consensus/base/engine.hpp
@@ -42,6 +42,12 @@ class EngineBase : public IEngine {
     ValidationResult validate_block_header(const BlockHeader& header, const BlockState& state,
                                            bool with_future_timestamp_check) override;
 
+    //! \brief Performs validation of block ommers only.
+    //! \brief See [YP] Sections 11.1 "Ommer Validation".
+    //! \param [in] block: block to validate.
+    //! \param [in] state: current state.
+    ValidationResult validate_ommers(const Block& block, const BlockState& state) override;
+
     //! \brief See [YP] Section 11.3 "Reward Application".
     //! \param [in] header: Current block to get beneficiary from
     evmc::address get_beneficiary(const BlockHeader& header) override;

--- a/core/silkworm/consensus/engine.hpp
+++ b/core/silkworm/consensus/engine.hpp
@@ -47,6 +47,12 @@ class IEngine {
     //! \brief Validates the seal of the header
     virtual ValidationResult validate_seal(const BlockHeader& header) = 0;
 
+    //! \brief Performs validation of block ommers only.
+    //! \brief See [YP] Sections 11.1 "Ommer Validation".
+    //! \param [in] block: block to validate.
+    //! \param [in] state: current state.
+    virtual ValidationResult validate_ommers(const Block& block, const BlockState& state) = 0;
+
     //! \brief Finalizes block execution by applying changes in the state of accounts or of the consensus itself
     //! \param [in] state: current state.
     //! \param [in] block: current block to apply rewards for.

--- a/core/silkworm/consensus/merge/engine.cpp
+++ b/core/silkworm/consensus/merge/engine.cpp
@@ -97,4 +97,8 @@ void MergeEngine::finalize(IntraBlockState& state, const Block& block, evmc_revi
 
 evmc::address MergeEngine::get_beneficiary(const BlockHeader& header) { return header.beneficiary; }
 
+ValidationResult MergeEngine::validate_ommers(const Block&, const BlockState&) {
+    return ValidationResult::kOk;
+}
+
 }  // namespace silkworm::consensus

--- a/core/silkworm/consensus/merge/engine.cpp
+++ b/core/silkworm/consensus/merge/engine.cpp
@@ -97,8 +97,12 @@ void MergeEngine::finalize(IntraBlockState& state, const Block& block, evmc_revi
 
 evmc::address MergeEngine::get_beneficiary(const BlockHeader& header) { return header.beneficiary; }
 
-ValidationResult MergeEngine::validate_ommers(const Block&, const BlockState&) {
-    return ValidationResult::kOk;
+ValidationResult MergeEngine::validate_ommers(const Block& block, const BlockState& state) {
+    if (block.header.difficulty != 0) {
+        return ethash_engine_.validate_ommers(block, state);
+    } else {
+        return pos_engine_.validate_ommers(block, state);
+    }
 }
 
 }  // namespace silkworm::consensus

--- a/core/silkworm/consensus/merge/engine.hpp
+++ b/core/silkworm/consensus/merge/engine.hpp
@@ -42,6 +42,8 @@ class MergeEngine : public IEngine {
   private:
     bool terminal_pow_block(const BlockHeader& header, const BlockState& state) const;
 
+    ValidationResult validate_ommers(const Block& block, const BlockState& state) override;
+
     intx::uint256 terminal_total_difficulty_;
     EthashEngine ethash_engine_;
     ProofOfStakeEngine pos_engine_;

--- a/node/silkworm/downloader/internals/body_persistence.cpp
+++ b/node/silkworm/downloader/internals/body_persistence.cpp
@@ -40,7 +40,7 @@ void BodyPersistence::persist(const Block& block) {
     BlockNum block_num = block.header.number;
 
     // todo: ask! (pre_validate_block() is more strong than Erigon does, but it seems more aligned with the yellow paper)
-    auto validation_result = consensus_engine_->pre_validate_block(block, chain_state_);
+    auto validation_result = consensus_engine_->validate_ommers(block, chain_state_);
 
     if (validation_result != ValidationResult::kOk) {
         unwind_needed_ = true;

--- a/node/silkworm/downloader/internals/body_persistence_test.cpp
+++ b/node/silkworm/downloader/internals/body_persistence_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("BodyPersistence - body persistence") {
         block1.header.difficulty = 17'171'480'576;  // a random value
         block1.header.parent_hash = *header0_hash;
         auto header1_hash = block1.header.hash();
-        // block is incomplete, so it is not valid, this is desired here
+        block1.ommers.push_back(BlockHeader{}); // generate error InvalidOmmerHeader
 
         BodyPersistence bp(tx, chain_identity);
 

--- a/node/silkworm/downloader/internals/chain_integration_test.cpp
+++ b/node/silkworm/downloader/internals/chain_integration_test.cpp
@@ -40,6 +40,8 @@ class DummyConsensusEngine : public consensus::IEngine {
   public:
     ValidationResult pre_validate_block(const Block&, const BlockState&) override { return ValidationResult::kOk; }
 
+    ValidationResult validate_ommers(const Block&, const BlockState&) override { return ValidationResult::kOk; }
+
     ValidationResult validate_block_header(const BlockHeader&, const BlockState&, bool) override {
         return ValidationResult::kOk;
     }


### PR DESCRIPTION
Body downloader only need to validate ommers. 
This PR 
- refactors _consensus::EngineBase_ `pre_validate_block()` introducing a `validate_ommers()` method
- in the body downloader replaces the call to `pre_validate_block()` with with `validate_ommers()`

Note that:
- ommers hash is computed elsewere
- for extensibility downloader calls `consensus::engine_factory()` to get a suitable consensus engine
- `consensus::engine_factory() `returns an object derived from _IEngine_ interface

so we had to add `validate_ommers() `to the _IEngine_ interface.

Reviewers knowing the details of the different consensus engine are asked to give a guidance here: is `validate_ommers()` meaningful in all consensus engine? do we need a more branched hierarchy to better state the differences between different consensus engines?

Also consider the position of static methods `compute_transaction_root()` and `compute_ommers_hash()` in _EngineBase_ and get guidance to move them (if needed) to the upper _IEngine_ class as noted [here](https://github.com/torquem-ch/silkworm/pull/677#pullrequestreview-1001476937) 
