### PR TITLE
Sentry command with an empty GRPC service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ add_subdirectory(core)
 if(NOT SILKWORM_CORE_ONLY)
   add_subdirectory(interfaces)
   add_subdirectory(node)
+  add_subdirectory(sentry)
 endif()
 
 if(NOT SILKWORM_HAS_PARENT)

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -81,6 +81,9 @@ if(NOT SILKWORM_CORE_ONLY)
   add_executable(downloader downloader.cpp common.cpp)
   target_link_libraries(downloader PRIVATE silkworm_node silkworm-buildinfo CLI11::CLI11)
 
+  add_executable(sentry sentry.cpp common.cpp)
+  target_link_libraries(sentry PRIVATE silkworm_node silkworm_sentry CLI11::CLI11)
+
   add_executable(backend_kv_server backend_kv_server.cpp common.cpp)
   target_link_libraries(backend_kv_server PRIVATE silkworm_node silkworm-buildinfo CLI11::CLI11)
 endif()

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -81,6 +81,6 @@ if(NOT SILKWORM_CORE_ONLY)
   add_executable(downloader downloader.cpp common.cpp)
   target_link_libraries(downloader PRIVATE silkworm_node silkworm-buildinfo CLI11::CLI11)
 
-  add_executable(backend_kv_server backend_kv_server.cpp)
+  add_executable(backend_kv_server backend_kv_server.cpp common.cpp)
   target_link_libraries(backend_kv_server PRIVATE silkworm_node silkworm-buildinfo CLI11::CLI11)
 endif()

--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -31,6 +31,7 @@
 #include <silkworm/common/settings.hpp>
 #include <silkworm/rpc/server/backend_kv_server.hpp>
 #include <silkworm/rpc/util.hpp>
+#include "common.hpp"
 
 //! Assemble the full node name using the Cable build information
 std::string get_node_name_from_build_info() {
@@ -115,20 +116,7 @@ int parse_command_line(int argc, char* argv[], CLI::App& app, BackEndKvSettings&
         ->capture_default_str()
         ->excludes(chain_name);
 
-    // Logging options
-    auto& log_opts = *app.add_option_group("Log", "Logging options");
-    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
-        ->capture_default_str()
-        ->check(CLI::Range(static_cast<uint32_t>(silkworm::log::Level::kCritical),
-                            static_cast<uint32_t>(silkworm::log::Level::kTrace)))
-        ->default_val(std::to_string(static_cast<uint32_t>(silkworm::log::Level::kCritical)));
-    log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
-    log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines")
-        ->default_val(std::to_string(true));
-    log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");
-    log_opts.add_flag("--log.threads", log_settings.log_threads, "Prints thread ids")
-        ->default_val(std::to_string(true));
-    log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
+    silkworm::cmd::add_logging_options(app, log_settings);
 
     app.parse(argc, argv);
 

--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -78,17 +78,13 @@ int parse_command_line(int argc, char* argv[], CLI::App& app, BackEndKvSettings&
     std::string data_dir{silkworm::DataDirectory::get_default_storage_path().string()};
     std::string etherbase_address{""};
     uint32_t num_contexts{std::thread::hardware_concurrency() / 2};
-    silkworm::rpc::WaitMode wait_mode;
+    silkworm::rpc::WaitMode wait_mode{silkworm::rpc::WaitMode::blocking};
     uint32_t max_readers{silkworm::db::EnvConfig{}.max_readers};
     app.add_option("--datadir", data_dir, "The path to data directory")->capture_default_str();
     app.add_option("--etherbase", etherbase_address, "The coinbase address as string")->capture_default_str();
     // TODO(canepat) add check on etherbase using EthAddressValidator [TBD]
-    app.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
-    app.add_option("--wait.mode", wait_mode, "The waiting mode for execution loops during idle cycles")
-        ->capture_default_str()
-        ->check(CLI::Range(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking),
-                            static_cast<uint32_t>(silkworm::rpc::WaitMode::busy_spin)))
-        ->default_val(std::to_string(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking)));
+    silkworm::cmd::add_option_num_contexts(app, num_contexts);
+    silkworm::cmd::add_option_wait_mode(app, wait_mode);
     app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
         ->capture_default_str()
         ->check(CLI::Range(1, 32767));

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -60,8 +60,8 @@ struct PruneModeValidator : public CLI::Validator {
     }
 };
 
