### PR TITLE
Add PROJECT_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ HunterGate(
 ]]
 
 project(silkworm)
+set(PROJECT_VERSION 0.1.0-dev)
+
+string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ ${PROJECT_VERSION})
+set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2})
+set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3})
 
 cable_add_buildinfo_library(PROJECT_NAME ${PROJECT_NAME})
 


### PR DESCRIPTION
IMHO the good old [semantic versioning](https://semver.org/) is better than calendar-based versioning for our projects. For example, with the calendar versions in Erigon there's a discrepancy between the "Erigon 2" moniker and the actual versions.