### PR TITLE
A body downloader that penalizes peers on malformed messages

### DIFF
--- a/node/silkworm/downloader/block_exchange.cpp
+++ b/node/silkworm/downloader/block_exchange.cpp
@@ -126,10 +126,10 @@ void BlockExchange::log_status() {
 }
 
 void BlockExchange::send_penalization(PeerId id, Penalty p) noexcept {
-    using namespace std::chrono_literals;
     rpc::PenalizePeer penalize_peer(id, p);
     penalize_peer.do_not_throw_on_failure();
-    penalize_peer.timeout(1s);
+    penalize_peer.timeout(kRpcTimeout);
+
     sentry_.exec_remotely(penalize_peer);
 }
 

--- a/node/silkworm/downloader/block_exchange.hpp
+++ b/node/silkworm/downloader/block_exchange.hpp
@@ -43,6 +43,7 @@ class BlockExchange : public ActiveComponent {
     using MessageQueue = ConcurrentQueue<std::shared_ptr<Message>>;  // used internally to store new messages
 
     void receive_message(const sentry::InboundMessage& raw_message);
+    void send_penalization(PeerId id, Penalty p) noexcept;
     void log_status();
 
     Db::ReadOnlyAccess db_access_;

--- a/node/silkworm/downloader/block_exchange.hpp
+++ b/node/silkworm/downloader/block_exchange.hpp
@@ -46,6 +46,8 @@ class BlockExchange : public ActiveComponent {
     void send_penalization(PeerId id, Penalty p) noexcept;
     void log_status();
 
+    static constexpr seconds_t kRpcTimeout = std::chrono::seconds(1);
+    
     Db::ReadOnlyAccess db_access_;
     SentryClient& sentry_;
     const ChainIdentity& chain_identity_;

--- a/node/silkworm/downloader/internals/body_sequence.cpp
+++ b/node/silkworm/downloader/internals/body_sequence.cpp
@@ -101,7 +101,8 @@ Penalty BodySequence::accept_requested_bodies(BlockBodiesPacket66& packet, const
             exact_request = body_requests_.find_by_hash(oh, tr);
 
             if (exact_request == body_requests_.end()) {
-                penalty = BadBlockPenalty;
+                //penalty = BadBlockPenalty; // Erigon doesn't penalize the peer maybe because can be a late response but
+                // todo: here we are sure it is not a late response, should we penalize the peer?
                 SILK_TRACE << "BodySequence: body rejected, no matching requests";
                 statistics_.reject_causes.not_requested += 1;
                 continue;
@@ -178,12 +179,12 @@ auto BodySequence::renew_stale_requests(GetBlockBodiesPacket66& packet, BlockNum
         if (past_request.ready || tp - past_request.request_time < timeout)
             continue;
 
-        // retry body request, todo: Erigon delete the request here, but will it retry?
         packet.request.push_back(past_request.block_hash);
         past_request.request_time = tp;
         past_request.request_id = packet.requestId;
-        // todo: Erigon increment a penalization counter for the peer but it doesn't use it
-        //penalizations.emplace_back({Penalty::BadBlockPenalty, }); // todo: find/create a more precise penalization
+
+        // Erigon increment a penalization counter for the peer, but it doesn't use it
+        //penalizations.emplace_back({Penalty::BadBlockPenalty, });
 
         SILK_TRACE << "BodySequence: renewed request block num= " << past_request.block_height
                    << ", hash= " << past_request.block_hash;

--- a/node/silkworm/downloader/internals/body_sequence_test.cpp
+++ b/node/silkworm/downloader/internals/body_sequence_test.cpp
@@ -221,7 +221,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
         response_packet.requestId = packet.requestId; // correct request-id
         response_packet.request.push_back(block1tampered); // wrong body
 
-        auto penalty = bs.accept_requested_bodies(response_packet, peer_id);
+        [[maybe_unused]] auto penalty = bs.accept_requested_bodies(response_packet, peer_id);
 
         //REQUIRE(penalty == BadBlockPenalty); // for now we choose to not penalize the peer
         REQUIRE(!request_status.ready);

--- a/node/silkworm/downloader/internals/body_sequence_test.cpp
+++ b/node/silkworm/downloader/internals/body_sequence_test.cpp
@@ -223,7 +223,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
 
         auto penalty = bs.accept_requested_bodies(response_packet, peer_id);
 
-        REQUIRE(penalty == BadBlockPenalty);
+        //REQUIRE(penalty == BadBlockPenalty); // for now we choose to not penalize the peer
         REQUIRE(!request_status.ready);
         REQUIRE(request_status.block_height == 1); // same as before
         REQUIRE(request_status.block_hash == header1_hash); // same as before

--- a/node/silkworm/downloader/messages/inbound_block_bodies.cpp
+++ b/node/silkworm/downloader/messages/inbound_block_bodies.cpp
@@ -17,6 +17,7 @@
 #include "inbound_block_bodies.hpp"
 
 #include <silkworm/common/log.hpp>
+#include <silkworm/downloader/rpc/penalize_peer.hpp>
 
 namespace silkworm {
 
@@ -32,12 +33,19 @@ InboundBlockBodies::InboundBlockBodies(const sentry::InboundMessage& msg) {
     SILK_TRACE << "Received message " << *this;
 }
 
-void InboundBlockBodies::execute(Db::ReadOnlyAccess, HeaderChain&, BodySequence& bs, SentryClient&) {
+void InboundBlockBodies::execute(Db::ReadOnlyAccess, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
 
     SILK_TRACE << "Processing message " << *this;
 
-    bs.accept_requested_bodies(packet_, peerId_);
-    // note: we are ignoring penalizations as Erigon does
+    Penalty penalty = bs.accept_requested_bodies(packet_, peerId_);
+
+    if (penalty != Penalty::NoPenalty) {
+        SILK_TRACE << "Replying to " << identify(*this) << " with penalize_peer";
+        SILK_TRACE << "Penalizing " << PeerPenalization(penalty, peerId_);
+        rpc::PenalizePeer penalize_peer(peerId_, penalty);
+        penalize_peer.do_not_throw_on_failure();
+        sentry.exec_remotely(penalize_peer);
+    }
 }
 
 uint64_t InboundBlockBodies::reqId() const { return packet_.requestId; }


### PR DESCRIPTION
On some test runs the downloader received many malformed messages. 
Tests seems to show that in such circumstances the downloader has a significative performance penalty.
The body downloader should penalize the corresponding peer so that Sentry will remove the buggy peer.