-struct IPEndPointValidator : public CLI::Validator {
-    explicit IPEndPointValidator(bool allow_empty = false) {
+IPEndPointValidator::IPEndPointValidator(bool allow_empty) {
+    {
         func_ = [&allow_empty](const std::string& value) -> std::string {
             if (value.empty() && allow_empty) {
                 return {};
@@ -89,7 +89,7 @@ struct IPEndPointValidator : public CLI::Validator {
             return {};
         };
     }
-};
+}
 
 void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Settings& log_settings,
                                  NodeSettings& node_settings) {

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -91,6 +91,19 @@ IPEndPointValidator::IPEndPointValidator(bool allow_empty) {
     }
 }
 
+void add_logging_options(CLI::App& cli, log::Settings& log_settings) {
+    auto& log_opts = *cli.add_option_group("Log", "Logging options");
+    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
+        ->capture_default_str()
+        ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)))
+        ->default_val(std::to_string(static_cast<uint32_t>(log_settings.log_verbosity)));
+    log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
+    log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines");
+    log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");
+    log_opts.add_flag("--log.threads", log_settings.log_threads, "Prints thread ids");
+    log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
+}
+
 void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Settings& log_settings,
                                  NodeSettings& node_settings) {
     // Node settings
@@ -190,17 +203,7 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     prune_opts.add_option("--prune.c.before", "Prune call traces data before this block")
         ->check(CLI::Range(0u, UINT32_MAX));
 
-    // Logging options
-    auto& log_opts = *cli.add_option_group("Log", "Logging options");
-    log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
-        ->capture_default_str()
-        ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)))
-        ->default_val(std::to_string(static_cast<uint32_t>(log_settings.log_verbosity)));
-    log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
-    log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines");
-    log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");
-    log_opts.add_flag("--log.threads", log_settings.log_threads, "Prints thread ids");
-    log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
+    add_logging_options(cli, log_settings);
 
     cli.parse(argc, argv);
 

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -104,6 +104,18 @@ void add_logging_options(CLI::App& cli, log::Settings& log_settings) {
     log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
 }
 
+void add_option_num_contexts(CLI::App& cli, uint32_t& num_contexts) {
+    cli.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
+}
+
+void add_option_wait_mode(CLI::App& cli, silkworm::rpc::WaitMode& wait_mode) {
+    cli.add_option("--wait.mode", wait_mode, "The waiting mode for execution loops during idle cycles")
+        ->capture_default_str()
+        ->check(CLI::Range(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking),
+                           static_cast<uint32_t>(silkworm::rpc::WaitMode::busy_spin)))
+        ->default_val(std::to_string(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking)));
+}
+
 void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Settings& log_settings,
                                  NodeSettings& node_settings) {
     // Node settings

--- a/cmd/common.hpp
+++ b/cmd/common.hpp
@@ -21,6 +21,7 @@
 #include <CLI/CLI.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/settings.hpp>
+#include <silkworm/rpc/server/wait_strategy.hpp>
 
 namespace silkworm::cmd {
 
@@ -38,6 +39,12 @@ struct IPEndPointValidator : public CLI::Validator {
 
 //! \brief Sets up logging options to populate log_settings after cli.parse()
 void add_logging_options(CLI::App& cli, log::Settings& log_settings);
+
+//! \brief Sets up parsing of num_contexts
+void add_option_num_contexts(CLI::App& cli, uint32_t& num_contexts);
+
+//! \brief Sets up parsing of wait_mode
+void add_option_wait_mode(CLI::App& cli, silkworm::rpc::WaitMode& wait_mode);
 
 } // namespace silkworm::cmd
 #endif  // SILKWORM_CMD_COMMON_HPP_

--- a/cmd/common.hpp
+++ b/cmd/common.hpp
@@ -32,6 +32,9 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
 //! \brief Ensures database is ready for take off and consistent with command line arguments
 void run_preflight_checklist(NodeSettings& node_settings);
 
+struct IPEndPointValidator : public CLI::Validator {
+    explicit IPEndPointValidator(bool allow_empty = false);
+};
 
 } // namespace silkworm::cmd
 #endif  // SILKWORM_CMD_COMMON_HPP_

--- a/cmd/common.hpp
+++ b/cmd/common.hpp
@@ -36,5 +36,8 @@ struct IPEndPointValidator : public CLI::Validator {
     explicit IPEndPointValidator(bool allow_empty = false);
 };
 
+//! \brief Sets up logging options to populate log_settings after cli.parse()
+void add_logging_options(CLI::App& cli, log::Settings& log_settings);
+
 } // namespace silkworm::cmd
 #endif  // SILKWORM_CMD_COMMON_HPP_

