### PR TITLE
A body downloader that exploits the pre-verified hashes

### DIFF
--- a/node/silkworm/downloader/block_exchange.cpp
+++ b/node/silkworm/downloader/block_exchange.cpp
@@ -30,11 +30,12 @@ BlockExchange::BlockExchange(SentryClient& sentry, const Db::ReadOnlyAccess& dba
     : db_access_{dba},
       sentry_{sentry},
       chain_identity_{ci},
+      preverified_hashes_{PreverifiedHashes::load(ci.chain.chain_id)},
       header_chain_{ci},
       body_sequence_{dba, ci} {
     auto tx = db_access_.start_ro_tx();
     header_chain_.recover_initial_state(tx);
-    header_chain_.set_preverified_hashes(PreverifiedHashes::load(ci.chain.chain_id));
+    header_chain_.set_preverified_hashes(&preverified_hashes_);
 }
 
 BlockExchange::~BlockExchange() {
@@ -42,9 +43,8 @@ BlockExchange::~BlockExchange() {
     log::Info() << "BlockExchange destroyed";
 }
 
-const ChainIdentity& BlockExchange::chain_identity() {
-    return chain_identity_;
-}
+const ChainIdentity& BlockExchange::chain_identity() const { return chain_identity_; }
+const PreverifiedHashes& BlockExchange::preverified_hashes() const { return preverified_hashes_; }
 
 void BlockExchange::accept(std::shared_ptr<Message> message) { messages_.push(message); }
 

--- a/node/silkworm/downloader/block_exchange.hpp
+++ b/node/silkworm/downloader/block_exchange.hpp
@@ -37,8 +37,8 @@ class BlockExchange : public ActiveComponent {
     void accept(std::shared_ptr<Message>); /*[[thread_safe]]*/
     void execution_loop() override;        /*[[long_running]]*/
 
-    const ChainIdentity& chain_identity();
-
+    const ChainIdentity& chain_identity() const;
+    const PreverifiedHashes& preverified_hashes() const;
   private:
     using MessageQueue = ConcurrentQueue<std::shared_ptr<Message>>;  // used internally to store new messages
 
@@ -48,6 +48,7 @@ class BlockExchange : public ActiveComponent {
     Db::ReadOnlyAccess db_access_;
     SentryClient& sentry_;
     const ChainIdentity& chain_identity_;
+    PreverifiedHashes preverified_hashes_;
     HeaderChain header_chain_;
     BodySequence body_sequence_;
     MessageQueue messages_{};  // thread safe queue where to receive messages from sentry

--- a/node/silkworm/downloader/internals/body_persistence.hpp
+++ b/node/silkworm/downloader/internals/body_persistence.hpp
@@ -43,6 +43,7 @@ class BodyPersistence {
     BlockNum highest_height() const;
     Hash bad_block() const;
 
+    void set_preverified_height(BlockNum height);
   private:
     using ConsensusEnginePtr = std::unique_ptr<consensus::IEngine>;
 
@@ -52,6 +53,8 @@ class BodyPersistence {
 
     BlockNum initial_height_{0};
     BlockNum highest_height_{0};
+
+    BlockNum preverified_height_{0};
 
     BlockNum unwind_point_{0};
     bool unwind_needed_{false};

--- a/node/silkworm/downloader/internals/header_chain.hpp
+++ b/node/silkworm/downloader/internals/header_chain.hpp
@@ -104,7 +104,7 @@ class HeaderChain {
     bool has_link(Hash hash);
     std::vector<Announce>& announces_to_do();
     void add_bad_headers(const std::set<Hash>& bads);
-    void set_preverified_hashes(PreverifiedHashes);
+    void set_preverified_hashes(const PreverifiedHashes*);
 
   protected:
     static constexpr BlockNum max_len = 192;
@@ -155,7 +155,7 @@ class HeaderChain {
     BlockNum highest_in_db_;
     BlockNum top_seen_height_;
     std::set<Hash> bad_headers_;
-    PreverifiedHashes preverified_hashes_;      // Set of hashes that are known to belong to canonical chain
+    const PreverifiedHashes* preverified_hashes_; // Set of hashes that are known to belong to canonical chain
     using Ignore = int;
     lru_cache<Hash, Ignore> seen_announces_;
     std::vector<Announce> announces_to_do_;

--- a/node/silkworm/downloader/internals/header_chain_test.cpp
+++ b/node/silkworm/downloader/internals/header_chain_test.cpp
@@ -880,7 +880,7 @@ TEST_CASE("HeaderChain - process_segment - (4) pre-verified hashes on canonical 
         headers[9].number                        // height
     };
 
-    chain.set_preverified_hashes(std::move(mynet_preverified_hashes));
+    chain.set_preverified_hashes(&mynet_preverified_hashes);
 
     // building the first part of the chain
     chain.accept_headers({headers[1], headers[2], headers[3], h3a, h4a}, request_id, peer_id);
@@ -938,7 +938,7 @@ TEST_CASE("HeaderChain - process_segment - (5) pre-verified hashes") {
         headers[6].number     // height
     };
 
-    chain.set_preverified_hashes(mynet_preverified_hashes);
+    chain.set_preverified_hashes(&mynet_preverified_hashes);
 
     // building the first chain segment
     chain.accept_headers({headers[1]}, request_id, peer_id);
@@ -1022,7 +1022,7 @@ TEST_CASE("HeaderChain - process_segment - (5') pre-verified hashes with canonic
         b_headers[6].number     // height
     };
 
-    chain.set_preverified_hashes(mynet_preverified_hashes);
+    chain.set_preverified_hashes(&mynet_preverified_hashes);
 
     // building the first branch of the chain
     chain.accept_headers({a_headers[1], a_headers[2], a_headers[3], a_headers[4], a_headers[5]}, request_id, peer_id);

--- a/node/silkworm/downloader/internals/preverified_hashes.cpp
+++ b/node/silkworm/downloader/internals/preverified_hashes.cpp
@@ -22,6 +22,8 @@ extern uint64_t preverified_hashes_mainnet_height();
 
 namespace silkworm {
 
+PreverifiedHashes PreverifiedHashes::none = {};
+
 void load_preverified_hashes(PreverifiedHashes& destination, const uint64_t* (*preverified_hashes_data)(),
                              size_t (*sizeof_preverified_hashes_data)(), uint64_t (*preverified_hashes_height)()) {
     auto data_size = sizeof_preverified_hashes_data();

--- a/node/silkworm/downloader/internals/preverified_hashes.hpp
+++ b/node/silkworm/downloader/internals/preverified_hashes.hpp
@@ -49,6 +49,7 @@ struct PreverifiedHashes {
     [[nodiscard]] bool contains(const evmc::bytes32& hash) const { return hashes.find(hash) != hashes.end(); }
 
     static PreverifiedHashes load(uint64_t chain_id); // Load a set of pre-verified hashes from low level impl
+    static PreverifiedHashes none;
 };
 
 }  // namespace silkworm

--- a/node/silkworm/downloader/stage_bodies.cpp
+++ b/node/silkworm/downloader/stage_bodies.cpp
@@ -122,6 +122,7 @@ Stage::Result BodiesStage::forward([[maybe_unused]] bool first_sync) {
         Db::ReadWriteAccess::Tx tx = db_access_.start_tx();  // start a new tx only if db_access has not an active tx
 
         BodyPersistence body_persistence(tx, block_downloader_.chain_identity());
+        body_persistence.set_preverified_height(block_downloader_.preverified_hashes().height);
 
         RepeatedMeasure<BlockNum> height_progress(body_persistence.initial_height());
         log::Info() << "[2/16 Bodies] Waiting for bodies... from=" << height_progress.get();


### PR DESCRIPTION
This PR modifies the downloader so that it skips validation of ommers of bodies whose height is below the pre-verified hashes maximum height.
The downloader only check that ommers hash and transaction root hash of each body are the same of the correspondent header (really it is the contrary: a body is accepted if and only if the two hashes matches the hashes in the header).