--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -1,0 +1,84 @@
+/*
+Copyright 2021-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <CLI/CLI.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/process/environment.hpp>
+#include <sentry/options.hpp>
+#include <sentry/server.hpp>
+
+#include <silkworm/rpc/util.hpp>
+
+#include "common.hpp"
+
+using namespace silkworm;
+using namespace silkworm::cmd;
+using namespace silkworm::sentry;
+
+int sentry_main(int argc, char* argv[]) {
+    CLI::App cli{"Sentry - P2P proxy"};
+
+    log::Settings log_settings;
+    add_logging_options(cli, log_settings);
+
+    Options options;
+    cli.add_option("--sentry.api.addr", options.api_address, "GRPC API endpoint")
+        ->capture_default_str()
+        ->check(IPEndPointValidator(/*allow_empty=*/true));
+    add_option_num_contexts(cli, options.num_contexts);
+    add_option_wait_mode(cli, options.wait_mode);
+
+    try {
+        cli.parse(argc, argv);
+    } catch (const CLI::ParseError& pe) {
+        return cli.exit(pe);
+    }
+
+    log::init(log_settings);
+    log::set_thread_name("main");
+    // TODO(canepat): this could be an option in Silkworm logging facility
+    silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
+
+    Server server{options};
+    server.build_and_start();
+
+    boost::asio::signal_set signals{server.next_io_context(), SIGINT, SIGTERM};
+    signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
+        log::Info() << "\n";
+        log::Info() << "Signal caught, error: " << error << " number: " << signal_number;
+        server.shutdown();
+    });
+
+    const auto pid = boost::this_process::get_id();
+    const auto tid = std::this_thread::get_id();
+    log::Info() << "Sentry is now running [pid=" << pid << ", main thread=" << tid << "]";
+    server.join();
+
+    log::Info() << "Sentry exiting [pid=" << pid << ", main thread=" << tid << "]";
+    return 0;
+}
+
+int main(int argc, char* argv[]) {
+    try {
+        return sentry_main(argc, argv);
+    } catch (const std::exception& e) {
+        log::Critical() << "Sentry exiting due to exception: " << e.what();
+        return -2;
+    } catch (...) {
+        log::Critical() << "Sentry exiting due to unexpected exception";
+        return -3;
+    }
+}

--- a/node/silkworm/rpc/server/server.hpp
+++ b/node/silkworm/rpc/server/server.hpp
@@ -141,7 +141,7 @@ class Server {
 
   private:
     //! The server configuration options.
-    const ServerConfig& config_;
+    ServerConfig config_;
 
     //! The gRPC server instance tied to this Server lifetime.
     std::unique_ptr<grpc::Server> server_;

--- a/sentry/CMakeLists.txt
+++ b/sentry/CMakeLists.txt
@@ -1,0 +1,65 @@
+#[[
+   Copyright 2020-2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+set(TARGET silkworm_sentry)
+
+find_package(absl CONFIG REQUIRED)
+find_package(Boost CONFIG REQUIRED thread)
+find_package(gRPC CONFIG REQUIRED)
+
+get_filename_component(MAIN_DIR ../ ABSOLUTE)
+
+set(SRC "")
+file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp" "*.c" "*.h" "*.cc")
+list(FILTER SRC EXCLUDE REGEX "_test\\.cpp$")
+
+set(GRPC_SRC "")
+set(GRPC_SRC_DIR "${MAIN_DIR}/interfaces/p2psentry")
+file(GLOB GRPC_SRC CONFIGURE_DEPENDS "${GRPC_SRC_DIR}/*.h" "${GRPC_SRC_DIR}/*.cc")
+list(PREPEND SRC ${GRPC_SRC})
+
+add_library(${TARGET} ${SRC})
+
+add_dependencies(silkworm_node generate_sentry_grpc)
+
+set_source_files_properties(${GRPC_SRC} PROPERTIES GENERATED TRUE)
+if(NOT MSVC)
+  set_source_files_properties(${GRPC_SRC} PROPERTIES COMPILE_FLAGS -Wno-sign-conversion)
+endif(NOT MSVC)
+
+# Suppress ASAN/TSAN in gRPC to avoid ODR violation when building Silkworm with sanitizers
+# See https://github.com/grpc/grpc/issues/19224
+if(SILKWORM_SANITIZE)
+    target_compile_definitions(${TARGET} PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
+endif()
+
+target_include_directories(${TARGET} PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  "${MAIN_DIR}/interfaces"
+)
+
+set(LIBS "")
+list(APPEND LIBS Boost::thread)
+list(APPEND LIBS protobuf::libprotobuf)
+list(APPEND LIBS gRPC::grpc++)
+list(APPEND LIBS silkworm_core)
+list(APPEND LIBS silkworm_node)
+
+if(MSVC)
+  list(APPEND LIBS ntdll.lib)
+endif(MSVC)
+
+target_link_libraries(${TARGET} PRIVATE ${LIBS})

--- a/sentry/sentry/options.cpp
+++ b/sentry/sentry/options.cpp
@@ -1,0 +1,26 @@
+/*
+Copyright 2020-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "options.hpp"
+#include <thread>
+
+namespace silkworm::sentry {
+
+Options::Options() {
+    num_contexts = std::thread::hardware_concurrency() / 2;
+}
+
+}  // namespace silkworm::sentry

--- a/sentry/sentry/options.hpp
+++ b/sentry/sentry/options.hpp
@@ -1,0 +1,35 @@
+/*
+Copyright 2020-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <silkworm/rpc/server/wait_strategy.hpp>
+
+namespace silkworm::sentry {
+
+struct Options {
+    std::string api_address{"127.0.0.1:9091"};
+
+    // initialized in the constructor based on hardware_concurrency
+    uint32_t num_contexts{0};
+
+    silkworm::rpc::WaitMode wait_mode{silkworm::rpc::WaitMode::blocking};
+
+    Options();
+};
+
+}  // namespace silkworm::sentry

--- a/sentry/sentry/server.cpp
+++ b/sentry/sentry/server.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright 2020-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "server.hpp"
+#include <silkworm/common/log.hpp>
+#include <silkworm/rpc/server/server_config.hpp>
+
+namespace silkworm::sentry {
+
+using namespace silkworm::log;
+
+static silkworm::rpc::ServerConfig make_server_config(const Options& options) {
+    silkworm::rpc::ServerConfig config;
+    config.set_address_uri(options.api_address);
+    config.set_num_contexts(options.num_contexts);
+    config.set_wait_mode(options.wait_mode);
+    return config;
+}
+
+Server::Server(const Options& options)
+    : silkworm::rpc::Server(make_server_config(options))
+{
+    std::size_t num_contexts = options.num_contexts;
+    for (std::size_t i = 0; i < num_contexts; i++) {
+        services_.push_back(std::make_unique<Service>());
+    }
+    log::Info() << "Server created"
+        << " listening on: " << options.api_address << ";"
+        << " contexts: " << num_contexts;
+}
+
+// Register the gRPC services: they must exist for the lifetime of the server built by builder.
+void Server::register_async_services(grpc::ServerBuilder& builder) {
+    builder.RegisterService(&async_service_);
+}
+
+/// Start server-side RPC requests as required by gRPC async model: one RPC per type is requested in advance.
+void Server::register_request_calls() {
+    for (auto& service : services_) {
+        const auto& context = next_context();
+        const auto io_context = context.io_context();
+        const auto server_queue = context.server_queue();
+        service->register_request_calls(*io_context, &async_service_, server_queue);
+    }
+}
+
+}  // namespace silkworm::sentry

--- a/sentry/sentry/server.hpp
+++ b/sentry/sentry/server.hpp
@@ -1,0 +1,39 @@
+/*
+Copyright 2020-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <p2psentry/sentry.grpc.pb.h>
+#include <silkworm/rpc/server/server.hpp>
+#include "options.hpp"
+#include "service.hpp"
+
+namespace silkworm::sentry {
+
+class Server final : public silkworm::rpc::Server {
+  public:
+    explicit Server(const Options& options);
+
+  private:
+    void register_async_services(grpc::ServerBuilder& builder) override;
+    void register_request_calls() override;
+
+    ::sentry::Sentry::AsyncService async_service_;
+
+    std::vector<std::unique_ptr<Service>> services_;
+};
+
+}  // namespace silkworm::sentry

--- a/sentry/sentry/service.cpp
+++ b/sentry/sentry/service.cpp
@@ -1,0 +1,30 @@
+/*
+Copyright 2020-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "service.hpp"
+
+namespace silkworm::sentry {
+
+// Register one requested call for each RPC factory
+void Service::register_request_calls(
+    boost::asio::io_context& /*scheduler*/,
+    ::sentry::Sentry::AsyncService* /*async_service*/,
+    grpc::ServerCompletionQueue* /*queue*/
+) {
+    // TODO
+}
+
+}  // namespace silkworm::sentry

--- a/sentry/sentry/service.hpp
+++ b/sentry/sentry/service.hpp
@@ -1,0 +1,33 @@
+/*
+Copyright 2020-2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+#include <grpcpp/grpcpp.h>
+#include <p2psentry/sentry.grpc.pb.h>
+
+namespace silkworm::sentry {
+
+class Service final {
+  public:
+    void register_request_calls(
+        boost::asio::io_context& scheduler,
+        ::sentry::Sentry::AsyncService* async_service,
+        grpc::ServerCompletionQueue* queue);
+};
+
+}  // namespace silkworm::sentry


### PR DESCRIPTION
* a separate folder/target for sentry builds a silkworm_sentry library (similar to silkworm_node)
* a new sentry.cpp command links with silkworm_sentry
* sentry GRPC Server is based on the silkworm::rpc::Server (similar to KV server) and a blank stub for the Service
* refactorings in common.cpp to be able to use some common CLI args setup logic
