### PR TITLE
Update GRPC interfaces to master

### DIFF
--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -25,6 +25,16 @@ find_program(GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
 
 set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/proto")
 
+set(PROTOC_ARGS
+    --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
+    -I "${PROTO_PATH}"
+)
+set(PROTOC_ARGS_GRPC
+    ${PROTOC_ARGS}
+    --grpc_out "${CMAKE_CURRENT_SOURCE_DIR}"
+    "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_EXECUTABLE}"
+)
+
 # ---------------------------------------------------------------------------------------------------------------------
 # Types
 # ---------------------------------------------------------------------------------------------------------------------
@@ -38,9 +48,7 @@ set(TYPES_PROTO_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/types/types.pb.h")
 add_custom_command(
     OUTPUT "${TYPES_PROTO_SOURCES}" "${TYPES_PROTO_HEADERS}"
     COMMAND ${PROTOBUF_PROTOC}
-    ARGS --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      -I "${PROTO_PATH}"
-      "${TYPES_PROTO}"
+    ARGS ${PROTOC_ARGS} "${TYPES_PROTO}"
     DEPENDS "${TYPES_PROTO}"
 )
 
@@ -59,11 +67,7 @@ set(SENTRY_GRPC_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/p2psentry/sentry.grpc.pb.h"
 add_custom_command(
     OUTPUT "${SENTRY_PROTO_SOURCES}" "${SENTRY_PROTO_HEADERS}" "${SENTRY_GRPC_SOURCES}" "${SENTRY_GRPC_HEADERS}"
     COMMAND ${PROTOBUF_PROTOC}
-    ARGS --grpc_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      -I "${PROTO_PATH}"
-      --plugin=protoc-gen-grpc="${GRPC_CPP_PLUGIN_EXECUTABLE}"
-      "${SENTRY_PROTO}"
+    ARGS ${PROTOC_ARGS_GRPC} "${SENTRY_PROTO}"
     DEPENDS "${SENTRY_PROTO}"
 )
 
@@ -88,11 +92,7 @@ set(KV_GRPC_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/remote/kv.grpc.pb.h")
 add_custom_command(
     OUTPUT "${KV_PROTO_SOURCES}" "${KV_PROTO_HEADERS}" "${KV_GRPC_SOURCES}" "${KV_GRPC_HEADERS}"
     COMMAND ${PROTOBUF_PROTOC}
-    ARGS --grpc_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      -I "${PROTO_PATH}"
-      --plugin=protoc-gen-grpc="${GRPC_CPP_PLUGIN_EXECUTABLE}"
-      "${KV_PROTO}"
+    ARGS ${PROTOC_ARGS_GRPC} "${KV_PROTO}"
     DEPENDS "${KV_PROTO}"
     COMMENT "Running C++ gRPC compiler on ${KV_PROTO}"
 )
@@ -118,11 +118,7 @@ set(ETHBACKEND_GRPC_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/remote/ethbackend.grpc.
 add_custom_command(
     OUTPUT "${ETHBACKEND_PROTO_SOURCES}" "${ETHBACKEND_PROTO_HEADERS}" "${ETHBACKEND_GRPC_SOURCES}" "${ETHBACKEND_GRPC_HEADERS}"
     COMMAND ${PROTOBUF_PROTOC}
-    ARGS --grpc_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
-      -I "${PROTO_PATH}"
-      --plugin=protoc-gen-grpc="${GRPC_CPP_PLUGIN_EXECUTABLE}"
-      "${ETHBACKEND_PROTO}"
+    ARGS ${PROTOC_ARGS_GRPC} "${ETHBACKEND_PROTO}"
     DEPENDS "${ETHBACKEND_PROTO}"
     COMMENT "Running C++ gRPC compiler on ${ETHBACKEND_PROTO}"
 )

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/proto")
 set(PROTOC_ARGS
     --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
     -I "${PROTO_PATH}"
+    --experimental_allow_proto3_optional
 )
 set(PROTOC_ARGS_GRPC
     ${PROTOC_ARGS}

--- a/interfaces/p2psentry/sentry.grpc.pb.cc
+++ b/interfaces/p2psentry/sentry.grpc.pb.cc
@@ -31,8 +31,10 @@ static const char* Sentry_method_names[] = {
   "/sentry.Sentry/SendMessageToRandomPeers",
   "/sentry.Sentry/SendMessageToAll",
   "/sentry.Sentry/Messages",
-  "/sentry.Sentry/PeerCount",
   "/sentry.Sentry/Peers",
+  "/sentry.Sentry/PeerCount",
+  "/sentry.Sentry/PeerById",
+  "/sentry.Sentry/PeerEvents",
   "/sentry.Sentry/NodeInfo",
 };
 
@@ -52,9 +54,11 @@ Sentry::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, co
   , rpcmethod_SendMessageToRandomPeers_(Sentry_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SendMessageToAll_(Sentry_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Messages_(Sentry_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_PeerCount_(Sentry_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Peers_(Sentry_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_NodeInfo_(Sentry_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Peers_(Sentry_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PeerCount_(Sentry_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PeerById_(Sentry_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PeerEvents_(Sentry_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_NodeInfo_(Sentry_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status Sentry::Stub::SetStatus(::grpc::ClientContext* context, const ::sentry::StatusData& request, ::sentry::SetStatusReply* response) {
@@ -257,6 +261,29 @@ void Sentry::Stub::async::Messages(::grpc::ClientContext* context, const ::sentr
   return ::grpc::internal::ClientAsyncReaderFactory< ::sentry::InboundMessage>::Create(channel_.get(), cq, rpcmethod_Messages_, context, request, false, nullptr);
 }
 
+::grpc::Status Sentry::Stub::Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::sentry::PeersReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::google::protobuf::Empty, ::sentry::PeersReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_Peers_, context, request, response);
+}
+
+void Sentry::Stub::async::Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::google::protobuf::Empty, ::sentry::PeersReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Peers_, context, request, response, std::move(f));
+}
+
+void Sentry::Stub::async::Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Peers_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>* Sentry::Stub::PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::sentry::PeersReply, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_Peers_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>* Sentry::Stub::AsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncPeersRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ::grpc::Status Sentry::Stub::PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::sentry::PeerCountReply* response) {
   return ::grpc::internal::BlockingUnaryCall< ::sentry::PeerCountRequest, ::sentry::PeerCountReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_PeerCount_, context, request, response);
 }
@@ -280,20 +307,43 @@ void Sentry::Stub::async::PeerCount(::grpc::ClientContext* context, const ::sent
   return result;
 }
 
-::grpc::ClientReader< ::sentry::PeersReply>* Sentry::Stub::PeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request) {
-  return ::grpc::internal::ClientReaderFactory< ::sentry::PeersReply>::Create(channel_.get(), rpcmethod_Peers_, context, request);
+::grpc::Status Sentry::Stub::PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::sentry::PeerByIdReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_PeerById_, context, request, response);
 }
 
-void Sentry::Stub::async::Peers(::grpc::ClientContext* context, const ::sentry::PeersRequest* request, ::grpc::ClientReadReactor< ::sentry::PeersReply>* reactor) {
-  ::grpc::internal::ClientCallbackReaderFactory< ::sentry::PeersReply>::Create(stub_->channel_.get(), stub_->rpcmethod_Peers_, context, request, reactor);
+void Sentry::Stub::async::PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_PeerById_, context, request, response, std::move(f));
 }
 
-::grpc::ClientAsyncReader< ::sentry::PeersReply>* Sentry::Stub::AsyncPeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
-  return ::grpc::internal::ClientAsyncReaderFactory< ::sentry::PeersReply>::Create(channel_.get(), cq, rpcmethod_Peers_, context, request, true, tag);
+void Sentry::Stub::async::PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_PeerById_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncReader< ::sentry::PeersReply>* Sentry::Stub::PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncReaderFactory< ::sentry::PeersReply>::Create(channel_.get(), cq, rpcmethod_Peers_, context, request, false, nullptr);
+::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>* Sentry::Stub::PrepareAsyncPeerByIdRaw(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::sentry::PeerByIdReply, ::sentry::PeerByIdRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_PeerById_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>* Sentry::Stub::AsyncPeerByIdRaw(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncPeerByIdRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::sentry::PeerEvent>* Sentry::Stub::PeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::sentry::PeerEvent>::Create(channel_.get(), rpcmethod_PeerEvents_, context, request);
+}
+
+void Sentry::Stub::async::PeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest* request, ::grpc::ClientReadReactor< ::sentry::PeerEvent>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::sentry::PeerEvent>::Create(stub_->channel_.get(), stub_->rpcmethod_PeerEvents_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::sentry::PeerEvent>* Sentry::Stub::AsyncPeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::sentry::PeerEvent>::Create(channel_.get(), cq, rpcmethod_PeerEvents_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::sentry::PeerEvent>* Sentry::Stub::PrepareAsyncPeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::sentry::PeerEvent>::Create(channel_.get(), cq, rpcmethod_PeerEvents_, context, request, false, nullptr);
 }
 
 ::grpc::Status Sentry::Stub::NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::types::NodeInfoReply* response) {
@@ -413,6 +463,16 @@ Sentry::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Sentry_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Sentry::Service, ::google::protobuf::Empty, ::sentry::PeersReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](Sentry::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::google::protobuf::Empty* req,
+             ::sentry::PeersReply* resp) {
+               return service->Peers(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Sentry_method_names[10],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Sentry::Service, ::sentry::PeerCountRequest, ::sentry::PeerCountReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](Sentry::Service* service,
              ::grpc::ServerContext* ctx,
@@ -421,17 +481,27 @@ Sentry::Service::Service() {
                return service->PeerCount(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Sentry_method_names[10],
-      ::grpc::internal::RpcMethod::SERVER_STREAMING,
-      new ::grpc::internal::ServerStreamingHandler< Sentry::Service, ::sentry::PeersRequest, ::sentry::PeersReply>(
+      Sentry_method_names[11],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Sentry::Service, ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](Sentry::Service* service,
              ::grpc::ServerContext* ctx,
-             const ::sentry::PeersRequest* req,
-             ::grpc::ServerWriter<::sentry::PeersReply>* writer) {
-               return service->Peers(ctx, req, writer);
+             const ::sentry::PeerByIdRequest* req,
+             ::sentry::PeerByIdReply* resp) {
+               return service->PeerById(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Sentry_method_names[11],
+      Sentry_method_names[12],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< Sentry::Service, ::sentry::PeerEventsRequest, ::sentry::PeerEvent>(
+          [](Sentry::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::sentry::PeerEventsRequest* req,
+             ::grpc::ServerWriter<::sentry::PeerEvent>* writer) {
+               return service->PeerEvents(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Sentry_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Sentry::Service, ::google::protobuf::Empty, ::types::NodeInfoReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](Sentry::Service* service,
@@ -508,6 +578,13 @@ Sentry::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
+::grpc::Status Sentry::Service::Peers(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
 ::grpc::Status Sentry::Service::PeerCount(::grpc::ServerContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response) {
   (void) context;
   (void) request;
@@ -515,7 +592,14 @@ Sentry::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status Sentry::Service::Peers(::grpc::ServerContext* context, const ::sentry::PeersRequest* request, ::grpc::ServerWriter< ::sentry::PeersReply>* writer) {
+::grpc::Status Sentry::Service::PeerById(::grpc::ServerContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Sentry::Service::PeerEvents(::grpc::ServerContext* context, const ::sentry::PeerEventsRequest* request, ::grpc::ServerWriter< ::sentry::PeerEvent>* writer) {
   (void) context;
   (void) request;
   (void) writer;

--- a/interfaces/p2psentry/sentry.grpc.pb.h
+++ b/interfaces/p2psentry/sentry.grpc.pb.h
@@ -106,6 +106,13 @@ class Sentry final {
     std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::InboundMessage>> PrepareAsyncMessages(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::InboundMessage>>(PrepareAsyncMessagesRaw(context, request, cq));
     }
+    virtual ::grpc::Status Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::sentry::PeersReply* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeersReply>> AsyncPeers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeersReply>>(AsyncPeersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeersReply>> PrepareAsyncPeers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeersReply>>(PrepareAsyncPeersRaw(context, request, cq));
+    }
     virtual ::grpc::Status PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::sentry::PeerCountReply* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerCountReply>> AsyncPeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerCountReply>>(AsyncPeerCountRaw(context, request, cq));
@@ -113,15 +120,22 @@ class Sentry final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerCountReply>> PrepareAsyncPeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerCountReply>>(PrepareAsyncPeerCountRaw(context, request, cq));
     }
-    // Notifications about connected (after sub-protocol handshake) or lost peer
-    std::unique_ptr< ::grpc::ClientReaderInterface< ::sentry::PeersReply>> Peers(::grpc::ClientContext* context, const ::sentry::PeersRequest& request) {
-      return std::unique_ptr< ::grpc::ClientReaderInterface< ::sentry::PeersReply>>(PeersRaw(context, request));
+    virtual ::grpc::Status PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::sentry::PeerByIdReply* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerByIdReply>> AsyncPeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerByIdReply>>(AsyncPeerByIdRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeersReply>> AsyncPeers(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeersReply>>(AsyncPeersRaw(context, request, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerByIdReply>> PrepareAsyncPeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerByIdReply>>(PrepareAsyncPeerByIdRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeersReply>> PrepareAsyncPeers(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeersReply>>(PrepareAsyncPeersRaw(context, request, cq));
+    // Subscribe to notifications about connected or lost peers.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::sentry::PeerEvent>> PeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::sentry::PeerEvent>>(PeerEventsRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeerEvent>> AsyncPeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeerEvent>>(AsyncPeerEventsRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeerEvent>> PrepareAsyncPeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::sentry::PeerEvent>>(PrepareAsyncPeerEventsRaw(context, request, cq));
     }
     // NodeInfo returns a collection of metadata known about the host.
     virtual ::grpc::Status NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::types::NodeInfoReply* response) = 0;
@@ -157,10 +171,14 @@ class Sentry final {
       // Calling multiple times with a different set of ids starts separate streams.
       // It is possible to subscribe to the same set if ids more than once.
       virtual void Messages(::grpc::ClientContext* context, const ::sentry::MessagesRequest* request, ::grpc::ClientReadReactor< ::sentry::InboundMessage>* reactor) = 0;
+      virtual void Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response, std::function<void(::grpc::Status)>) = 0;
       virtual void PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      // Notifications about connected (after sub-protocol handshake) or lost peer
-      virtual void Peers(::grpc::ClientContext* context, const ::sentry::PeersRequest* request, ::grpc::ClientReadReactor< ::sentry::PeersReply>* reactor) = 0;
+      virtual void PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to notifications about connected or lost peers.
+      virtual void PeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest* request, ::grpc::ClientReadReactor< ::sentry::PeerEvent>* reactor) = 0;
       // NodeInfo returns a collection of metadata known about the host.
       virtual void NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::types::NodeInfoReply* response, std::function<void(::grpc::Status)>) = 0;
       virtual void NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::types::NodeInfoReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -188,11 +206,15 @@ class Sentry final {
     virtual ::grpc::ClientReaderInterface< ::sentry::InboundMessage>* MessagesRaw(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< ::sentry::InboundMessage>* AsyncMessagesRaw(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< ::sentry::InboundMessage>* PrepareAsyncMessagesRaw(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeersReply>* AsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeersReply>* PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerCountReply>* AsyncPeerCountRaw(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerCountReply>* PrepareAsyncPeerCountRaw(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientReaderInterface< ::sentry::PeersReply>* PeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request) = 0;
-    virtual ::grpc::ClientAsyncReaderInterface< ::sentry::PeersReply>* AsyncPeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
-    virtual ::grpc::ClientAsyncReaderInterface< ::sentry::PeersReply>* PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerByIdReply>* AsyncPeerByIdRaw(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::sentry::PeerByIdReply>* PrepareAsyncPeerByIdRaw(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::sentry::PeerEvent>* PeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::sentry::PeerEvent>* AsyncPeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::sentry::PeerEvent>* PrepareAsyncPeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::types::NodeInfoReply>* AsyncNodeInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::types::NodeInfoReply>* PrepareAsyncNodeInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
   };
@@ -264,6 +286,13 @@ class Sentry final {
     std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::InboundMessage>> PrepareAsyncMessages(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::InboundMessage>>(PrepareAsyncMessagesRaw(context, request, cq));
     }
+    ::grpc::Status Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::sentry::PeersReply* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>> AsyncPeers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>>(AsyncPeersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>> PrepareAsyncPeers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>>(PrepareAsyncPeersRaw(context, request, cq));
+    }
     ::grpc::Status PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::sentry::PeerCountReply* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerCountReply>> AsyncPeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerCountReply>>(AsyncPeerCountRaw(context, request, cq));
@@ -271,14 +300,21 @@ class Sentry final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerCountReply>> PrepareAsyncPeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerCountReply>>(PrepareAsyncPeerCountRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientReader< ::sentry::PeersReply>> Peers(::grpc::ClientContext* context, const ::sentry::PeersRequest& request) {
-      return std::unique_ptr< ::grpc::ClientReader< ::sentry::PeersReply>>(PeersRaw(context, request));
+    ::grpc::Status PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::sentry::PeerByIdReply* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>> AsyncPeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>>(AsyncPeerByIdRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeersReply>> AsyncPeers(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeersReply>>(AsyncPeersRaw(context, request, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>> PrepareAsyncPeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>>(PrepareAsyncPeerByIdRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeersReply>> PrepareAsyncPeers(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeersReply>>(PrepareAsyncPeersRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientReader< ::sentry::PeerEvent>> PeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::sentry::PeerEvent>>(PeerEventsRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeerEvent>> AsyncPeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeerEvent>>(AsyncPeerEventsRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeerEvent>> PrepareAsyncPeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::sentry::PeerEvent>>(PrepareAsyncPeerEventsRaw(context, request, cq));
     }
     ::grpc::Status NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::types::NodeInfoReply* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::types::NodeInfoReply>> AsyncNodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
@@ -307,9 +343,13 @@ class Sentry final {
       void SendMessageToAll(::grpc::ClientContext* context, const ::sentry::OutboundMessageData* request, ::sentry::SentPeers* response, std::function<void(::grpc::Status)>) override;
       void SendMessageToAll(::grpc::ClientContext* context, const ::sentry::OutboundMessageData* request, ::sentry::SentPeers* response, ::grpc::ClientUnaryReactor* reactor) override;
       void Messages(::grpc::ClientContext* context, const ::sentry::MessagesRequest* request, ::grpc::ClientReadReactor< ::sentry::InboundMessage>* reactor) override;
+      void Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response, std::function<void(::grpc::Status)>) override;
+      void Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response, std::function<void(::grpc::Status)>) override;
       void PeerCount(::grpc::ClientContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response, ::grpc::ClientUnaryReactor* reactor) override;
-      void Peers(::grpc::ClientContext* context, const ::sentry::PeersRequest* request, ::grpc::ClientReadReactor< ::sentry::PeersReply>* reactor) override;
+      void PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response, std::function<void(::grpc::Status)>) override;
+      void PeerById(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void PeerEvents(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest* request, ::grpc::ClientReadReactor< ::sentry::PeerEvent>* reactor) override;
       void NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::types::NodeInfoReply* response, std::function<void(::grpc::Status)>) override;
       void NodeInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::types::NodeInfoReply* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
@@ -342,11 +382,15 @@ class Sentry final {
     ::grpc::ClientReader< ::sentry::InboundMessage>* MessagesRaw(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request) override;
     ::grpc::ClientAsyncReader< ::sentry::InboundMessage>* AsyncMessagesRaw(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncReader< ::sentry::InboundMessage>* PrepareAsyncMessagesRaw(::grpc::ClientContext* context, const ::sentry::MessagesRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>* AsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::sentry::PeersReply>* PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::sentry::PeerCountReply>* AsyncPeerCountRaw(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::sentry::PeerCountReply>* PrepareAsyncPeerCountRaw(::grpc::ClientContext* context, const ::sentry::PeerCountRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientReader< ::sentry::PeersReply>* PeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request) override;
-    ::grpc::ClientAsyncReader< ::sentry::PeersReply>* AsyncPeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
-    ::grpc::ClientAsyncReader< ::sentry::PeersReply>* PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::sentry::PeersRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>* AsyncPeerByIdRaw(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::sentry::PeerByIdReply>* PrepareAsyncPeerByIdRaw(::grpc::ClientContext* context, const ::sentry::PeerByIdRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::sentry::PeerEvent>* PeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request) override;
+    ::grpc::ClientAsyncReader< ::sentry::PeerEvent>* AsyncPeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::sentry::PeerEvent>* PrepareAsyncPeerEventsRaw(::grpc::ClientContext* context, const ::sentry::PeerEventsRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::types::NodeInfoReply>* AsyncNodeInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::types::NodeInfoReply>* PrepareAsyncNodeInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_SetStatus_;
@@ -358,8 +402,10 @@ class Sentry final {
     const ::grpc::internal::RpcMethod rpcmethod_SendMessageToRandomPeers_;
     const ::grpc::internal::RpcMethod rpcmethod_SendMessageToAll_;
     const ::grpc::internal::RpcMethod rpcmethod_Messages_;
-    const ::grpc::internal::RpcMethod rpcmethod_PeerCount_;
     const ::grpc::internal::RpcMethod rpcmethod_Peers_;
+    const ::grpc::internal::RpcMethod rpcmethod_PeerCount_;
+    const ::grpc::internal::RpcMethod rpcmethod_PeerById_;
+    const ::grpc::internal::RpcMethod rpcmethod_PeerEvents_;
     const ::grpc::internal::RpcMethod rpcmethod_NodeInfo_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
@@ -383,9 +429,11 @@ class Sentry final {
     // Calling multiple times with a different set of ids starts separate streams.
     // It is possible to subscribe to the same set if ids more than once.
     virtual ::grpc::Status Messages(::grpc::ServerContext* context, const ::sentry::MessagesRequest* request, ::grpc::ServerWriter< ::sentry::InboundMessage>* writer);
+    virtual ::grpc::Status Peers(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response);
     virtual ::grpc::Status PeerCount(::grpc::ServerContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response);
-    // Notifications about connected (after sub-protocol handshake) or lost peer
-    virtual ::grpc::Status Peers(::grpc::ServerContext* context, const ::sentry::PeersRequest* request, ::grpc::ServerWriter< ::sentry::PeersReply>* writer);
+    virtual ::grpc::Status PeerById(::grpc::ServerContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response);
+    // Subscribe to notifications about connected or lost peers.
+    virtual ::grpc::Status PeerEvents(::grpc::ServerContext* context, const ::sentry::PeerEventsRequest* request, ::grpc::ServerWriter< ::sentry::PeerEvent>* writer);
     // NodeInfo returns a collection of metadata known about the host.
     virtual ::grpc::Status NodeInfo(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::types::NodeInfoReply* response);
   };
@@ -570,12 +618,32 @@ class Sentry final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_Peers : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_Peers() {
+      ::grpc::Service::MarkMethodAsync(9);
+    }
+    ~WithAsyncMethod_Peers() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPeers(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::sentry::PeersReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_PeerCount : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_PeerCount() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_PeerCount() override {
       BaseClassMustBeDerivedFromService(this);
@@ -586,27 +654,47 @@ class Sentry final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPeerCount(::grpc::ServerContext* context, ::sentry::PeerCountRequest* request, ::grpc::ServerAsyncResponseWriter< ::sentry::PeerCountReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithAsyncMethod_Peers : public BaseClass {
+  class WithAsyncMethod_PeerById : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithAsyncMethod_Peers() {
-      ::grpc::Service::MarkMethodAsync(10);
+    WithAsyncMethod_PeerById() {
+      ::grpc::Service::MarkMethodAsync(11);
     }
-    ~WithAsyncMethod_Peers() override {
+    ~WithAsyncMethod_PeerById() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeersReply>* /*writer*/) override {
+    ::grpc::Status PeerById(::grpc::ServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestPeers(::grpc::ServerContext* context, ::sentry::PeersRequest* request, ::grpc::ServerAsyncWriter< ::sentry::PeersReply>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(10, context, request, writer, new_call_cq, notification_cq, tag);
+    void RequestPeerById(::grpc::ServerContext* context, ::sentry::PeerByIdRequest* request, ::grpc::ServerAsyncResponseWriter< ::sentry::PeerByIdReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_PeerEvents : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_PeerEvents() {
+      ::grpc::Service::MarkMethodAsync(12);
+    }
+    ~WithAsyncMethod_PeerEvents() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PeerEvents(::grpc::ServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeerEvent>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPeerEvents(::grpc::ServerContext* context, ::sentry::PeerEventsRequest* request, ::grpc::ServerAsyncWriter< ::sentry::PeerEvent>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(12, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -615,7 +703,7 @@ class Sentry final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_NodeInfo() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_NodeInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -626,10 +714,10 @@ class Sentry final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestNodeInfo(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::types::NodeInfoReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetStatus<WithAsyncMethod_PenalizePeer<WithAsyncMethod_PeerMinBlock<WithAsyncMethod_HandShake<WithAsyncMethod_SendMessageByMinBlock<WithAsyncMethod_SendMessageById<WithAsyncMethod_SendMessageToRandomPeers<WithAsyncMethod_SendMessageToAll<WithAsyncMethod_Messages<WithAsyncMethod_PeerCount<WithAsyncMethod_Peers<WithAsyncMethod_NodeInfo<Service > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_SetStatus<WithAsyncMethod_PenalizePeer<WithAsyncMethod_PeerMinBlock<WithAsyncMethod_HandShake<WithAsyncMethod_SendMessageByMinBlock<WithAsyncMethod_SendMessageById<WithAsyncMethod_SendMessageToRandomPeers<WithAsyncMethod_SendMessageToAll<WithAsyncMethod_Messages<WithAsyncMethod_Peers<WithAsyncMethod_PeerCount<WithAsyncMethod_PeerById<WithAsyncMethod_PeerEvents<WithAsyncMethod_NodeInfo<Service > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SetStatus : public BaseClass {
    private:
@@ -869,18 +957,45 @@ class Sentry final {
       ::grpc::CallbackServerContext* /*context*/, const ::sentry::MessagesRequest* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_Peers : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_Peers() {
+      ::grpc::Service::MarkMethodCallback(9,
+          new ::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::sentry::PeersReply>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::google::protobuf::Empty* request, ::sentry::PeersReply* response) { return this->Peers(context, request, response); }));}
+    void SetMessageAllocatorFor_Peers(
+        ::grpc::MessageAllocator< ::google::protobuf::Empty, ::sentry::PeersReply>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::sentry::PeersReply>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_Peers() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* Peers(
+      ::grpc::CallbackServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_PeerCount : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_PeerCount() {
-      ::grpc::Service::MarkMethodCallback(9,
+      ::grpc::Service::MarkMethodCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::sentry::PeerCountRequest, ::sentry::PeerCountReply>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::sentry::PeerCountRequest* request, ::sentry::PeerCountReply* response) { return this->PeerCount(context, request, response); }));}
     void SetMessageAllocatorFor_PeerCount(
         ::grpc::MessageAllocator< ::sentry::PeerCountRequest, ::sentry::PeerCountReply>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::sentry::PeerCountRequest, ::sentry::PeerCountReply>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -896,26 +1011,53 @@ class Sentry final {
       ::grpc::CallbackServerContext* /*context*/, const ::sentry::PeerCountRequest* /*request*/, ::sentry::PeerCountReply* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithCallbackMethod_Peers : public BaseClass {
+  class WithCallbackMethod_PeerById : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithCallbackMethod_Peers() {
-      ::grpc::Service::MarkMethodCallback(10,
-          new ::grpc::internal::CallbackServerStreamingHandler< ::sentry::PeersRequest, ::sentry::PeersReply>(
+    WithCallbackMethod_PeerById() {
+      ::grpc::Service::MarkMethodCallback(11,
+          new ::grpc::internal::CallbackUnaryHandler< ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::sentry::PeersRequest* request) { return this->Peers(context, request); }));
+                   ::grpc::CallbackServerContext* context, const ::sentry::PeerByIdRequest* request, ::sentry::PeerByIdReply* response) { return this->PeerById(context, request, response); }));}
+    void SetMessageAllocatorFor_PeerById(
+        ::grpc::MessageAllocator< ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply>*>(handler)
+              ->SetMessageAllocator(allocator);
     }
-    ~WithCallbackMethod_Peers() override {
+    ~WithCallbackMethod_PeerById() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeersReply>* /*writer*/) override {
+    ::grpc::Status PeerById(::grpc::ServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerWriteReactor< ::sentry::PeersReply>* Peers(
-      ::grpc::CallbackServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/)  { return nullptr; }
+    virtual ::grpc::ServerUnaryReactor* PeerById(
+      ::grpc::CallbackServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_PeerEvents : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_PeerEvents() {
+      ::grpc::Service::MarkMethodCallback(12,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::sentry::PeerEventsRequest, ::sentry::PeerEvent>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::sentry::PeerEventsRequest* request) { return this->PeerEvents(context, request); }));
+    }
+    ~WithCallbackMethod_PeerEvents() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PeerEvents(::grpc::ServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeerEvent>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::sentry::PeerEvent>* PeerEvents(
+      ::grpc::CallbackServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithCallbackMethod_NodeInfo : public BaseClass {
@@ -923,13 +1065,13 @@ class Sentry final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_NodeInfo() {
-      ::grpc::Service::MarkMethodCallback(11,
+      ::grpc::Service::MarkMethodCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::types::NodeInfoReply>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::google::protobuf::Empty* request, ::types::NodeInfoReply* response) { return this->NodeInfo(context, request, response); }));}
     void SetMessageAllocatorFor_NodeInfo(
         ::grpc::MessageAllocator< ::google::protobuf::Empty, ::types::NodeInfoReply>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::types::NodeInfoReply>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -944,7 +1086,7 @@ class Sentry final {
     virtual ::grpc::ServerUnaryReactor* NodeInfo(
       ::grpc::CallbackServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::types::NodeInfoReply* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetStatus<WithCallbackMethod_PenalizePeer<WithCallbackMethod_PeerMinBlock<WithCallbackMethod_HandShake<WithCallbackMethod_SendMessageByMinBlock<WithCallbackMethod_SendMessageById<WithCallbackMethod_SendMessageToRandomPeers<WithCallbackMethod_SendMessageToAll<WithCallbackMethod_Messages<WithCallbackMethod_PeerCount<WithCallbackMethod_Peers<WithCallbackMethod_NodeInfo<Service > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_SetStatus<WithCallbackMethod_PenalizePeer<WithCallbackMethod_PeerMinBlock<WithCallbackMethod_HandShake<WithCallbackMethod_SendMessageByMinBlock<WithCallbackMethod_SendMessageById<WithCallbackMethod_SendMessageToRandomPeers<WithCallbackMethod_SendMessageToAll<WithCallbackMethod_Messages<WithCallbackMethod_Peers<WithCallbackMethod_PeerCount<WithCallbackMethod_PeerById<WithCallbackMethod_PeerEvents<WithCallbackMethod_NodeInfo<Service > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetStatus : public BaseClass {
@@ -1100,12 +1242,29 @@ class Sentry final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_Peers : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_Peers() {
+      ::grpc::Service::MarkMethodGeneric(9);
+    }
+    ~WithGenericMethod_Peers() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_PeerCount : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_PeerCount() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_PeerCount() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1117,18 +1276,35 @@ class Sentry final {
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_Peers : public BaseClass {
+  class WithGenericMethod_PeerById : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithGenericMethod_Peers() {
-      ::grpc::Service::MarkMethodGeneric(10);
+    WithGenericMethod_PeerById() {
+      ::grpc::Service::MarkMethodGeneric(11);
     }
-    ~WithGenericMethod_Peers() override {
+    ~WithGenericMethod_PeerById() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeersReply>* /*writer*/) override {
+    ::grpc::Status PeerById(::grpc::ServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_PeerEvents : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_PeerEvents() {
+      ::grpc::Service::MarkMethodGeneric(12);
+    }
+    ~WithGenericMethod_PeerEvents() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PeerEvents(::grpc::ServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeerEvent>* /*writer*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1139,7 +1315,7 @@ class Sentry final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_NodeInfo() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_NodeInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1331,12 +1507,32 @@ class Sentry final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_Peers : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_Peers() {
+      ::grpc::Service::MarkMethodRaw(9);
+    }
+    ~WithRawMethod_Peers() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPeers(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_PeerCount : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_PeerCount() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_PeerCount() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1347,27 +1543,47 @@ class Sentry final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPeerCount(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithRawMethod_Peers : public BaseClass {
+  class WithRawMethod_PeerById : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawMethod_Peers() {
-      ::grpc::Service::MarkMethodRaw(10);
+    WithRawMethod_PeerById() {
+      ::grpc::Service::MarkMethodRaw(11);
     }
-    ~WithRawMethod_Peers() override {
+    ~WithRawMethod_PeerById() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeersReply>* /*writer*/) override {
+    ::grpc::Status PeerById(::grpc::ServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestPeers(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(10, context, request, writer, new_call_cq, notification_cq, tag);
+    void RequestPeerById(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_PeerEvents : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_PeerEvents() {
+      ::grpc::Service::MarkMethodRaw(12);
+    }
+    ~WithRawMethod_PeerEvents() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PeerEvents(::grpc::ServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeerEvent>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestPeerEvents(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(12, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1376,7 +1592,7 @@ class Sentry final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_NodeInfo() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_NodeInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1387,7 +1603,7 @@ class Sentry final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestNodeInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1589,12 +1805,34 @@ class Sentry final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_Peers : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_Peers() {
+      ::grpc::Service::MarkMethodRawCallback(9,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->Peers(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_Peers() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* Peers(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_PeerCount : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_PeerCount() {
-      ::grpc::Service::MarkMethodRawCallback(9,
+      ::grpc::Service::MarkMethodRawCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->PeerCount(context, request, response); }));
@@ -1611,25 +1849,47 @@ class Sentry final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithRawCallbackMethod_Peers : public BaseClass {
+  class WithRawCallbackMethod_PeerById : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawCallbackMethod_Peers() {
-      ::grpc::Service::MarkMethodRawCallback(10,
-          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+    WithRawCallbackMethod_PeerById() {
+      ::grpc::Service::MarkMethodRawCallback(11,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->Peers(context, request); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->PeerById(context, request, response); }));
     }
-    ~WithRawCallbackMethod_Peers() override {
+    ~WithRawCallbackMethod_PeerById() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeersReply>* /*writer*/) override {
+    ::grpc::Status PeerById(::grpc::ServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* Peers(
+    virtual ::grpc::ServerUnaryReactor* PeerById(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_PeerEvents : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_PeerEvents() {
+      ::grpc::Service::MarkMethodRawCallback(12,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->PeerEvents(context, request); }));
+    }
+    ~WithRawCallbackMethod_PeerEvents() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status PeerEvents(::grpc::ServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeerEvent>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* PeerEvents(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -1638,7 +1898,7 @@ class Sentry final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_NodeInfo() {
-      ::grpc::Service::MarkMethodRawCallback(11,
+      ::grpc::Service::MarkMethodRawCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->NodeInfo(context, request, response); }));
@@ -1871,12 +2131,39 @@ class Sentry final {
     virtual ::grpc::Status StreamedSendMessageToAll(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::sentry::OutboundMessageData,::sentry::SentPeers>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_Peers : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_Peers() {
+      ::grpc::Service::MarkMethodStreamed(9,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::google::protobuf::Empty, ::sentry::PeersReply>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::google::protobuf::Empty, ::sentry::PeersReply>* streamer) {
+                       return this->StreamedPeers(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_Peers() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::google::protobuf::Empty* /*request*/, ::sentry::PeersReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedPeers(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::sentry::PeersReply>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_PeerCount : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_PeerCount() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler<
           ::sentry::PeerCountRequest, ::sentry::PeerCountReply>(
             [this](::grpc::ServerContext* context,
@@ -1898,12 +2185,39 @@ class Sentry final {
     virtual ::grpc::Status StreamedPeerCount(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::sentry::PeerCountRequest,::sentry::PeerCountReply>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_PeerById : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_PeerById() {
+      ::grpc::Service::MarkMethodStreamed(11,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::sentry::PeerByIdRequest, ::sentry::PeerByIdReply>* streamer) {
+                       return this->StreamedPeerById(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_PeerById() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status PeerById(::grpc::ServerContext* /*context*/, const ::sentry::PeerByIdRequest* /*request*/, ::sentry::PeerByIdReply* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedPeerById(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::sentry::PeerByIdRequest,::sentry::PeerByIdReply>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_NodeInfo : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_NodeInfo() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler<
           ::google::protobuf::Empty, ::types::NodeInfoReply>(
             [this](::grpc::ServerContext* context,
@@ -1924,7 +2238,7 @@ class Sentry final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedNodeInfo(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::types::NodeInfoReply>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetStatus<WithStreamedUnaryMethod_PenalizePeer<WithStreamedUnaryMethod_PeerMinBlock<WithStreamedUnaryMethod_HandShake<WithStreamedUnaryMethod_SendMessageByMinBlock<WithStreamedUnaryMethod_SendMessageById<WithStreamedUnaryMethod_SendMessageToRandomPeers<WithStreamedUnaryMethod_SendMessageToAll<WithStreamedUnaryMethod_PeerCount<WithStreamedUnaryMethod_NodeInfo<Service > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_SetStatus<WithStreamedUnaryMethod_PenalizePeer<WithStreamedUnaryMethod_PeerMinBlock<WithStreamedUnaryMethod_HandShake<WithStreamedUnaryMethod_SendMessageByMinBlock<WithStreamedUnaryMethod_SendMessageById<WithStreamedUnaryMethod_SendMessageToRandomPeers<WithStreamedUnaryMethod_SendMessageToAll<WithStreamedUnaryMethod_Peers<WithStreamedUnaryMethod_PeerCount<WithStreamedUnaryMethod_PeerById<WithStreamedUnaryMethod_NodeInfo<Service > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_Messages : public BaseClass {
    private:
@@ -1953,34 +2267,34 @@ class Sentry final {
     virtual ::grpc::Status StreamedMessages(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::sentry::MessagesRequest,::sentry::InboundMessage>* server_split_streamer) = 0;
   };
   template <class BaseClass>
-  class WithSplitStreamingMethod_Peers : public BaseClass {
+  class WithSplitStreamingMethod_PeerEvents : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithSplitStreamingMethod_Peers() {
-      ::grpc::Service::MarkMethodStreamed(10,
+    WithSplitStreamingMethod_PeerEvents() {
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::SplitServerStreamingHandler<
-          ::sentry::PeersRequest, ::sentry::PeersReply>(
+          ::sentry::PeerEventsRequest, ::sentry::PeerEvent>(
             [this](::grpc::ServerContext* context,
                    ::grpc::ServerSplitStreamer<
-                     ::sentry::PeersRequest, ::sentry::PeersReply>* streamer) {
-                       return this->StreamedPeers(context,
+                     ::sentry::PeerEventsRequest, ::sentry::PeerEvent>* streamer) {
+                       return this->StreamedPeerEvents(context,
                          streamer);
                   }));
     }
-    ~WithSplitStreamingMethod_Peers() override {
+    ~WithSplitStreamingMethod_PeerEvents() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status Peers(::grpc::ServerContext* /*context*/, const ::sentry::PeersRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeersReply>* /*writer*/) override {
+    ::grpc::Status PeerEvents(::grpc::ServerContext* /*context*/, const ::sentry::PeerEventsRequest* /*request*/, ::grpc::ServerWriter< ::sentry::PeerEvent>* /*writer*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with split streamed
-    virtual ::grpc::Status StreamedPeers(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::sentry::PeersRequest,::sentry::PeersReply>* server_split_streamer) = 0;
+    virtual ::grpc::Status StreamedPeerEvents(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::sentry::PeerEventsRequest,::sentry::PeerEvent>* server_split_streamer) = 0;
   };
-  typedef WithSplitStreamingMethod_Messages<WithSplitStreamingMethod_Peers<Service > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetStatus<WithStreamedUnaryMethod_PenalizePeer<WithStreamedUnaryMethod_PeerMinBlock<WithStreamedUnaryMethod_HandShake<WithStreamedUnaryMethod_SendMessageByMinBlock<WithStreamedUnaryMethod_SendMessageById<WithStreamedUnaryMethod_SendMessageToRandomPeers<WithStreamedUnaryMethod_SendMessageToAll<WithSplitStreamingMethod_Messages<WithStreamedUnaryMethod_PeerCount<WithSplitStreamingMethod_Peers<WithStreamedUnaryMethod_NodeInfo<Service > > > > > > > > > > > > StreamedService;
+  typedef WithSplitStreamingMethod_Messages<WithSplitStreamingMethod_PeerEvents<Service > > SplitStreamedService;
+  typedef WithStreamedUnaryMethod_SetStatus<WithStreamedUnaryMethod_PenalizePeer<WithStreamedUnaryMethod_PeerMinBlock<WithStreamedUnaryMethod_HandShake<WithStreamedUnaryMethod_SendMessageByMinBlock<WithStreamedUnaryMethod_SendMessageById<WithStreamedUnaryMethod_SendMessageToRandomPeers<WithStreamedUnaryMethod_SendMessageToAll<WithSplitStreamingMethod_Messages<WithStreamedUnaryMethod_Peers<WithStreamedUnaryMethod_PeerCount<WithStreamedUnaryMethod_PeerById<WithSplitStreamingMethod_PeerEvents<WithStreamedUnaryMethod_NodeInfo<Service > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace sentry

--- a/interfaces/p2psentry/sentry.pb.cc
+++ b/interfaces/p2psentry/sentry.pb.cc
@@ -18,6 +18,7 @@ extern PROTOBUF_INTERNAL_EXPORT_p2psentry_2fsentry_2eproto ::PROTOBUF_NAMESPACE_
 extern PROTOBUF_INTERNAL_EXPORT_p2psentry_2fsentry_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_OutboundMessageData_p2psentry_2fsentry_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H256_types_2ftypes_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H512_types_2ftypes_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_PeerInfo_types_2ftypes_2eproto;
 namespace sentry {
 class OutboundMessageDataDefaultTypeInternal {
  public:
@@ -71,6 +72,10 @@ class MessagesRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<MessagesRequest> _instance;
 } _MessagesRequest_default_instance_;
+class PeersReplyDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeersReply> _instance;
+} _PeersReply_default_instance_;
 class PeerCountRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerCountRequest> _instance;
@@ -79,14 +84,22 @@ class PeerCountReplyDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerCountReply> _instance;
 } _PeerCountReply_default_instance_;
-class PeersRequestDefaultTypeInternal {
+class PeerByIdRequestDefaultTypeInternal {
  public:
-  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeersRequest> _instance;
-} _PeersRequest_default_instance_;
-class PeersReplyDefaultTypeInternal {
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerByIdRequest> _instance;
+} _PeerByIdRequest_default_instance_;
+class PeerByIdReplyDefaultTypeInternal {
  public:
-  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeersReply> _instance;
-} _PeersReply_default_instance_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerByIdReply> _instance;
+} _PeerByIdReply_default_instance_;
+class PeerEventsRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerEventsRequest> _instance;
+} _PeerEventsRequest_default_instance_;
+class PeerEventDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerEvent> _instance;
+} _PeerEvent_default_instance_;
 }  // namespace sentry
 static void InitDefaultsscc_info_Forks_p2psentry_2fsentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -155,6 +168,34 @@ static void InitDefaultsscc_info_OutboundMessageData_p2psentry_2fsentry_2eproto(
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_OutboundMessageData_p2psentry_2fsentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_OutboundMessageData_p2psentry_2fsentry_2eproto}, {}};
 
+static void InitDefaultsscc_info_PeerByIdReply_p2psentry_2fsentry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::sentry::_PeerByIdReply_default_instance_;
+    new (ptr) ::sentry::PeerByIdReply();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PeerByIdReply_p2psentry_2fsentry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PeerByIdReply_p2psentry_2fsentry_2eproto}, {
+      &scc_info_PeerInfo_types_2ftypes_2eproto.base,}};
+
+static void InitDefaultsscc_info_PeerByIdRequest_p2psentry_2fsentry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::sentry::_PeerByIdRequest_default_instance_;
+    new (ptr) ::sentry::PeerByIdRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PeerByIdRequest_p2psentry_2fsentry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PeerByIdRequest_p2psentry_2fsentry_2eproto}, {
+      &scc_info_H512_types_2ftypes_2eproto.base,}};
+
 static void InitDefaultsscc_info_PeerCountReply_p2psentry_2fsentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -180,6 +221,33 @@ static void InitDefaultsscc_info_PeerCountRequest_p2psentry_2fsentry_2eproto() {
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_PeerCountRequest_p2psentry_2fsentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_PeerCountRequest_p2psentry_2fsentry_2eproto}, {}};
+
+static void InitDefaultsscc_info_PeerEvent_p2psentry_2fsentry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::sentry::_PeerEvent_default_instance_;
+    new (ptr) ::sentry::PeerEvent();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PeerEvent_p2psentry_2fsentry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PeerEvent_p2psentry_2fsentry_2eproto}, {
+      &scc_info_H512_types_2ftypes_2eproto.base,}};
+
+static void InitDefaultsscc_info_PeerEventsRequest_p2psentry_2fsentry_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::sentry::_PeerEventsRequest_default_instance_;
+    new (ptr) ::sentry::PeerEventsRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_PeerEventsRequest_p2psentry_2fsentry_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_PeerEventsRequest_p2psentry_2fsentry_2eproto}, {}};
 
 static void InitDefaultsscc_info_PeerMinBlockRequest_p2psentry_2fsentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -207,20 +275,7 @@ static void InitDefaultsscc_info_PeersReply_p2psentry_2fsentry_2eproto() {
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PeersReply_p2psentry_2fsentry_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PeersReply_p2psentry_2fsentry_2eproto}, {
-      &scc_info_H512_types_2ftypes_2eproto.base,}};
-
-static void InitDefaultsscc_info_PeersRequest_p2psentry_2fsentry_2eproto() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::sentry::_PeersRequest_default_instance_;
-    new (ptr) ::sentry::PeersRequest();
-    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
-  }
-}
-
-::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_PeersRequest_p2psentry_2fsentry_2eproto =
-    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_PeersRequest_p2psentry_2fsentry_2eproto}, {}};
+      &scc_info_PeerInfo_types_2ftypes_2eproto.base,}};
 
 static void InitDefaultsscc_info_PenalizePeerRequest_p2psentry_2fsentry_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -321,7 +376,7 @@ static void InitDefaultsscc_info_StatusData_p2psentry_2fsentry_2eproto() {
       &scc_info_H256_types_2ftypes_2eproto.base,
       &scc_info_Forks_p2psentry_2fsentry_2eproto.base,}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_p2psentry_2fsentry_2eproto[17];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_p2psentry_2fsentry_2eproto[20];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_p2psentry_2fsentry_2eproto[4];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_p2psentry_2fsentry_2eproto = nullptr;
 
@@ -417,6 +472,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_p2psentry_2fsentry_2eproto::of
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::sentry::MessagesRequest, ids_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::sentry::PeersReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::sentry::PeersReply, peers_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::sentry::PeerCountRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -428,17 +489,30 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_p2psentry_2fsentry_2eproto::of
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::sentry::PeerCountReply, count_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::sentry::PeersRequest, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerByIdRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerByIdRequest, peer_id_),
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerByIdReply, _has_bits_),
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerByIdReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerByIdReply, peer_),
+  0,
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerEventsRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::sentry::PeersReply, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerEvent, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  PROTOBUF_FIELD_OFFSET(::sentry::PeersReply, peer_id_),
-  PROTOBUF_FIELD_OFFSET(::sentry::PeersReply, event_),
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerEvent, peer_id_),
+  PROTOBUF_FIELD_OFFSET(::sentry::PeerEvent, event_id_),
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::sentry::OutboundMessageData)},
@@ -454,10 +528,13 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 73, -1, sizeof(::sentry::SetStatusReply)},
   { 78, -1, sizeof(::sentry::HandShakeReply)},
   { 84, -1, sizeof(::sentry::MessagesRequest)},
-  { 90, -1, sizeof(::sentry::PeerCountRequest)},
-  { 95, -1, sizeof(::sentry::PeerCountReply)},
-  { 101, -1, sizeof(::sentry::PeersRequest)},
-  { 106, -1, sizeof(::sentry::PeersReply)},
+  { 90, -1, sizeof(::sentry::PeersReply)},
+  { 96, -1, sizeof(::sentry::PeerCountRequest)},
+  { 101, -1, sizeof(::sentry::PeerCountReply)},
+  { 107, -1, sizeof(::sentry::PeerByIdRequest)},
+  { 113, 119, sizeof(::sentry::PeerByIdReply)},
+  { 120, -1, sizeof(::sentry::PeerEventsRequest)},
+  { 125, -1, sizeof(::sentry::PeerEvent)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -474,10 +551,13 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_SetStatusReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_HandShakeReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_MessagesRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeersReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeerCountRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeerCountReply_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeersRequest_default_instance_),
-  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeersReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeerByIdRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeerByIdReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeerEventsRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::sentry::_PeerEvent_default_instance_),
 };
 
 const char descriptor_table_protodef_p2psentry_2fsentry_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
@@ -507,69 +587,80 @@ const char descriptor_table_protodef_p2psentry_2fsentry_2eproto[] PROTOBUF_SECTI
   "try.Forks\022\021\n\tmax_block\030\005 \001(\004\"\020\n\016SetStatu"
   "sReply\"4\n\016HandShakeReply\022\"\n\010protocol\030\001 \001"
   "(\0162\020.sentry.Protocol\"1\n\017MessagesRequest\022"
-  "\036\n\003ids\030\001 \003(\0162\021.sentry.MessageId\"\022\n\020PeerC"
-  "ountRequest\"\037\n\016PeerCountReply\022\r\n\005count\030\001"
-  " \001(\004\"\016\n\014PeersRequest\"\201\001\n\nPeersReply\022\034\n\007p"
-  "eer_id\030\001 \001(\0132\013.types.H512\022+\n\005event\030\002 \001(\016"
-  "2\034.sentry.PeersReply.PeerEvent\"(\n\tPeerEv"
-  "ent\022\013\n\007Connect\020\000\022\016\n\nDisconnect\020\001*\332\005\n\tMes"
-  "sageId\022\r\n\tSTATUS_65\020\000\022\030\n\024GET_BLOCK_HEADE"
-  "RS_65\020\001\022\024\n\020BLOCK_HEADERS_65\020\002\022\023\n\017BLOCK_H"
-  "ASHES_65\020\003\022\027\n\023GET_BLOCK_BODIES_65\020\004\022\023\n\017B"
-  "LOCK_BODIES_65\020\005\022\024\n\020GET_NODE_DATA_65\020\006\022\020"
-  "\n\014NODE_DATA_65\020\007\022\023\n\017GET_RECEIPTS_65\020\010\022\017\n"
-  "\013RECEIPTS_65\020\t\022\027\n\023NEW_BLOCK_HASHES_65\020\n\022"
-  "\020\n\014NEW_BLOCK_65\020\013\022\023\n\017TRANSACTIONS_65\020\014\022$"
-  "\n NEW_POOLED_TRANSACTION_HASHES_65\020\r\022\036\n\032"
-  "GET_POOLED_TRANSACTIONS_65\020\016\022\032\n\026POOLED_T"
-  "RANSACTIONS_65\020\017\022\r\n\tSTATUS_66\020\021\022\027\n\023NEW_B"
-  "LOCK_HASHES_66\020\022\022\020\n\014NEW_BLOCK_66\020\023\022\023\n\017TR"
-  "ANSACTIONS_66\020\024\022$\n NEW_POOLED_TRANSACTIO"
-  "N_HASHES_66\020\025\022\030\n\024GET_BLOCK_HEADERS_66\020\026\022"
-  "\027\n\023GET_BLOCK_BODIES_66\020\027\022\024\n\020GET_NODE_DAT"
-  "A_66\020\030\022\023\n\017GET_RECEIPTS_66\020\031\022\036\n\032GET_POOLE"
-  "D_TRANSACTIONS_66\020\032\022\024\n\020BLOCK_HEADERS_66\020"
-  "\033\022\023\n\017BLOCK_BODIES_66\020\034\022\020\n\014NODE_DATA_66\020\035"
-  "\022\017\n\013RECEIPTS_66\020\036\022\032\n\026POOLED_TRANSACTIONS"
-  "_66\020\037*\027\n\013PenaltyKind\022\010\n\004Kick\020\000* \n\010Protoc"
-  "ol\022\t\n\005ETH65\020\000\022\t\n\005ETH66\020\0012\251\006\n\006Sentry\0227\n\tS"
-  "etStatus\022\022.sentry.StatusData\032\026.sentry.Se"
-  "tStatusReply\022C\n\014PenalizePeer\022\033.sentry.Pe"
-  "nalizePeerRequest\032\026.google.protobuf.Empt"
-  "y\022C\n\014PeerMinBlock\022\033.sentry.PeerMinBlockR"
-  "equest\032\026.google.protobuf.Empty\022;\n\tHandSh"
-  "ake\022\026.google.protobuf.Empty\032\026.sentry.Han"
-  "dShakeReply\022P\n\025SendMessageByMinBlock\022$.s"
-  "entry.SendMessageByMinBlockRequest\032\021.sen"
-  "try.SentPeers\022D\n\017SendMessageById\022\036.sentr"
-  "y.SendMessageByIdRequest\032\021.sentry.SentPe"
-  "ers\022V\n\030SendMessageToRandomPeers\022\'.sentry"
-  ".SendMessageToRandomPeersRequest\032\021.sentr"
-  "y.SentPeers\022B\n\020SendMessageToAll\022\033.sentry"
-  ".OutboundMessageData\032\021.sentry.SentPeers\022"
-  "=\n\010Messages\022\027.sentry.MessagesRequest\032\026.s"
-  "entry.InboundMessage0\001\022=\n\tPeerCount\022\030.se"
-  "ntry.PeerCountRequest\032\026.sentry.PeerCount"
-  "Reply\0223\n\005Peers\022\024.sentry.PeersRequest\032\022.s"
-  "entry.PeersReply0\001\0228\n\010NodeInfo\022\026.google."
-  "protobuf.Empty\032\024.types.NodeInfoReplyB\021Z\017"
-  "./sentry;sentryb\006proto3"
+  "\036\n\003ids\030\001 \003(\0162\021.sentry.MessageId\",\n\nPeers"
+  "Reply\022\036\n\005peers\030\001 \003(\0132\017.types.PeerInfo\"\022\n"
+  "\020PeerCountRequest\"\037\n\016PeerCountReply\022\r\n\005c"
+  "ount\030\001 \001(\004\"/\n\017PeerByIdRequest\022\034\n\007peer_id"
+  "\030\001 \001(\0132\013.types.H512\"<\n\rPeerByIdReply\022\"\n\004"
+  "peer\030\001 \001(\0132\017.types.PeerInfoH\000\210\001\001B\007\n\005_pee"
+  "r\"\023\n\021PeerEventsRequest\"\206\001\n\tPeerEvent\022\034\n\007"
+  "peer_id\030\001 \001(\0132\013.types.H512\022/\n\010event_id\030\002"
+  " \001(\0162\035.sentry.PeerEvent.PeerEventId\"*\n\013P"
+  "eerEventId\022\013\n\007Connect\020\000\022\016\n\nDisconnect\020\001*"
+  "\332\005\n\tMessageId\022\r\n\tSTATUS_65\020\000\022\030\n\024GET_BLOC"
+  "K_HEADERS_65\020\001\022\024\n\020BLOCK_HEADERS_65\020\002\022\023\n\017"
+  "BLOCK_HASHES_65\020\003\022\027\n\023GET_BLOCK_BODIES_65"
+  "\020\004\022\023\n\017BLOCK_BODIES_65\020\005\022\024\n\020GET_NODE_DATA"
+  "_65\020\006\022\020\n\014NODE_DATA_65\020\007\022\023\n\017GET_RECEIPTS_"
+  "65\020\010\022\017\n\013RECEIPTS_65\020\t\022\027\n\023NEW_BLOCK_HASHE"
+  "S_65\020\n\022\020\n\014NEW_BLOCK_65\020\013\022\023\n\017TRANSACTIONS"
+  "_65\020\014\022$\n NEW_POOLED_TRANSACTION_HASHES_6"
+  "5\020\r\022\036\n\032GET_POOLED_TRANSACTIONS_65\020\016\022\032\n\026P"
+  "OOLED_TRANSACTIONS_65\020\017\022\r\n\tSTATUS_66\020\021\022\027"
+  "\n\023NEW_BLOCK_HASHES_66\020\022\022\020\n\014NEW_BLOCK_66\020"
+  "\023\022\023\n\017TRANSACTIONS_66\020\024\022$\n NEW_POOLED_TRA"
+  "NSACTION_HASHES_66\020\025\022\030\n\024GET_BLOCK_HEADER"
+  "S_66\020\026\022\027\n\023GET_BLOCK_BODIES_66\020\027\022\024\n\020GET_N"
+  "ODE_DATA_66\020\030\022\023\n\017GET_RECEIPTS_66\020\031\022\036\n\032GE"
+  "T_POOLED_TRANSACTIONS_66\020\032\022\024\n\020BLOCK_HEAD"
+  "ERS_66\020\033\022\023\n\017BLOCK_BODIES_66\020\034\022\020\n\014NODE_DA"
+  "TA_66\020\035\022\017\n\013RECEIPTS_66\020\036\022\032\n\026POOLED_TRANS"
+  "ACTIONS_66\020\037*\027\n\013PenaltyKind\022\010\n\004Kick\020\000*+\n"
+  "\010Protocol\022\t\n\005ETH65\020\000\022\t\n\005ETH66\020\001\022\t\n\005ETH67"
+  "\020\0022\243\007\n\006Sentry\0227\n\tSetStatus\022\022.sentry.Stat"
+  "usData\032\026.sentry.SetStatusReply\022C\n\014Penali"
+  "zePeer\022\033.sentry.PenalizePeerRequest\032\026.go"
+  "ogle.protobuf.Empty\022C\n\014PeerMinBlock\022\033.se"
+  "ntry.PeerMinBlockRequest\032\026.google.protob"
+  "uf.Empty\022;\n\tHandShake\022\026.google.protobuf."
+  "Empty\032\026.sentry.HandShakeReply\022P\n\025SendMes"
+  "sageByMinBlock\022$.sentry.SendMessageByMin"
+  "BlockRequest\032\021.sentry.SentPeers\022D\n\017SendM"
+  "essageById\022\036.sentry.SendMessageByIdReque"
+  "st\032\021.sentry.SentPeers\022V\n\030SendMessageToRa"
+  "ndomPeers\022\'.sentry.SendMessageToRandomPe"
+  "ersRequest\032\021.sentry.SentPeers\022B\n\020SendMes"
+  "sageToAll\022\033.sentry.OutboundMessageData\032\021"
+  ".sentry.SentPeers\022=\n\010Messages\022\027.sentry.M"
+  "essagesRequest\032\026.sentry.InboundMessage0\001"
+  "\0223\n\005Peers\022\026.google.protobuf.Empty\032\022.sent"
+  "ry.PeersReply\022=\n\tPeerCount\022\030.sentry.Peer"
+  "CountRequest\032\026.sentry.PeerCountReply\022:\n\010"
+  "PeerById\022\027.sentry.PeerByIdRequest\032\025.sent"
+  "ry.PeerByIdReply\022<\n\nPeerEvents\022\031.sentry."
+  "PeerEventsRequest\032\021.sentry.PeerEvent0\001\0228"
+  "\n\010NodeInfo\022\026.google.protobuf.Empty\032\024.typ"
+  "es.NodeInfoReplyB\021Z\017./sentry;sentryb\006pro"
+  "to3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_p2psentry_2fsentry_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
   &::descriptor_table_types_2ftypes_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_p2psentry_2fsentry_2eproto_sccs[17] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_p2psentry_2fsentry_2eproto_sccs[20] = {
   &scc_info_Forks_p2psentry_2fsentry_2eproto.base,
   &scc_info_HandShakeReply_p2psentry_2fsentry_2eproto.base,
   &scc_info_InboundMessage_p2psentry_2fsentry_2eproto.base,
   &scc_info_MessagesRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_OutboundMessageData_p2psentry_2fsentry_2eproto.base,
+  &scc_info_PeerByIdReply_p2psentry_2fsentry_2eproto.base,
+  &scc_info_PeerByIdRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_PeerCountReply_p2psentry_2fsentry_2eproto.base,
   &scc_info_PeerCountRequest_p2psentry_2fsentry_2eproto.base,
+  &scc_info_PeerEvent_p2psentry_2fsentry_2eproto.base,
+  &scc_info_PeerEventsRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_PeerMinBlockRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_PeersReply_p2psentry_2fsentry_2eproto.base,
-  &scc_info_PeersRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_PenalizePeerRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_SendMessageByIdRequest_p2psentry_2fsentry_2eproto.base,
   &scc_info_SendMessageByMinBlockRequest_p2psentry_2fsentry_2eproto.base,
@@ -580,20 +671,20 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_p2p
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_p2psentry_2fsentry_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_p2psentry_2fsentry_2eproto = {
-  false, false, descriptor_table_protodef_p2psentry_2fsentry_2eproto, "p2psentry/sentry.proto", 2903,
-  &descriptor_table_p2psentry_2fsentry_2eproto_once, descriptor_table_p2psentry_2fsentry_2eproto_sccs, descriptor_table_p2psentry_2fsentry_2eproto_deps, 17, 2,
+  false, false, descriptor_table_protodef_p2psentry_2fsentry_2eproto, "p2psentry/sentry.proto", 3203,
+  &descriptor_table_p2psentry_2fsentry_2eproto_once, descriptor_table_p2psentry_2fsentry_2eproto_sccs, descriptor_table_p2psentry_2fsentry_2eproto_deps, 20, 2,
   schemas, file_default_instances, TableStruct_p2psentry_2fsentry_2eproto::offsets,
-  file_level_metadata_p2psentry_2fsentry_2eproto, 17, file_level_enum_descriptors_p2psentry_2fsentry_2eproto, file_level_service_descriptors_p2psentry_2fsentry_2eproto,
+  file_level_metadata_p2psentry_2fsentry_2eproto, 20, file_level_enum_descriptors_p2psentry_2fsentry_2eproto, file_level_service_descriptors_p2psentry_2fsentry_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
 static bool dynamic_init_dummy_p2psentry_2fsentry_2eproto = (static_cast<void>(::PROTOBUF_NAMESPACE_ID::internal::AddDescriptors(&descriptor_table_p2psentry_2fsentry_2eproto)), true);
 namespace sentry {
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* PeersReply_PeerEvent_descriptor() {
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* PeerEvent_PeerEventId_descriptor() {
   ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_p2psentry_2fsentry_2eproto);
   return file_level_enum_descriptors_p2psentry_2fsentry_2eproto[0];
 }
-bool PeersReply_PeerEvent_IsValid(int value) {
+bool PeerEvent_PeerEventId_IsValid(int value) {
   switch (value) {
     case 0:
     case 1:
@@ -604,11 +695,11 @@ bool PeersReply_PeerEvent_IsValid(int value) {
 }
 
 #if (__cplusplus < 201703) && (!defined(_MSC_VER) || _MSC_VER >= 1900)
-constexpr PeersReply_PeerEvent PeersReply::Connect;
-constexpr PeersReply_PeerEvent PeersReply::Disconnect;
-constexpr PeersReply_PeerEvent PeersReply::PeerEvent_MIN;
-constexpr PeersReply_PeerEvent PeersReply::PeerEvent_MAX;
-constexpr int PeersReply::PeerEvent_ARRAYSIZE;
+constexpr PeerEvent_PeerEventId PeerEvent::Connect;
+constexpr PeerEvent_PeerEventId PeerEvent::Disconnect;
+constexpr PeerEvent_PeerEventId PeerEvent::PeerEventId_MIN;
+constexpr PeerEvent_PeerEventId PeerEvent::PeerEventId_MAX;
+constexpr int PeerEvent::PeerEventId_ARRAYSIZE;
 #endif  // (__cplusplus < 201703) && (!defined(_MSC_VER) || _MSC_VER >= 1900)
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MessageId_descriptor() {
   ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_p2psentry_2fsentry_2eproto);
@@ -674,6 +765,7 @@ bool Protocol_IsValid(int value) {
   switch (value) {
     case 0:
     case 1:
+    case 2:
       return true;
     default:
       return false;
@@ -3831,6 +3923,209 @@ void MessagesRequest::InternalSwap(MessagesRequest* other) {
 
 // ===================================================================
 
+class PeersReply::_Internal {
+ public:
+};
+
+void PeersReply::clear_peers() {
+  peers_.Clear();
+}
+PeersReply::PeersReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  peers_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sentry.PeersReply)
+}
+PeersReply::PeersReply(const PeersReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      peers_(from.peers_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:sentry.PeersReply)
+}
+
+void PeersReply::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeersReply_p2psentry_2fsentry_2eproto.base);
+}
+
+PeersReply::~PeersReply() {
+  // @@protoc_insertion_point(destructor:sentry.PeersReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void PeersReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void PeersReply::ArenaDtor(void* object) {
+  PeersReply* _this = reinterpret_cast< PeersReply* >(object);
+  (void)_this;
+}
+void PeersReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PeersReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const PeersReply& PeersReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeersReply_p2psentry_2fsentry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void PeersReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:sentry.PeersReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  peers_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PeersReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // repeated .types.PeerInfo peers = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_peers(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PeersReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeersReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .types.PeerInfo peers = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_peers_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, this->_internal_peers(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeersReply)
+  return target;
+}
+
+size_t PeersReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:sentry.PeersReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .types.PeerInfo peers = 1;
+  total_size += 1UL * this->_internal_peers_size();
+  for (const auto& msg : this->peers_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void PeersReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeersReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  const PeersReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeersReply>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeersReply)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeersReply)
+    MergeFrom(*source);
+  }
+}
+
+void PeersReply::MergeFrom(const PeersReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeersReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  peers_.MergeFrom(from.peers_);
+}
+
+void PeersReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeersReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void PeersReply::CopyFrom(const PeersReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeersReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PeersReply::IsInitialized() const {
+  return true;
+}
+
+void PeersReply::InternalSwap(PeersReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  peers_.InternalSwap(&other->peers_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PeersReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 class PeerCountRequest::_Internal {
  public:
 };
@@ -4187,190 +4482,28 @@ void PeerCountReply::InternalSwap(PeerCountReply* other) {
 
 // ===================================================================
 
-class PeersRequest::_Internal {
+class PeerByIdRequest::_Internal {
  public:
-};
-
-PeersRequest::PeersRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
-  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
-  SharedCtor();
-  RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:sentry.PeersRequest)
-}
-PeersRequest::PeersRequest(const PeersRequest& from)
-  : ::PROTOBUF_NAMESPACE_ID::Message() {
-  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:sentry.PeersRequest)
-}
-
-void PeersRequest::SharedCtor() {
-}
-
-PeersRequest::~PeersRequest() {
-  // @@protoc_insertion_point(destructor:sentry.PeersRequest)
-  SharedDtor();
-  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
-}
-
-void PeersRequest::SharedDtor() {
-  GOOGLE_DCHECK(GetArena() == nullptr);
-}
-
-void PeersRequest::ArenaDtor(void* object) {
-  PeersRequest* _this = reinterpret_cast< PeersRequest* >(object);
-  (void)_this;
-}
-void PeersRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
-}
-void PeersRequest::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const PeersRequest& PeersRequest::default_instance() {
-  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeersRequest_p2psentry_2fsentry_2eproto.base);
-  return *internal_default_instance();
-}
-
-
-void PeersRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:sentry.PeersRequest)
-  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
-}
-
-const char* PeersRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
-#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
-  while (!ctx->Done(&ptr)) {
-    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
-    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
-    CHK_(ptr);
-        if ((tag & 7) == 4 || tag == 0) {
-          ctx->SetLastTag(tag);
-          goto success;
-        }
-        ptr = UnknownFieldParse(tag,
-            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
-            ptr, ctx);
-        CHK_(ptr != nullptr);
-        continue;
-  }  // while
-success:
-  return ptr;
-failure:
-  ptr = nullptr;
-  goto success;
-#undef CHK_
-}
-
-::PROTOBUF_NAMESPACE_ID::uint8* PeersRequest::_InternalSerialize(
-    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeersRequest)
-  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
-        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeersRequest)
-  return target;
-}
-
-size_t PeersRequest::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:sentry.PeersRequest)
-  size_t total_size = 0;
-
-  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
-    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
-        _internal_metadata_, total_size, &_cached_size_);
-  }
-  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void PeersRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeersRequest)
-  GOOGLE_DCHECK_NE(&from, this);
-  const PeersRequest* source =
-      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeersRequest>(
-          &from);
-  if (source == nullptr) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeersRequest)
-    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeersRequest)
-    MergeFrom(*source);
-  }
-}
-
-void PeersRequest::MergeFrom(const PeersRequest& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeersRequest)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-}
-
-void PeersRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeersRequest)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void PeersRequest::CopyFrom(const PeersRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeersRequest)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool PeersRequest::IsInitialized() const {
-  return true;
-}
-
-void PeersRequest::InternalSwap(PeersRequest* other) {
-  using std::swap;
-  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
-}
-
-::PROTOBUF_NAMESPACE_ID::Metadata PeersRequest::GetMetadata() const {
-  return GetMetadataStatic();
-}
-
-
-// ===================================================================
-
-class PeersReply::_Internal {
- public:
-  static const ::types::H512& peer_id(const PeersReply* msg);
+  static const ::types::H512& peer_id(const PeerByIdRequest* msg);
 };
 
 const ::types::H512&
-PeersReply::_Internal::peer_id(const PeersReply* msg) {
+PeerByIdRequest::_Internal::peer_id(const PeerByIdRequest* msg) {
   return *msg->peer_id_;
 }
-void PeersReply::clear_peer_id() {
+void PeerByIdRequest::clear_peer_id() {
   if (GetArena() == nullptr && peer_id_ != nullptr) {
     delete peer_id_;
   }
   peer_id_ = nullptr;
 }
-PeersReply::PeersReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+PeerByIdRequest::PeerByIdRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:sentry.PeersReply)
+  // @@protoc_insertion_point(arena_constructor:sentry.PeerByIdRequest)
 }
-PeersReply::PeersReply(const PeersReply& from)
+PeerByIdRequest::PeerByIdRequest(const PeerByIdRequest& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_peer_id()) {
@@ -4378,46 +4511,42 @@ PeersReply::PeersReply(const PeersReply& from)
   } else {
     peer_id_ = nullptr;
   }
-  event_ = from.event_;
-  // @@protoc_insertion_point(copy_constructor:sentry.PeersReply)
+  // @@protoc_insertion_point(copy_constructor:sentry.PeerByIdRequest)
 }
 
-void PeersReply::SharedCtor() {
-  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeersReply_p2psentry_2fsentry_2eproto.base);
-  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
-      reinterpret_cast<char*>(&peer_id_) - reinterpret_cast<char*>(this)),
-      0, static_cast<size_t>(reinterpret_cast<char*>(&event_) -
-      reinterpret_cast<char*>(&peer_id_)) + sizeof(event_));
+void PeerByIdRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeerByIdRequest_p2psentry_2fsentry_2eproto.base);
+  peer_id_ = nullptr;
 }
 
-PeersReply::~PeersReply() {
-  // @@protoc_insertion_point(destructor:sentry.PeersReply)
+PeerByIdRequest::~PeerByIdRequest() {
+  // @@protoc_insertion_point(destructor:sentry.PeerByIdRequest)
   SharedDtor();
   _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-void PeersReply::SharedDtor() {
+void PeerByIdRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArena() == nullptr);
   if (this != internal_default_instance()) delete peer_id_;
 }
 
-void PeersReply::ArenaDtor(void* object) {
-  PeersReply* _this = reinterpret_cast< PeersReply* >(object);
+void PeerByIdRequest::ArenaDtor(void* object) {
+  PeerByIdRequest* _this = reinterpret_cast< PeerByIdRequest* >(object);
   (void)_this;
 }
-void PeersReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+void PeerByIdRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
 }
-void PeersReply::SetCachedSize(int size) const {
+void PeerByIdRequest::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const PeersReply& PeersReply::default_instance() {
-  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeersReply_p2psentry_2fsentry_2eproto.base);
+const PeerByIdRequest& PeerByIdRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeerByIdRequest_p2psentry_2fsentry_2eproto.base);
   return *internal_default_instance();
 }
 
 
-void PeersReply::Clear() {
-// @@protoc_insertion_point(message_clear_start:sentry.PeersReply)
+void PeerByIdRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sentry.PeerByIdRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -4426,11 +4555,10 @@ void PeersReply::Clear() {
     delete peer_id_;
   }
   peer_id_ = nullptr;
-  event_ = 0;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* PeersReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+const char* PeerByIdRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
@@ -4442,14 +4570,6 @@ const char* PeersReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
           ptr = ctx->ParseMessage(_internal_mutable_peer_id(), ptr);
           CHK_(ptr);
-        } else goto handle_unusual;
-        continue;
-      // .sentry.PeersReply.PeerEvent event = 2;
-      case 2:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
-          ::PROTOBUF_NAMESPACE_ID::uint64 val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
-          CHK_(ptr);
-          _internal_set_event(static_cast<::sentry::PeersReply_PeerEvent>(val));
         } else goto handle_unusual;
         continue;
       default: {
@@ -4474,9 +4594,9 @@ failure:
 #undef CHK_
 }
 
-::PROTOBUF_NAMESPACE_ID::uint8* PeersReply::_InternalSerialize(
+::PROTOBUF_NAMESPACE_ID::uint8* PeerByIdRequest::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeersReply)
+  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeerByIdRequest)
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -4488,23 +4608,16 @@ failure:
         1, _Internal::peer_id(this), target, stream);
   }
 
-  // .sentry.PeersReply.PeerEvent event = 2;
-  if (this->event() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteEnumToArray(
-      2, this->_internal_event(), target);
-  }
-
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeersReply)
+  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeerByIdRequest)
   return target;
 }
 
-size_t PeersReply::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:sentry.PeersReply)
+size_t PeerByIdRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:sentry.PeerByIdRequest)
   size_t total_size = 0;
 
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -4518,10 +4631,233 @@ size_t PeersReply::ByteSizeLong() const {
         *peer_id_);
   }
 
-  // .sentry.PeersReply.PeerEvent event = 2;
-  if (this->event() != 0) {
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void PeerByIdRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeerByIdRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const PeerByIdRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeerByIdRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeerByIdRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeerByIdRequest)
+    MergeFrom(*source);
+  }
+}
+
+void PeerByIdRequest::MergeFrom(const PeerByIdRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeerByIdRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_peer_id()) {
+    _internal_mutable_peer_id()->::types::H512::MergeFrom(from._internal_peer_id());
+  }
+}
+
+void PeerByIdRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeerByIdRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void PeerByIdRequest::CopyFrom(const PeerByIdRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeerByIdRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PeerByIdRequest::IsInitialized() const {
+  return true;
+}
+
+void PeerByIdRequest::InternalSwap(PeerByIdRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(peer_id_, other->peer_id_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PeerByIdRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class PeerByIdReply::_Internal {
+ public:
+  using HasBits = decltype(std::declval<PeerByIdReply>()._has_bits_);
+  static const ::types::PeerInfo& peer(const PeerByIdReply* msg);
+  static void set_has_peer(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+};
+
+const ::types::PeerInfo&
+PeerByIdReply::_Internal::peer(const PeerByIdReply* msg) {
+  return *msg->peer_;
+}
+void PeerByIdReply::clear_peer() {
+  if (GetArena() == nullptr && peer_ != nullptr) {
+    delete peer_;
+  }
+  peer_ = nullptr;
+  _has_bits_[0] &= ~0x00000001u;
+}
+PeerByIdReply::PeerByIdReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sentry.PeerByIdReply)
+}
+PeerByIdReply::PeerByIdReply(const PeerByIdReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      _has_bits_(from._has_bits_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_peer()) {
+    peer_ = new ::types::PeerInfo(*from.peer_);
+  } else {
+    peer_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:sentry.PeerByIdReply)
+}
+
+void PeerByIdReply::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeerByIdReply_p2psentry_2fsentry_2eproto.base);
+  peer_ = nullptr;
+}
+
+PeerByIdReply::~PeerByIdReply() {
+  // @@protoc_insertion_point(destructor:sentry.PeerByIdReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void PeerByIdReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete peer_;
+}
+
+void PeerByIdReply::ArenaDtor(void* object) {
+  PeerByIdReply* _this = reinterpret_cast< PeerByIdReply* >(object);
+  (void)_this;
+}
+void PeerByIdReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PeerByIdReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const PeerByIdReply& PeerByIdReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeerByIdReply_p2psentry_2fsentry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void PeerByIdReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:sentry.PeerByIdReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    if (GetArena() == nullptr && peer_ != nullptr) {
+      delete peer_;
+    }
+    peer_ = nullptr;
+  }
+  _has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PeerByIdReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .types.PeerInfo peer = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_peer(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  _has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PeerByIdReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeerByIdReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.PeerInfo peer = 1;
+  if (_internal_has_peer()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::peer(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeerByIdReply)
+  return target;
+}
+
+size_t PeerByIdReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:sentry.PeerByIdReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .types.PeerInfo peer = 1;
+  cached_has_bits = _has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
     total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::EnumSize(this->_internal_event());
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *peer_);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -4533,23 +4869,428 @@ size_t PeersReply::ByteSizeLong() const {
   return total_size;
 }
 
-void PeersReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeersReply)
+void PeerByIdReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeerByIdReply)
   GOOGLE_DCHECK_NE(&from, this);
-  const PeersReply* source =
-      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeersReply>(
+  const PeerByIdReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeerByIdReply>(
           &from);
   if (source == nullptr) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeersReply)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeerByIdReply)
     ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeersReply)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeerByIdReply)
     MergeFrom(*source);
   }
 }
 
-void PeersReply::MergeFrom(const PeersReply& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeersReply)
+void PeerByIdReply::MergeFrom(const PeerByIdReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeerByIdReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_peer()) {
+    _internal_mutable_peer()->::types::PeerInfo::MergeFrom(from._internal_peer());
+  }
+}
+
+void PeerByIdReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeerByIdReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void PeerByIdReply::CopyFrom(const PeerByIdReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeerByIdReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PeerByIdReply::IsInitialized() const {
+  return true;
+}
+
+void PeerByIdReply::InternalSwap(PeerByIdReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(_has_bits_[0], other->_has_bits_[0]);
+  swap(peer_, other->peer_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PeerByIdReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class PeerEventsRequest::_Internal {
+ public:
+};
+
+PeerEventsRequest::PeerEventsRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sentry.PeerEventsRequest)
+}
+PeerEventsRequest::PeerEventsRequest(const PeerEventsRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:sentry.PeerEventsRequest)
+}
+
+void PeerEventsRequest::SharedCtor() {
+}
+
+PeerEventsRequest::~PeerEventsRequest() {
+  // @@protoc_insertion_point(destructor:sentry.PeerEventsRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void PeerEventsRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void PeerEventsRequest::ArenaDtor(void* object) {
+  PeerEventsRequest* _this = reinterpret_cast< PeerEventsRequest* >(object);
+  (void)_this;
+}
+void PeerEventsRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PeerEventsRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const PeerEventsRequest& PeerEventsRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeerEventsRequest_p2psentry_2fsentry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void PeerEventsRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sentry.PeerEventsRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PeerEventsRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PeerEventsRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeerEventsRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeerEventsRequest)
+  return target;
+}
+
+size_t PeerEventsRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:sentry.PeerEventsRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void PeerEventsRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeerEventsRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const PeerEventsRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeerEventsRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeerEventsRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeerEventsRequest)
+    MergeFrom(*source);
+  }
+}
+
+void PeerEventsRequest::MergeFrom(const PeerEventsRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeerEventsRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void PeerEventsRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeerEventsRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void PeerEventsRequest::CopyFrom(const PeerEventsRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeerEventsRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PeerEventsRequest::IsInitialized() const {
+  return true;
+}
+
+void PeerEventsRequest::InternalSwap(PeerEventsRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PeerEventsRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class PeerEvent::_Internal {
+ public:
+  static const ::types::H512& peer_id(const PeerEvent* msg);
+};
+
+const ::types::H512&
+PeerEvent::_Internal::peer_id(const PeerEvent* msg) {
+  return *msg->peer_id_;
+}
+void PeerEvent::clear_peer_id() {
+  if (GetArena() == nullptr && peer_id_ != nullptr) {
+    delete peer_id_;
+  }
+  peer_id_ = nullptr;
+}
+PeerEvent::PeerEvent(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sentry.PeerEvent)
+}
+PeerEvent::PeerEvent(const PeerEvent& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_peer_id()) {
+    peer_id_ = new ::types::H512(*from.peer_id_);
+  } else {
+    peer_id_ = nullptr;
+  }
+  event_id_ = from.event_id_;
+  // @@protoc_insertion_point(copy_constructor:sentry.PeerEvent)
+}
+
+void PeerEvent::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeerEvent_p2psentry_2fsentry_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&peer_id_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&event_id_) -
+      reinterpret_cast<char*>(&peer_id_)) + sizeof(event_id_));
+}
+
+PeerEvent::~PeerEvent() {
+  // @@protoc_insertion_point(destructor:sentry.PeerEvent)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void PeerEvent::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete peer_id_;
+}
+
+void PeerEvent::ArenaDtor(void* object) {
+  PeerEvent* _this = reinterpret_cast< PeerEvent* >(object);
+  (void)_this;
+}
+void PeerEvent::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PeerEvent::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const PeerEvent& PeerEvent::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeerEvent_p2psentry_2fsentry_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void PeerEvent::Clear() {
+// @@protoc_insertion_point(message_clear_start:sentry.PeerEvent)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && peer_id_ != nullptr) {
+    delete peer_id_;
+  }
+  peer_id_ = nullptr;
+  event_id_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PeerEvent::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .types.H512 peer_id = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_peer_id(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .sentry.PeerEvent.PeerEventId event_id = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
+          ::PROTOBUF_NAMESPACE_ID::uint64 val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_event_id(static_cast<::sentry::PeerEvent_PeerEventId>(val));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PeerEvent::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:sentry.PeerEvent)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H512 peer_id = 1;
+  if (this->has_peer_id()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::peer_id(this), target, stream);
+  }
+
+  // .sentry.PeerEvent.PeerEventId event_id = 2;
+  if (this->event_id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteEnumToArray(
+      2, this->_internal_event_id(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:sentry.PeerEvent)
+  return target;
+}
+
+size_t PeerEvent::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:sentry.PeerEvent)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .types.H512 peer_id = 1;
+  if (this->has_peer_id()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *peer_id_);
+  }
+
+  // .sentry.PeerEvent.PeerEventId event_id = 2;
+  if (this->event_id() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::EnumSize(this->_internal_event_id());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void PeerEvent::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:sentry.PeerEvent)
+  GOOGLE_DCHECK_NE(&from, this);
+  const PeerEvent* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeerEvent>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:sentry.PeerEvent)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:sentry.PeerEvent)
+    MergeFrom(*source);
+  }
+}
+
+void PeerEvent::MergeFrom(const PeerEvent& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:sentry.PeerEvent)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
@@ -4558,41 +5299,41 @@ void PeersReply::MergeFrom(const PeersReply& from) {
   if (from.has_peer_id()) {
     _internal_mutable_peer_id()->::types::H512::MergeFrom(from._internal_peer_id());
   }
-  if (from.event() != 0) {
-    _internal_set_event(from._internal_event());
+  if (from.event_id() != 0) {
+    _internal_set_event_id(from._internal_event_id());
   }
 }
 
-void PeersReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeersReply)
+void PeerEvent::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:sentry.PeerEvent)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void PeersReply::CopyFrom(const PeersReply& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeersReply)
+void PeerEvent::CopyFrom(const PeerEvent& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sentry.PeerEvent)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool PeersReply::IsInitialized() const {
+bool PeerEvent::IsInitialized() const {
   return true;
 }
 
-void PeersReply::InternalSwap(PeersReply* other) {
+void PeerEvent::InternalSwap(PeerEvent* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(PeersReply, event_)
-      + sizeof(PeersReply::event_)
-      - PROTOBUF_FIELD_OFFSET(PeersReply, peer_id_)>(
+      PROTOBUF_FIELD_OFFSET(PeerEvent, event_id_)
+      + sizeof(PeerEvent::event_id_)
+      - PROTOBUF_FIELD_OFFSET(PeerEvent, peer_id_)>(
           reinterpret_cast<char*>(&peer_id_),
           reinterpret_cast<char*>(&other->peer_id_));
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata PeersReply::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata PeerEvent::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -4639,17 +5380,26 @@ template<> PROTOBUF_NOINLINE ::sentry::HandShakeReply* Arena::CreateMaybeMessage
 template<> PROTOBUF_NOINLINE ::sentry::MessagesRequest* Arena::CreateMaybeMessage< ::sentry::MessagesRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::sentry::MessagesRequest >(arena);
 }
+template<> PROTOBUF_NOINLINE ::sentry::PeersReply* Arena::CreateMaybeMessage< ::sentry::PeersReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::sentry::PeersReply >(arena);
+}
 template<> PROTOBUF_NOINLINE ::sentry::PeerCountRequest* Arena::CreateMaybeMessage< ::sentry::PeerCountRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::sentry::PeerCountRequest >(arena);
 }
 template<> PROTOBUF_NOINLINE ::sentry::PeerCountReply* Arena::CreateMaybeMessage< ::sentry::PeerCountReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::sentry::PeerCountReply >(arena);
 }
-template<> PROTOBUF_NOINLINE ::sentry::PeersRequest* Arena::CreateMaybeMessage< ::sentry::PeersRequest >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::sentry::PeersRequest >(arena);
+template<> PROTOBUF_NOINLINE ::sentry::PeerByIdRequest* Arena::CreateMaybeMessage< ::sentry::PeerByIdRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::sentry::PeerByIdRequest >(arena);
 }
-template<> PROTOBUF_NOINLINE ::sentry::PeersReply* Arena::CreateMaybeMessage< ::sentry::PeersReply >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::sentry::PeersReply >(arena);
+template<> PROTOBUF_NOINLINE ::sentry::PeerByIdReply* Arena::CreateMaybeMessage< ::sentry::PeerByIdReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::sentry::PeerByIdReply >(arena);
+}
+template<> PROTOBUF_NOINLINE ::sentry::PeerEventsRequest* Arena::CreateMaybeMessage< ::sentry::PeerEventsRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::sentry::PeerEventsRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::sentry::PeerEvent* Arena::CreateMaybeMessage< ::sentry::PeerEvent >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::sentry::PeerEvent >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/interfaces/p2psentry/sentry.pb.h
+++ b/interfaces/p2psentry/sentry.pb.h
@@ -49,7 +49,7 @@ struct TableStruct_p2psentry_2fsentry_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[17]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[20]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -72,21 +72,30 @@ extern MessagesRequestDefaultTypeInternal _MessagesRequest_default_instance_;
 class OutboundMessageData;
 class OutboundMessageDataDefaultTypeInternal;
 extern OutboundMessageDataDefaultTypeInternal _OutboundMessageData_default_instance_;
+class PeerByIdReply;
+class PeerByIdReplyDefaultTypeInternal;
+extern PeerByIdReplyDefaultTypeInternal _PeerByIdReply_default_instance_;
+class PeerByIdRequest;
+class PeerByIdRequestDefaultTypeInternal;
+extern PeerByIdRequestDefaultTypeInternal _PeerByIdRequest_default_instance_;
 class PeerCountReply;
 class PeerCountReplyDefaultTypeInternal;
 extern PeerCountReplyDefaultTypeInternal _PeerCountReply_default_instance_;
 class PeerCountRequest;
 class PeerCountRequestDefaultTypeInternal;
 extern PeerCountRequestDefaultTypeInternal _PeerCountRequest_default_instance_;
+class PeerEvent;
+class PeerEventDefaultTypeInternal;
+extern PeerEventDefaultTypeInternal _PeerEvent_default_instance_;
+class PeerEventsRequest;
+class PeerEventsRequestDefaultTypeInternal;
+extern PeerEventsRequestDefaultTypeInternal _PeerEventsRequest_default_instance_;
 class PeerMinBlockRequest;
 class PeerMinBlockRequestDefaultTypeInternal;
 extern PeerMinBlockRequestDefaultTypeInternal _PeerMinBlockRequest_default_instance_;
 class PeersReply;
 class PeersReplyDefaultTypeInternal;
 extern PeersReplyDefaultTypeInternal _PeersReply_default_instance_;
-class PeersRequest;
-class PeersRequestDefaultTypeInternal;
-extern PeersRequestDefaultTypeInternal _PeersRequest_default_instance_;
 class PenalizePeerRequest;
 class PenalizePeerRequestDefaultTypeInternal;
 extern PenalizePeerRequestDefaultTypeInternal _PenalizePeerRequest_default_instance_;
@@ -115,11 +124,14 @@ template<> ::sentry::HandShakeReply* Arena::CreateMaybeMessage<::sentry::HandSha
 template<> ::sentry::InboundMessage* Arena::CreateMaybeMessage<::sentry::InboundMessage>(Arena*);
 template<> ::sentry::MessagesRequest* Arena::CreateMaybeMessage<::sentry::MessagesRequest>(Arena*);
 template<> ::sentry::OutboundMessageData* Arena::CreateMaybeMessage<::sentry::OutboundMessageData>(Arena*);
+template<> ::sentry::PeerByIdReply* Arena::CreateMaybeMessage<::sentry::PeerByIdReply>(Arena*);
+template<> ::sentry::PeerByIdRequest* Arena::CreateMaybeMessage<::sentry::PeerByIdRequest>(Arena*);
 template<> ::sentry::PeerCountReply* Arena::CreateMaybeMessage<::sentry::PeerCountReply>(Arena*);
 template<> ::sentry::PeerCountRequest* Arena::CreateMaybeMessage<::sentry::PeerCountRequest>(Arena*);
+template<> ::sentry::PeerEvent* Arena::CreateMaybeMessage<::sentry::PeerEvent>(Arena*);
+template<> ::sentry::PeerEventsRequest* Arena::CreateMaybeMessage<::sentry::PeerEventsRequest>(Arena*);
 template<> ::sentry::PeerMinBlockRequest* Arena::CreateMaybeMessage<::sentry::PeerMinBlockRequest>(Arena*);
 template<> ::sentry::PeersReply* Arena::CreateMaybeMessage<::sentry::PeersReply>(Arena*);
-template<> ::sentry::PeersRequest* Arena::CreateMaybeMessage<::sentry::PeersRequest>(Arena*);
 template<> ::sentry::PenalizePeerRequest* Arena::CreateMaybeMessage<::sentry::PenalizePeerRequest>(Arena*);
 template<> ::sentry::SendMessageByIdRequest* Arena::CreateMaybeMessage<::sentry::SendMessageByIdRequest>(Arena*);
 template<> ::sentry::SendMessageByMinBlockRequest* Arena::CreateMaybeMessage<::sentry::SendMessageByMinBlockRequest>(Arena*);
@@ -130,30 +142,30 @@ template<> ::sentry::StatusData* Arena::CreateMaybeMessage<::sentry::StatusData>
 PROTOBUF_NAMESPACE_CLOSE
 namespace sentry {
 
-enum PeersReply_PeerEvent : int {
-  PeersReply_PeerEvent_Connect = 0,
-  PeersReply_PeerEvent_Disconnect = 1,
-  PeersReply_PeerEvent_PeersReply_PeerEvent_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
-  PeersReply_PeerEvent_PeersReply_PeerEvent_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
+enum PeerEvent_PeerEventId : int {
+  PeerEvent_PeerEventId_Connect = 0,
+  PeerEvent_PeerEventId_Disconnect = 1,
+  PeerEvent_PeerEventId_PeerEvent_PeerEventId_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
+  PeerEvent_PeerEventId_PeerEvent_PeerEventId_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
-bool PeersReply_PeerEvent_IsValid(int value);
-constexpr PeersReply_PeerEvent PeersReply_PeerEvent_PeerEvent_MIN = PeersReply_PeerEvent_Connect;
-constexpr PeersReply_PeerEvent PeersReply_PeerEvent_PeerEvent_MAX = PeersReply_PeerEvent_Disconnect;
-constexpr int PeersReply_PeerEvent_PeerEvent_ARRAYSIZE = PeersReply_PeerEvent_PeerEvent_MAX + 1;
+bool PeerEvent_PeerEventId_IsValid(int value);
+constexpr PeerEvent_PeerEventId PeerEvent_PeerEventId_PeerEventId_MIN = PeerEvent_PeerEventId_Connect;
+constexpr PeerEvent_PeerEventId PeerEvent_PeerEventId_PeerEventId_MAX = PeerEvent_PeerEventId_Disconnect;
+constexpr int PeerEvent_PeerEventId_PeerEventId_ARRAYSIZE = PeerEvent_PeerEventId_PeerEventId_MAX + 1;
 
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* PeersReply_PeerEvent_descriptor();
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* PeerEvent_PeerEventId_descriptor();
 template<typename T>
-inline const std::string& PeersReply_PeerEvent_Name(T enum_t_value) {
-  static_assert(::std::is_same<T, PeersReply_PeerEvent>::value ||
+inline const std::string& PeerEvent_PeerEventId_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, PeerEvent_PeerEventId>::value ||
     ::std::is_integral<T>::value,
-    "Incorrect type passed to function PeersReply_PeerEvent_Name.");
+    "Incorrect type passed to function PeerEvent_PeerEventId_Name.");
   return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
-    PeersReply_PeerEvent_descriptor(), enum_t_value);
+    PeerEvent_PeerEventId_descriptor(), enum_t_value);
 }
-inline bool PeersReply_PeerEvent_Parse(
-    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, PeersReply_PeerEvent* value) {
-  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<PeersReply_PeerEvent>(
-    PeersReply_PeerEvent_descriptor(), name, value);
+inline bool PeerEvent_PeerEventId_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, PeerEvent_PeerEventId* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<PeerEvent_PeerEventId>(
+    PeerEvent_PeerEventId_descriptor(), name, value);
 }
 enum MessageId : int {
   STATUS_65 = 0,
@@ -236,12 +248,13 @@ inline bool PenaltyKind_Parse(
 enum Protocol : int {
   ETH65 = 0,
   ETH66 = 1,
+  ETH67 = 2,
   Protocol_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
   Protocol_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
 bool Protocol_IsValid(int value);
 constexpr Protocol Protocol_MIN = ETH65;
-constexpr Protocol Protocol_MAX = ETH66;
+constexpr Protocol Protocol_MAX = ETH67;
 constexpr int Protocol_ARRAYSIZE = Protocol_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* Protocol_descriptor();
@@ -2303,6 +2316,151 @@ class MessagesRequest PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class PeersReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeersReply) */ {
+ public:
+  inline PeersReply() : PeersReply(nullptr) {}
+  virtual ~PeersReply();
+
+  PeersReply(const PeersReply& from);
+  PeersReply(PeersReply&& from) noexcept
+    : PeersReply() {
+    *this = ::std::move(from);
+  }
+
+  inline PeersReply& operator=(const PeersReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PeersReply& operator=(PeersReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const PeersReply& default_instance();
+
+  static inline const PeersReply* internal_default_instance() {
+    return reinterpret_cast<const PeersReply*>(
+               &_PeersReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    13;
+
+  friend void swap(PeersReply& a, PeersReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PeersReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PeersReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PeersReply* New() const final {
+    return CreateMaybeMessage<PeersReply>(nullptr);
+  }
+
+  PeersReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeersReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const PeersReply& from);
+  void MergeFrom(const PeersReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PeersReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "sentry.PeersReply";
+  }
+  protected:
+  explicit PeersReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_p2psentry_2fsentry_2eproto);
+    return ::descriptor_table_p2psentry_2fsentry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPeersFieldNumber = 1,
+  };
+  // repeated .types.PeerInfo peers = 1;
+  int peers_size() const;
+  private:
+  int _internal_peers_size() const;
+  public:
+  void clear_peers();
+  ::types::PeerInfo* mutable_peers(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >*
+      mutable_peers();
+  private:
+  const ::types::PeerInfo& _internal_peers(int index) const;
+  ::types::PeerInfo* _internal_add_peers();
+  public:
+  const ::types::PeerInfo& peers(int index) const;
+  ::types::PeerInfo* add_peers();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >&
+      peers() const;
+
+  // @@protoc_insertion_point(class_scope:sentry.PeersReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo > peers_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_p2psentry_2fsentry_2eproto;
+};
+// -------------------------------------------------------------------
+
 class PeerCountRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeerCountRequest) */ {
  public:
@@ -2344,7 +2502,7 @@ class PeerCountRequest PROTOBUF_FINAL :
                &_PeerCountRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    14;
 
   friend void swap(PeerCountRequest& a, PeerCountRequest& b) {
     a.Swap(&b);
@@ -2467,7 +2625,7 @@ class PeerCountReply PROTOBUF_FINAL :
                &_PeerCountReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    15;
 
   friend void swap(PeerCountReply& a, PeerCountReply& b) {
     a.Swap(&b);
@@ -2562,23 +2720,23 @@ class PeerCountReply PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
-class PeersRequest PROTOBUF_FINAL :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeersRequest) */ {
+class PeerByIdRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeerByIdRequest) */ {
  public:
-  inline PeersRequest() : PeersRequest(nullptr) {}
-  virtual ~PeersRequest();
+  inline PeerByIdRequest() : PeerByIdRequest(nullptr) {}
+  virtual ~PeerByIdRequest();
 
-  PeersRequest(const PeersRequest& from);
-  PeersRequest(PeersRequest&& from) noexcept
-    : PeersRequest() {
+  PeerByIdRequest(const PeerByIdRequest& from);
+  PeerByIdRequest(PeerByIdRequest&& from) noexcept
+    : PeerByIdRequest() {
     *this = ::std::move(from);
   }
 
-  inline PeersRequest& operator=(const PeersRequest& from) {
+  inline PeerByIdRequest& operator=(const PeerByIdRequest& from) {
     CopyFrom(from);
     return *this;
   }
-  inline PeersRequest& operator=(PeersRequest&& from) noexcept {
+  inline PeerByIdRequest& operator=(PeerByIdRequest&& from) noexcept {
     if (GetArena() == from.GetArena()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -2596,142 +2754,19 @@ class PeersRequest PROTOBUF_FINAL :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return GetMetadataStatic().reflection;
   }
-  static const PeersRequest& default_instance();
+  static const PeerByIdRequest& default_instance();
 
-  static inline const PeersRequest* internal_default_instance() {
-    return reinterpret_cast<const PeersRequest*>(
-               &_PeersRequest_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    15;
-
-  friend void swap(PeersRequest& a, PeersRequest& b) {
-    a.Swap(&b);
-  }
-  inline void Swap(PeersRequest* other) {
-    if (other == this) return;
-    if (GetArena() == other->GetArena()) {
-      InternalSwap(other);
-    } else {
-      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(PeersRequest* other) {
-    if (other == this) return;
-    GOOGLE_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline PeersRequest* New() const final {
-    return CreateMaybeMessage<PeersRequest>(nullptr);
-  }
-
-  PeersRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<PeersRequest>(arena);
-  }
-  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
-  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
-  void CopyFrom(const PeersRequest& from);
-  void MergeFrom(const PeersRequest& from);
-  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
-  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
-      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  inline void SharedCtor();
-  inline void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(PeersRequest* other);
-  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
-  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "sentry.PeersRequest";
-  }
-  protected:
-  explicit PeersRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
-  private:
-  static void ArenaDtor(void* object);
-  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
-  public:
-
-  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
-  private:
-  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
-    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_p2psentry_2fsentry_2eproto);
-    return ::descriptor_table_p2psentry_2fsentry_2eproto.file_level_metadata[kIndexInFileMessages];
-  }
-
-  public:
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // @@protoc_insertion_point(class_scope:sentry.PeersRequest)
- private:
-  class _Internal;
-
-  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
-  typedef void InternalArenaConstructable_;
-  typedef void DestructorSkippable_;
-  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
-  friend struct ::TableStruct_p2psentry_2fsentry_2eproto;
-};
-// -------------------------------------------------------------------
-
-class PeersReply PROTOBUF_FINAL :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeersReply) */ {
- public:
-  inline PeersReply() : PeersReply(nullptr) {}
-  virtual ~PeersReply();
-
-  PeersReply(const PeersReply& from);
-  PeersReply(PeersReply&& from) noexcept
-    : PeersReply() {
-    *this = ::std::move(from);
-  }
-
-  inline PeersReply& operator=(const PeersReply& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline PeersReply& operator=(PeersReply&& from) noexcept {
-    if (GetArena() == from.GetArena()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
-    return GetMetadataStatic().descriptor;
-  }
-  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
-    return GetMetadataStatic().reflection;
-  }
-  static const PeersReply& default_instance();
-
-  static inline const PeersReply* internal_default_instance() {
-    return reinterpret_cast<const PeersReply*>(
-               &_PeersReply_default_instance_);
+  static inline const PeerByIdRequest* internal_default_instance() {
+    return reinterpret_cast<const PeerByIdRequest*>(
+               &_PeerByIdRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     16;
 
-  friend void swap(PeersReply& a, PeersReply& b) {
+  friend void swap(PeerByIdRequest& a, PeerByIdRequest& b) {
     a.Swap(&b);
   }
-  inline void Swap(PeersReply* other) {
+  inline void Swap(PeerByIdRequest* other) {
     if (other == this) return;
     if (GetArena() == other->GetArena()) {
       InternalSwap(other);
@@ -2739,7 +2774,7 @@ class PeersReply PROTOBUF_FINAL :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(PeersReply* other) {
+  void UnsafeArenaSwap(PeerByIdRequest* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetArena() == other->GetArena());
     InternalSwap(other);
@@ -2747,17 +2782,17 @@ class PeersReply PROTOBUF_FINAL :
 
   // implements Message ----------------------------------------------
 
-  inline PeersReply* New() const final {
-    return CreateMaybeMessage<PeersReply>(nullptr);
+  inline PeerByIdRequest* New() const final {
+    return CreateMaybeMessage<PeerByIdRequest>(nullptr);
   }
 
-  PeersReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
-    return CreateMaybeMessage<PeersReply>(arena);
+  PeerByIdRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeerByIdRequest>(arena);
   }
   void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
   void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
-  void CopyFrom(const PeersReply& from);
-  void MergeFrom(const PeersReply& from);
+  void CopyFrom(const PeerByIdRequest& from);
+  void MergeFrom(const PeerByIdRequest& from);
   PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
   bool IsInitialized() const final;
 
@@ -2771,13 +2806,13 @@ class PeersReply PROTOBUF_FINAL :
   inline void SharedCtor();
   inline void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(PeersReply* other);
+  void InternalSwap(PeerByIdRequest* other);
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "sentry.PeersReply";
+    return "sentry.PeerByIdRequest";
   }
   protected:
-  explicit PeersReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  explicit PeerByIdRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
   private:
   static void ArenaDtor(void* object);
   inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
@@ -2793,42 +2828,11 @@ class PeersReply PROTOBUF_FINAL :
   public:
 
   // nested types ----------------------------------------------------
-
-  typedef PeersReply_PeerEvent PeerEvent;
-  static constexpr PeerEvent Connect =
-    PeersReply_PeerEvent_Connect;
-  static constexpr PeerEvent Disconnect =
-    PeersReply_PeerEvent_Disconnect;
-  static inline bool PeerEvent_IsValid(int value) {
-    return PeersReply_PeerEvent_IsValid(value);
-  }
-  static constexpr PeerEvent PeerEvent_MIN =
-    PeersReply_PeerEvent_PeerEvent_MIN;
-  static constexpr PeerEvent PeerEvent_MAX =
-    PeersReply_PeerEvent_PeerEvent_MAX;
-  static constexpr int PeerEvent_ARRAYSIZE =
-    PeersReply_PeerEvent_PeerEvent_ARRAYSIZE;
-  static inline const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor*
-  PeerEvent_descriptor() {
-    return PeersReply_PeerEvent_descriptor();
-  }
-  template<typename T>
-  static inline const std::string& PeerEvent_Name(T enum_t_value) {
-    static_assert(::std::is_same<T, PeerEvent>::value ||
-      ::std::is_integral<T>::value,
-      "Incorrect type passed to function PeerEvent_Name.");
-    return PeersReply_PeerEvent_Name(enum_t_value);
-  }
-  static inline bool PeerEvent_Parse(::PROTOBUF_NAMESPACE_ID::ConstStringParam name,
-      PeerEvent* value) {
-    return PeersReply_PeerEvent_Parse(name, value);
-  }
 
   // accessors -------------------------------------------------------
 
   enum : int {
     kPeerIdFieldNumber = 1,
-    kEventFieldNumber = 2,
   };
   // .types.H512 peer_id = 1;
   bool has_peer_id() const;
@@ -2848,16 +2852,7 @@ class PeersReply PROTOBUF_FINAL :
       ::types::H512* peer_id);
   ::types::H512* unsafe_arena_release_peer_id();
 
-  // .sentry.PeersReply.PeerEvent event = 2;
-  void clear_event();
-  ::sentry::PeersReply_PeerEvent event() const;
-  void set_event(::sentry::PeersReply_PeerEvent value);
-  private:
-  ::sentry::PeersReply_PeerEvent _internal_event() const;
-  void _internal_set_event(::sentry::PeersReply_PeerEvent value);
-  public:
-
-  // @@protoc_insertion_point(class_scope:sentry.PeersReply)
+  // @@protoc_insertion_point(class_scope:sentry.PeerByIdRequest)
  private:
   class _Internal;
 
@@ -2865,7 +2860,461 @@ class PeersReply PROTOBUF_FINAL :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   ::types::H512* peer_id_;
-  int event_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_p2psentry_2fsentry_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PeerByIdReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeerByIdReply) */ {
+ public:
+  inline PeerByIdReply() : PeerByIdReply(nullptr) {}
+  virtual ~PeerByIdReply();
+
+  PeerByIdReply(const PeerByIdReply& from);
+  PeerByIdReply(PeerByIdReply&& from) noexcept
+    : PeerByIdReply() {
+    *this = ::std::move(from);
+  }
+
+  inline PeerByIdReply& operator=(const PeerByIdReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PeerByIdReply& operator=(PeerByIdReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const PeerByIdReply& default_instance();
+
+  static inline const PeerByIdReply* internal_default_instance() {
+    return reinterpret_cast<const PeerByIdReply*>(
+               &_PeerByIdReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    17;
+
+  friend void swap(PeerByIdReply& a, PeerByIdReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PeerByIdReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PeerByIdReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PeerByIdReply* New() const final {
+    return CreateMaybeMessage<PeerByIdReply>(nullptr);
+  }
+
+  PeerByIdReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeerByIdReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const PeerByIdReply& from);
+  void MergeFrom(const PeerByIdReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PeerByIdReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "sentry.PeerByIdReply";
+  }
+  protected:
+  explicit PeerByIdReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_p2psentry_2fsentry_2eproto);
+    return ::descriptor_table_p2psentry_2fsentry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPeerFieldNumber = 1,
+  };
+  // .types.PeerInfo peer = 1;
+  bool has_peer() const;
+  private:
+  bool _internal_has_peer() const;
+  public:
+  void clear_peer();
+  const ::types::PeerInfo& peer() const;
+  ::types::PeerInfo* release_peer();
+  ::types::PeerInfo* mutable_peer();
+  void set_allocated_peer(::types::PeerInfo* peer);
+  private:
+  const ::types::PeerInfo& _internal_peer() const;
+  ::types::PeerInfo* _internal_mutable_peer();
+  public:
+  void unsafe_arena_set_allocated_peer(
+      ::types::PeerInfo* peer);
+  ::types::PeerInfo* unsafe_arena_release_peer();
+
+  // @@protoc_insertion_point(class_scope:sentry.PeerByIdReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  ::types::PeerInfo* peer_;
+  friend struct ::TableStruct_p2psentry_2fsentry_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PeerEventsRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeerEventsRequest) */ {
+ public:
+  inline PeerEventsRequest() : PeerEventsRequest(nullptr) {}
+  virtual ~PeerEventsRequest();
+
+  PeerEventsRequest(const PeerEventsRequest& from);
+  PeerEventsRequest(PeerEventsRequest&& from) noexcept
+    : PeerEventsRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline PeerEventsRequest& operator=(const PeerEventsRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PeerEventsRequest& operator=(PeerEventsRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const PeerEventsRequest& default_instance();
+
+  static inline const PeerEventsRequest* internal_default_instance() {
+    return reinterpret_cast<const PeerEventsRequest*>(
+               &_PeerEventsRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    18;
+
+  friend void swap(PeerEventsRequest& a, PeerEventsRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PeerEventsRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PeerEventsRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PeerEventsRequest* New() const final {
+    return CreateMaybeMessage<PeerEventsRequest>(nullptr);
+  }
+
+  PeerEventsRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeerEventsRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const PeerEventsRequest& from);
+  void MergeFrom(const PeerEventsRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PeerEventsRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "sentry.PeerEventsRequest";
+  }
+  protected:
+  explicit PeerEventsRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_p2psentry_2fsentry_2eproto);
+    return ::descriptor_table_p2psentry_2fsentry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:sentry.PeerEventsRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_p2psentry_2fsentry_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PeerEvent PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:sentry.PeerEvent) */ {
+ public:
+  inline PeerEvent() : PeerEvent(nullptr) {}
+  virtual ~PeerEvent();
+
+  PeerEvent(const PeerEvent& from);
+  PeerEvent(PeerEvent&& from) noexcept
+    : PeerEvent() {
+    *this = ::std::move(from);
+  }
+
+  inline PeerEvent& operator=(const PeerEvent& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PeerEvent& operator=(PeerEvent&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const PeerEvent& default_instance();
+
+  static inline const PeerEvent* internal_default_instance() {
+    return reinterpret_cast<const PeerEvent*>(
+               &_PeerEvent_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    19;
+
+  friend void swap(PeerEvent& a, PeerEvent& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PeerEvent* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PeerEvent* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PeerEvent* New() const final {
+    return CreateMaybeMessage<PeerEvent>(nullptr);
+  }
+
+  PeerEvent* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeerEvent>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const PeerEvent& from);
+  void MergeFrom(const PeerEvent& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PeerEvent* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "sentry.PeerEvent";
+  }
+  protected:
+  explicit PeerEvent(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_p2psentry_2fsentry_2eproto);
+    return ::descriptor_table_p2psentry_2fsentry_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef PeerEvent_PeerEventId PeerEventId;
+  static constexpr PeerEventId Connect =
+    PeerEvent_PeerEventId_Connect;
+  static constexpr PeerEventId Disconnect =
+    PeerEvent_PeerEventId_Disconnect;
+  static inline bool PeerEventId_IsValid(int value) {
+    return PeerEvent_PeerEventId_IsValid(value);
+  }
+  static constexpr PeerEventId PeerEventId_MIN =
+    PeerEvent_PeerEventId_PeerEventId_MIN;
+  static constexpr PeerEventId PeerEventId_MAX =
+    PeerEvent_PeerEventId_PeerEventId_MAX;
+  static constexpr int PeerEventId_ARRAYSIZE =
+    PeerEvent_PeerEventId_PeerEventId_ARRAYSIZE;
+  static inline const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor*
+  PeerEventId_descriptor() {
+    return PeerEvent_PeerEventId_descriptor();
+  }
+  template<typename T>
+  static inline const std::string& PeerEventId_Name(T enum_t_value) {
+    static_assert(::std::is_same<T, PeerEventId>::value ||
+      ::std::is_integral<T>::value,
+      "Incorrect type passed to function PeerEventId_Name.");
+    return PeerEvent_PeerEventId_Name(enum_t_value);
+  }
+  static inline bool PeerEventId_Parse(::PROTOBUF_NAMESPACE_ID::ConstStringParam name,
+      PeerEventId* value) {
+    return PeerEvent_PeerEventId_Parse(name, value);
+  }
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPeerIdFieldNumber = 1,
+    kEventIdFieldNumber = 2,
+  };
+  // .types.H512 peer_id = 1;
+  bool has_peer_id() const;
+  private:
+  bool _internal_has_peer_id() const;
+  public:
+  void clear_peer_id();
+  const ::types::H512& peer_id() const;
+  ::types::H512* release_peer_id();
+  ::types::H512* mutable_peer_id();
+  void set_allocated_peer_id(::types::H512* peer_id);
+  private:
+  const ::types::H512& _internal_peer_id() const;
+  ::types::H512* _internal_mutable_peer_id();
+  public:
+  void unsafe_arena_set_allocated_peer_id(
+      ::types::H512* peer_id);
+  ::types::H512* unsafe_arena_release_peer_id();
+
+  // .sentry.PeerEvent.PeerEventId event_id = 2;
+  void clear_event_id();
+  ::sentry::PeerEvent_PeerEventId event_id() const;
+  void set_event_id(::sentry::PeerEvent_PeerEventId value);
+  private:
+  ::sentry::PeerEvent_PeerEventId _internal_event_id() const;
+  void _internal_set_event_id(::sentry::PeerEvent_PeerEventId value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:sentry.PeerEvent)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::types::H512* peer_id_;
+  int event_id_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_p2psentry_2fsentry_2eproto;
 };
@@ -4229,6 +4678,46 @@ MessagesRequest::mutable_ids() {
 
 // -------------------------------------------------------------------
 
+// PeersReply
+
+// repeated .types.PeerInfo peers = 1;
+inline int PeersReply::_internal_peers_size() const {
+  return peers_.size();
+}
+inline int PeersReply::peers_size() const {
+  return _internal_peers_size();
+}
+inline ::types::PeerInfo* PeersReply::mutable_peers(int index) {
+  // @@protoc_insertion_point(field_mutable:sentry.PeersReply.peers)
+  return peers_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >*
+PeersReply::mutable_peers() {
+  // @@protoc_insertion_point(field_mutable_list:sentry.PeersReply.peers)
+  return &peers_;
+}
+inline const ::types::PeerInfo& PeersReply::_internal_peers(int index) const {
+  return peers_.Get(index);
+}
+inline const ::types::PeerInfo& PeersReply::peers(int index) const {
+  // @@protoc_insertion_point(field_get:sentry.PeersReply.peers)
+  return _internal_peers(index);
+}
+inline ::types::PeerInfo* PeersReply::_internal_add_peers() {
+  return peers_.Add();
+}
+inline ::types::PeerInfo* PeersReply::add_peers() {
+  // @@protoc_insertion_point(field_add:sentry.PeersReply.peers)
+  return _internal_add_peers();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >&
+PeersReply::peers() const {
+  // @@protoc_insertion_point(field_list:sentry.PeersReply.peers)
+  return peers_;
+}
+
+// -------------------------------------------------------------------
+
 // PeerCountRequest
 
 // -------------------------------------------------------------------
@@ -4257,29 +4746,25 @@ inline void PeerCountReply::set_count(::PROTOBUF_NAMESPACE_ID::uint64 value) {
 
 // -------------------------------------------------------------------
 
-// PeersRequest
-
-// -------------------------------------------------------------------
-
-// PeersReply
+// PeerByIdRequest
 
 // .types.H512 peer_id = 1;
-inline bool PeersReply::_internal_has_peer_id() const {
+inline bool PeerByIdRequest::_internal_has_peer_id() const {
   return this != internal_default_instance() && peer_id_ != nullptr;
 }
-inline bool PeersReply::has_peer_id() const {
+inline bool PeerByIdRequest::has_peer_id() const {
   return _internal_has_peer_id();
 }
-inline const ::types::H512& PeersReply::_internal_peer_id() const {
+inline const ::types::H512& PeerByIdRequest::_internal_peer_id() const {
   const ::types::H512* p = peer_id_;
   return p != nullptr ? *p : reinterpret_cast<const ::types::H512&>(
       ::types::_H512_default_instance_);
 }
-inline const ::types::H512& PeersReply::peer_id() const {
-  // @@protoc_insertion_point(field_get:sentry.PeersReply.peer_id)
+inline const ::types::H512& PeerByIdRequest::peer_id() const {
+  // @@protoc_insertion_point(field_get:sentry.PeerByIdRequest.peer_id)
   return _internal_peer_id();
 }
-inline void PeersReply::unsafe_arena_set_allocated_peer_id(
+inline void PeerByIdRequest::unsafe_arena_set_allocated_peer_id(
     ::types::H512* peer_id) {
   if (GetArena() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
@@ -4290,9 +4775,9 @@ inline void PeersReply::unsafe_arena_set_allocated_peer_id(
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.PeersReply.peer_id)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.PeerByIdRequest.peer_id)
 }
-inline ::types::H512* PeersReply::release_peer_id() {
+inline ::types::H512* PeerByIdRequest::release_peer_id() {
   
   ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
@@ -4301,14 +4786,14 @@ inline ::types::H512* PeersReply::release_peer_id() {
   }
   return temp;
 }
-inline ::types::H512* PeersReply::unsafe_arena_release_peer_id() {
-  // @@protoc_insertion_point(field_release:sentry.PeersReply.peer_id)
+inline ::types::H512* PeerByIdRequest::unsafe_arena_release_peer_id() {
+  // @@protoc_insertion_point(field_release:sentry.PeerByIdRequest.peer_id)
   
   ::types::H512* temp = peer_id_;
   peer_id_ = nullptr;
   return temp;
 }
-inline ::types::H512* PeersReply::_internal_mutable_peer_id() {
+inline ::types::H512* PeerByIdRequest::_internal_mutable_peer_id() {
   
   if (peer_id_ == nullptr) {
     auto* p = CreateMaybeMessage<::types::H512>(GetArena());
@@ -4316,11 +4801,11 @@ inline ::types::H512* PeersReply::_internal_mutable_peer_id() {
   }
   return peer_id_;
 }
-inline ::types::H512* PeersReply::mutable_peer_id() {
-  // @@protoc_insertion_point(field_mutable:sentry.PeersReply.peer_id)
+inline ::types::H512* PeerByIdRequest::mutable_peer_id() {
+  // @@protoc_insertion_point(field_mutable:sentry.PeerByIdRequest.peer_id)
   return _internal_mutable_peer_id();
 }
-inline void PeersReply::set_allocated_peer_id(::types::H512* peer_id) {
+inline void PeerByIdRequest::set_allocated_peer_id(::types::H512* peer_id) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
   if (message_arena == nullptr) {
     delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
@@ -4337,32 +4822,206 @@ inline void PeersReply::set_allocated_peer_id(::types::H512* peer_id) {
     
   }
   peer_id_ = peer_id;
-  // @@protoc_insertion_point(field_set_allocated:sentry.PeersReply.peer_id)
+  // @@protoc_insertion_point(field_set_allocated:sentry.PeerByIdRequest.peer_id)
 }
 
-// .sentry.PeersReply.PeerEvent event = 2;
-inline void PeersReply::clear_event() {
-  event_ = 0;
+// -------------------------------------------------------------------
+
+// PeerByIdReply
+
+// .types.PeerInfo peer = 1;
+inline bool PeerByIdReply::_internal_has_peer() const {
+  bool value = (_has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || peer_ != nullptr);
+  return value;
 }
-inline ::sentry::PeersReply_PeerEvent PeersReply::_internal_event() const {
-  return static_cast< ::sentry::PeersReply_PeerEvent >(event_);
+inline bool PeerByIdReply::has_peer() const {
+  return _internal_has_peer();
 }
-inline ::sentry::PeersReply_PeerEvent PeersReply::event() const {
-  // @@protoc_insertion_point(field_get:sentry.PeersReply.event)
-  return _internal_event();
+inline const ::types::PeerInfo& PeerByIdReply::_internal_peer() const {
+  const ::types::PeerInfo* p = peer_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::PeerInfo&>(
+      ::types::_PeerInfo_default_instance_);
 }
-inline void PeersReply::_internal_set_event(::sentry::PeersReply_PeerEvent value) {
+inline const ::types::PeerInfo& PeerByIdReply::peer() const {
+  // @@protoc_insertion_point(field_get:sentry.PeerByIdReply.peer)
+  return _internal_peer();
+}
+inline void PeerByIdReply::unsafe_arena_set_allocated_peer(
+    ::types::PeerInfo* peer) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_);
+  }
+  peer_ = peer;
+  if (peer) {
+    _has_bits_[0] |= 0x00000001u;
+  } else {
+    _has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.PeerByIdReply.peer)
+}
+inline ::types::PeerInfo* PeerByIdReply::release_peer() {
+  _has_bits_[0] &= ~0x00000001u;
+  ::types::PeerInfo* temp = peer_;
+  peer_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::PeerInfo* PeerByIdReply::unsafe_arena_release_peer() {
+  // @@protoc_insertion_point(field_release:sentry.PeerByIdReply.peer)
+  _has_bits_[0] &= ~0x00000001u;
+  ::types::PeerInfo* temp = peer_;
+  peer_ = nullptr;
+  return temp;
+}
+inline ::types::PeerInfo* PeerByIdReply::_internal_mutable_peer() {
+  _has_bits_[0] |= 0x00000001u;
+  if (peer_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::PeerInfo>(GetArena());
+    peer_ = p;
+  }
+  return peer_;
+}
+inline ::types::PeerInfo* PeerByIdReply::mutable_peer() {
+  // @@protoc_insertion_point(field_mutable:sentry.PeerByIdReply.peer)
+  return _internal_mutable_peer();
+}
+inline void PeerByIdReply::set_allocated_peer(::types::PeerInfo* peer) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_);
+  }
+  if (peer) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer)->GetArena();
+    if (message_arena != submessage_arena) {
+      peer = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, peer, submessage_arena);
+    }
+    _has_bits_[0] |= 0x00000001u;
+  } else {
+    _has_bits_[0] &= ~0x00000001u;
+  }
+  peer_ = peer;
+  // @@protoc_insertion_point(field_set_allocated:sentry.PeerByIdReply.peer)
+}
+
+// -------------------------------------------------------------------
+
+// PeerEventsRequest
+
+// -------------------------------------------------------------------
+
+// PeerEvent
+
+// .types.H512 peer_id = 1;
+inline bool PeerEvent::_internal_has_peer_id() const {
+  return this != internal_default_instance() && peer_id_ != nullptr;
+}
+inline bool PeerEvent::has_peer_id() const {
+  return _internal_has_peer_id();
+}
+inline const ::types::H512& PeerEvent::_internal_peer_id() const {
+  const ::types::H512* p = peer_id_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H512&>(
+      ::types::_H512_default_instance_);
+}
+inline const ::types::H512& PeerEvent::peer_id() const {
+  // @@protoc_insertion_point(field_get:sentry.PeerEvent.peer_id)
+  return _internal_peer_id();
+}
+inline void PeerEvent::unsafe_arena_set_allocated_peer_id(
+    ::types::H512* peer_id) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
+  }
+  peer_id_ = peer_id;
+  if (peer_id) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sentry.PeerEvent.peer_id)
+}
+inline ::types::H512* PeerEvent::release_peer_id() {
   
-  event_ = value;
+  ::types::H512* temp = peer_id_;
+  peer_id_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
 }
-inline void PeersReply::set_event(::sentry::PeersReply_PeerEvent value) {
-  _internal_set_event(value);
-  // @@protoc_insertion_point(field_set:sentry.PeersReply.event)
+inline ::types::H512* PeerEvent::unsafe_arena_release_peer_id() {
+  // @@protoc_insertion_point(field_release:sentry.PeerEvent.peer_id)
+  
+  ::types::H512* temp = peer_id_;
+  peer_id_ = nullptr;
+  return temp;
+}
+inline ::types::H512* PeerEvent::_internal_mutable_peer_id() {
+  
+  if (peer_id_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H512>(GetArena());
+    peer_id_ = p;
+  }
+  return peer_id_;
+}
+inline ::types::H512* PeerEvent::mutable_peer_id() {
+  // @@protoc_insertion_point(field_mutable:sentry.PeerEvent.peer_id)
+  return _internal_mutable_peer_id();
+}
+inline void PeerEvent::set_allocated_peer_id(::types::H512* peer_id) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id_);
+  }
+  if (peer_id) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(peer_id)->GetArena();
+    if (message_arena != submessage_arena) {
+      peer_id = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, peer_id, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  peer_id_ = peer_id;
+  // @@protoc_insertion_point(field_set_allocated:sentry.PeerEvent.peer_id)
+}
+
+// .sentry.PeerEvent.PeerEventId event_id = 2;
+inline void PeerEvent::clear_event_id() {
+  event_id_ = 0;
+}
+inline ::sentry::PeerEvent_PeerEventId PeerEvent::_internal_event_id() const {
+  return static_cast< ::sentry::PeerEvent_PeerEventId >(event_id_);
+}
+inline ::sentry::PeerEvent_PeerEventId PeerEvent::event_id() const {
+  // @@protoc_insertion_point(field_get:sentry.PeerEvent.event_id)
+  return _internal_event_id();
+}
+inline void PeerEvent::_internal_set_event_id(::sentry::PeerEvent_PeerEventId value) {
+  
+  event_id_ = value;
+}
+inline void PeerEvent::set_event_id(::sentry::PeerEvent_PeerEventId value) {
+  _internal_set_event_id(value);
+  // @@protoc_insertion_point(field_set:sentry.PeerEvent.event_id)
 }
 
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -4402,10 +5061,10 @@ inline void PeersReply::set_event(::sentry::PeersReply_PeerEvent value) {
 
 PROTOBUF_NAMESPACE_OPEN
 
-template <> struct is_proto_enum< ::sentry::PeersReply_PeerEvent> : ::std::true_type {};
+template <> struct is_proto_enum< ::sentry::PeerEvent_PeerEventId> : ::std::true_type {};
 template <>
-inline const EnumDescriptor* GetEnumDescriptor< ::sentry::PeersReply_PeerEvent>() {
-  return ::sentry::PeersReply_PeerEvent_descriptor();
+inline const EnumDescriptor* GetEnumDescriptor< ::sentry::PeerEvent_PeerEventId>() {
+  return ::sentry::PeerEvent_PeerEventId_descriptor();
 }
 template <> struct is_proto_enum< ::sentry::MessageId> : ::std::true_type {};
 template <>

--- a/interfaces/remote/ethbackend.grpc.pb.cc
+++ b/interfaces/remote/ethbackend.grpc.pb.cc
@@ -25,11 +25,18 @@ static const char* ETHBACKEND_method_names[] = {
   "/remote.ETHBACKEND/Etherbase",
   "/remote.ETHBACKEND/NetVersion",
   "/remote.ETHBACKEND/NetPeerCount",
+  "/remote.ETHBACKEND/EngineGetPayloadV1",
+  "/remote.ETHBACKEND/EngineNewPayloadV1",
+  "/remote.ETHBACKEND/EngineForkChoiceUpdatedV1",
   "/remote.ETHBACKEND/Version",
   "/remote.ETHBACKEND/ProtocolVersion",
   "/remote.ETHBACKEND/ClientVersion",
   "/remote.ETHBACKEND/Subscribe",
+  "/remote.ETHBACKEND/SubscribeLogs",
+  "/remote.ETHBACKEND/Block",
+  "/remote.ETHBACKEND/TxnLookup",
   "/remote.ETHBACKEND/NodeInfo",
+  "/remote.ETHBACKEND/Peers",
 };
 
 std::unique_ptr< ETHBACKEND::Stub> ETHBACKEND::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -42,11 +49,18 @@ ETHBACKEND::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel
   : channel_(channel), rpcmethod_Etherbase_(ETHBACKEND_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_NetVersion_(ETHBACKEND_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_NetPeerCount_(ETHBACKEND_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Version_(ETHBACKEND_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ProtocolVersion_(ETHBACKEND_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ClientVersion_(ETHBACKEND_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Subscribe_(ETHBACKEND_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_NodeInfo_(ETHBACKEND_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_EngineGetPayloadV1_(ETHBACKEND_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_EngineNewPayloadV1_(ETHBACKEND_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_EngineForkChoiceUpdatedV1_(ETHBACKEND_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Version_(ETHBACKEND_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ProtocolVersion_(ETHBACKEND_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ClientVersion_(ETHBACKEND_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Subscribe_(ETHBACKEND_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeLogs_(ETHBACKEND_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::BIDI_STREAMING, channel)
+  , rpcmethod_Block_(ETHBACKEND_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_TxnLookup_(ETHBACKEND_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_NodeInfo_(ETHBACKEND_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Peers_(ETHBACKEND_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status ETHBACKEND::Stub::Etherbase(::grpc::ClientContext* context, const ::remote::EtherbaseRequest& request, ::remote::EtherbaseReply* response) {
@@ -114,6 +128,75 @@ void ETHBACKEND::Stub::async::NetPeerCount(::grpc::ClientContext* context, const
 ::grpc::ClientAsyncResponseReader< ::remote::NetPeerCountReply>* ETHBACKEND::Stub::AsyncNetPeerCountRaw(::grpc::ClientContext* context, const ::remote::NetPeerCountRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncNetPeerCountRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ETHBACKEND::Stub::EngineGetPayloadV1(::grpc::ClientContext* context, const ::remote::EngineGetPayloadRequest& request, ::types::ExecutionPayload* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::EngineGetPayloadRequest, ::types::ExecutionPayload, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_EngineGetPayloadV1_, context, request, response);
+}
+
+void ETHBACKEND::Stub::async::EngineGetPayloadV1(::grpc::ClientContext* context, const ::remote::EngineGetPayloadRequest* request, ::types::ExecutionPayload* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::EngineGetPayloadRequest, ::types::ExecutionPayload, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_EngineGetPayloadV1_, context, request, response, std::move(f));
+}
+
+void ETHBACKEND::Stub::async::EngineGetPayloadV1(::grpc::ClientContext* context, const ::remote::EngineGetPayloadRequest* request, ::types::ExecutionPayload* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_EngineGetPayloadV1_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::types::ExecutionPayload>* ETHBACKEND::Stub::PrepareAsyncEngineGetPayloadV1Raw(::grpc::ClientContext* context, const ::remote::EngineGetPayloadRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::types::ExecutionPayload, ::remote::EngineGetPayloadRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_EngineGetPayloadV1_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::types::ExecutionPayload>* ETHBACKEND::Stub::AsyncEngineGetPayloadV1Raw(::grpc::ClientContext* context, const ::remote::EngineGetPayloadRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncEngineGetPayloadV1Raw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ETHBACKEND::Stub::EngineNewPayloadV1(::grpc::ClientContext* context, const ::types::ExecutionPayload& request, ::remote::EnginePayloadStatus* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::types::ExecutionPayload, ::remote::EnginePayloadStatus, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_EngineNewPayloadV1_, context, request, response);
+}
+
+void ETHBACKEND::Stub::async::EngineNewPayloadV1(::grpc::ClientContext* context, const ::types::ExecutionPayload* request, ::remote::EnginePayloadStatus* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::types::ExecutionPayload, ::remote::EnginePayloadStatus, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_EngineNewPayloadV1_, context, request, response, std::move(f));
+}
+
+void ETHBACKEND::Stub::async::EngineNewPayloadV1(::grpc::ClientContext* context, const ::types::ExecutionPayload* request, ::remote::EnginePayloadStatus* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_EngineNewPayloadV1_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::EnginePayloadStatus>* ETHBACKEND::Stub::PrepareAsyncEngineNewPayloadV1Raw(::grpc::ClientContext* context, const ::types::ExecutionPayload& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::EnginePayloadStatus, ::types::ExecutionPayload, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_EngineNewPayloadV1_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::EnginePayloadStatus>* ETHBACKEND::Stub::AsyncEngineNewPayloadV1Raw(::grpc::ClientContext* context, const ::types::ExecutionPayload& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncEngineNewPayloadV1Raw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ETHBACKEND::Stub::EngineForkChoiceUpdatedV1(::grpc::ClientContext* context, const ::remote::EngineForkChoiceUpdatedRequest& request, ::remote::EngineForkChoiceUpdatedReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::EngineForkChoiceUpdatedRequest, ::remote::EngineForkChoiceUpdatedReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_EngineForkChoiceUpdatedV1_, context, request, response);
+}
+
+void ETHBACKEND::Stub::async::EngineForkChoiceUpdatedV1(::grpc::ClientContext* context, const ::remote::EngineForkChoiceUpdatedRequest* request, ::remote::EngineForkChoiceUpdatedReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::EngineForkChoiceUpdatedRequest, ::remote::EngineForkChoiceUpdatedReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_EngineForkChoiceUpdatedV1_, context, request, response, std::move(f));
+}
+
+void ETHBACKEND::Stub::async::EngineForkChoiceUpdatedV1(::grpc::ClientContext* context, const ::remote::EngineForkChoiceUpdatedRequest* request, ::remote::EngineForkChoiceUpdatedReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_EngineForkChoiceUpdatedV1_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::EngineForkChoiceUpdatedReply>* ETHBACKEND::Stub::PrepareAsyncEngineForkChoiceUpdatedV1Raw(::grpc::ClientContext* context, const ::remote::EngineForkChoiceUpdatedRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::EngineForkChoiceUpdatedReply, ::remote::EngineForkChoiceUpdatedRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_EngineForkChoiceUpdatedV1_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::EngineForkChoiceUpdatedReply>* ETHBACKEND::Stub::AsyncEngineForkChoiceUpdatedV1Raw(::grpc::ClientContext* context, const ::remote::EngineForkChoiceUpdatedRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncEngineForkChoiceUpdatedV1Raw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -203,6 +286,68 @@ void ETHBACKEND::Stub::async::Subscribe(::grpc::ClientContext* context, const ::
   return ::grpc::internal::ClientAsyncReaderFactory< ::remote::SubscribeReply>::Create(channel_.get(), cq, rpcmethod_Subscribe_, context, request, false, nullptr);
 }
 
+::grpc::ClientReaderWriter< ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>* ETHBACKEND::Stub::SubscribeLogsRaw(::grpc::ClientContext* context) {
+  return ::grpc::internal::ClientReaderWriterFactory< ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>::Create(channel_.get(), rpcmethod_SubscribeLogs_, context);
+}
+
+void ETHBACKEND::Stub::async::SubscribeLogs(::grpc::ClientContext* context, ::grpc::ClientBidiReactor< ::remote::LogsFilterRequest,::remote::SubscribeLogsReply>* reactor) {
+  ::grpc::internal::ClientCallbackReaderWriterFactory< ::remote::LogsFilterRequest,::remote::SubscribeLogsReply>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeLogs_, context, reactor);
+}
+
+::grpc::ClientAsyncReaderWriter< ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>* ETHBACKEND::Stub::AsyncSubscribeLogsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>::Create(channel_.get(), cq, rpcmethod_SubscribeLogs_, context, true, tag);
+}
+
+::grpc::ClientAsyncReaderWriter< ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>* ETHBACKEND::Stub::PrepareAsyncSubscribeLogsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>::Create(channel_.get(), cq, rpcmethod_SubscribeLogs_, context, false, nullptr);
+}
+
+::grpc::Status ETHBACKEND::Stub::Block(::grpc::ClientContext* context, const ::remote::BlockRequest& request, ::remote::BlockReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::BlockRequest, ::remote::BlockReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_Block_, context, request, response);
+}
+
+void ETHBACKEND::Stub::async::Block(::grpc::ClientContext* context, const ::remote::BlockRequest* request, ::remote::BlockReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::BlockRequest, ::remote::BlockReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Block_, context, request, response, std::move(f));
+}
+
+void ETHBACKEND::Stub::async::Block(::grpc::ClientContext* context, const ::remote::BlockRequest* request, ::remote::BlockReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Block_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::BlockReply>* ETHBACKEND::Stub::PrepareAsyncBlockRaw(::grpc::ClientContext* context, const ::remote::BlockRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::BlockReply, ::remote::BlockRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_Block_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::BlockReply>* ETHBACKEND::Stub::AsyncBlockRaw(::grpc::ClientContext* context, const ::remote::BlockRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncBlockRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ETHBACKEND::Stub::TxnLookup(::grpc::ClientContext* context, const ::remote::TxnLookupRequest& request, ::remote::TxnLookupReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::TxnLookupRequest, ::remote::TxnLookupReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_TxnLookup_, context, request, response);
+}
+
+void ETHBACKEND::Stub::async::TxnLookup(::grpc::ClientContext* context, const ::remote::TxnLookupRequest* request, ::remote::TxnLookupReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::TxnLookupRequest, ::remote::TxnLookupReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_TxnLookup_, context, request, response, std::move(f));
+}
+
+void ETHBACKEND::Stub::async::TxnLookup(::grpc::ClientContext* context, const ::remote::TxnLookupRequest* request, ::remote::TxnLookupReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_TxnLookup_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::TxnLookupReply>* ETHBACKEND::Stub::PrepareAsyncTxnLookupRaw(::grpc::ClientContext* context, const ::remote::TxnLookupRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::TxnLookupReply, ::remote::TxnLookupRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_TxnLookup_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::TxnLookupReply>* ETHBACKEND::Stub::AsyncTxnLookupRaw(::grpc::ClientContext* context, const ::remote::TxnLookupRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncTxnLookupRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ::grpc::Status ETHBACKEND::Stub::NodeInfo(::grpc::ClientContext* context, const ::remote::NodesInfoRequest& request, ::remote::NodesInfoReply* response) {
   return ::grpc::internal::BlockingUnaryCall< ::remote::NodesInfoRequest, ::remote::NodesInfoReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_NodeInfo_, context, request, response);
 }
@@ -222,6 +367,29 @@ void ETHBACKEND::Stub::async::NodeInfo(::grpc::ClientContext* context, const ::r
 ::grpc::ClientAsyncResponseReader< ::remote::NodesInfoReply>* ETHBACKEND::Stub::AsyncNodeInfoRaw(::grpc::ClientContext* context, const ::remote::NodesInfoRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncNodeInfoRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status ETHBACKEND::Stub::Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::remote::PeersReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::google::protobuf::Empty, ::remote::PeersReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_Peers_, context, request, response);
+}
+
+void ETHBACKEND::Stub::async::Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::remote::PeersReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::google::protobuf::Empty, ::remote::PeersReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Peers_, context, request, response, std::move(f));
+}
+
+void ETHBACKEND::Stub::async::Peers(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::remote::PeersReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Peers_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::PeersReply>* ETHBACKEND::Stub::PrepareAsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::PeersReply, ::google::protobuf::Empty, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_Peers_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::remote::PeersReply>* ETHBACKEND::Stub::AsyncPeersRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncPeersRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -260,6 +428,36 @@ ETHBACKEND::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       ETHBACKEND_method_names[3],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::EngineGetPayloadRequest, ::types::ExecutionPayload, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::remote::EngineGetPayloadRequest* req,
+             ::types::ExecutionPayload* resp) {
+               return service->EngineGetPayloadV1(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[4],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::types::ExecutionPayload, ::remote::EnginePayloadStatus, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::types::ExecutionPayload* req,
+             ::remote::EnginePayloadStatus* resp) {
+               return service->EngineNewPayloadV1(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[5],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::EngineForkChoiceUpdatedRequest, ::remote::EngineForkChoiceUpdatedReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::remote::EngineForkChoiceUpdatedRequest* req,
+             ::remote::EngineForkChoiceUpdatedReply* resp) {
+               return service->EngineForkChoiceUpdatedV1(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[6],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::google::protobuf::Empty, ::types::VersionReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ETHBACKEND::Service* service,
              ::grpc::ServerContext* ctx,
@@ -268,7 +466,7 @@ ETHBACKEND::Service::Service() {
                return service->Version(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ETHBACKEND_method_names[4],
+      ETHBACKEND_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::ProtocolVersionRequest, ::remote::ProtocolVersionReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ETHBACKEND::Service* service,
@@ -278,7 +476,7 @@ ETHBACKEND::Service::Service() {
                return service->ProtocolVersion(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ETHBACKEND_method_names[5],
+      ETHBACKEND_method_names[8],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::ClientVersionRequest, ::remote::ClientVersionReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ETHBACKEND::Service* service,
@@ -288,7 +486,7 @@ ETHBACKEND::Service::Service() {
                return service->ClientVersion(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ETHBACKEND_method_names[6],
+      ETHBACKEND_method_names[9],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< ETHBACKEND::Service, ::remote::SubscribeRequest, ::remote::SubscribeReply>(
           [](ETHBACKEND::Service* service,
@@ -298,7 +496,37 @@ ETHBACKEND::Service::Service() {
                return service->Subscribe(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      ETHBACKEND_method_names[7],
+      ETHBACKEND_method_names[10],
+      ::grpc::internal::RpcMethod::BIDI_STREAMING,
+      new ::grpc::internal::BidiStreamingHandler< ETHBACKEND::Service, ::remote::LogsFilterRequest, ::remote::SubscribeLogsReply>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             ::grpc::ServerReaderWriter<::remote::SubscribeLogsReply,
+             ::remote::LogsFilterRequest>* stream) {
+               return service->SubscribeLogs(ctx, stream);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[11],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::BlockRequest, ::remote::BlockReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::remote::BlockRequest* req,
+             ::remote::BlockReply* resp) {
+               return service->Block(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[12],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::TxnLookupRequest, ::remote::TxnLookupReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::remote::TxnLookupRequest* req,
+             ::remote::TxnLookupReply* resp) {
+               return service->TxnLookup(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::remote::NodesInfoRequest, ::remote::NodesInfoReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](ETHBACKEND::Service* service,
@@ -306,6 +534,16 @@ ETHBACKEND::Service::Service() {
              const ::remote::NodesInfoRequest* req,
              ::remote::NodesInfoReply* resp) {
                return service->NodeInfo(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      ETHBACKEND_method_names[14],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< ETHBACKEND::Service, ::google::protobuf::Empty, ::remote::PeersReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](ETHBACKEND::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::google::protobuf::Empty* req,
+             ::remote::PeersReply* resp) {
+               return service->Peers(ctx, req, resp);
              }, this)));
 }
 
@@ -327,6 +565,27 @@ ETHBACKEND::Service::~Service() {
 }
 
 ::grpc::Status ETHBACKEND::Service::NetPeerCount(::grpc::ServerContext* context, const ::remote::NetPeerCountRequest* request, ::remote::NetPeerCountReply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ETHBACKEND::Service::EngineGetPayloadV1(::grpc::ServerContext* context, const ::remote::EngineGetPayloadRequest* request, ::types::ExecutionPayload* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ETHBACKEND::Service::EngineNewPayloadV1(::grpc::ServerContext* context, const ::types::ExecutionPayload* request, ::remote::EnginePayloadStatus* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ETHBACKEND::Service::EngineForkChoiceUpdatedV1(::grpc::ServerContext* context, const ::remote::EngineForkChoiceUpdatedRequest* request, ::remote::EngineForkChoiceUpdatedReply* response) {
   (void) context;
   (void) request;
   (void) response;
@@ -361,7 +620,34 @@ ETHBACKEND::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
+::grpc::Status ETHBACKEND::Service::SubscribeLogs(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::remote::SubscribeLogsReply, ::remote::LogsFilterRequest>* stream) {
+  (void) context;
+  (void) stream;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ETHBACKEND::Service::Block(::grpc::ServerContext* context, const ::remote::BlockRequest* request, ::remote::BlockReply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ETHBACKEND::Service::TxnLookup(::grpc::ServerContext* context, const ::remote::TxnLookupRequest* request, ::remote::TxnLookupReply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
 ::grpc::Status ETHBACKEND::Service::NodeInfo(::grpc::ServerContext* context, const ::remote::NodesInfoRequest* request, ::remote::NodesInfoReply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status ETHBACKEND::Service::Peers(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::remote::PeersReply* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/interfaces/remote/ethbackend.pb.cc
+++ b/interfaces/remote/ethbackend.pb.cc
@@ -14,8 +14,13 @@
 #include <google/protobuf/wire_format.h>
 // @@protoc_insertion_point(includes)
 #include <google/protobuf/port_def.inc>
+extern PROTOBUF_INTERNAL_EXPORT_remote_2fethbackend_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_EngineForkChoiceState_remote_2fethbackend_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_remote_2fethbackend_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_remote_2fethbackend_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_EnginePayloadStatus_remote_2fethbackend_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H160_types_2ftypes_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H256_types_2ftypes_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_NodeInfoReply_types_2ftypes_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_PeerInfo_types_2ftypes_2eproto;
 namespace remote {
 class EtherbaseRequestDefaultTypeInternal {
  public:
@@ -41,6 +46,30 @@ class NetPeerCountReplyDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<NetPeerCountReply> _instance;
 } _NetPeerCountReply_default_instance_;
+class EngineGetPayloadRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EngineGetPayloadRequest> _instance;
+} _EngineGetPayloadRequest_default_instance_;
+class EnginePayloadStatusDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EnginePayloadStatus> _instance;
+} _EnginePayloadStatus_default_instance_;
+class EnginePayloadAttributesDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EnginePayloadAttributes> _instance;
+} _EnginePayloadAttributes_default_instance_;
+class EngineForkChoiceStateDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EngineForkChoiceState> _instance;
+} _EngineForkChoiceState_default_instance_;
+class EngineForkChoiceUpdatedRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EngineForkChoiceUpdatedRequest> _instance;
+} _EngineForkChoiceUpdatedRequest_default_instance_;
+class EngineForkChoiceUpdatedReplyDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EngineForkChoiceUpdatedReply> _instance;
+} _EngineForkChoiceUpdatedReply_default_instance_;
 class ProtocolVersionRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ProtocolVersionRequest> _instance;
@@ -65,6 +94,30 @@ class SubscribeReplyDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SubscribeReply> _instance;
 } _SubscribeReply_default_instance_;
+class LogsFilterRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<LogsFilterRequest> _instance;
+} _LogsFilterRequest_default_instance_;
+class SubscribeLogsReplyDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SubscribeLogsReply> _instance;
+} _SubscribeLogsReply_default_instance_;
+class BlockRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<BlockRequest> _instance;
+} _BlockRequest_default_instance_;
+class BlockReplyDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<BlockReply> _instance;
+} _BlockReply_default_instance_;
+class TxnLookupRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TxnLookupRequest> _instance;
+} _TxnLookupRequest_default_instance_;
+class TxnLookupReplyDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<TxnLookupReply> _instance;
+} _TxnLookupReply_default_instance_;
 class NodesInfoRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<NodesInfoRequest> _instance;
@@ -73,7 +126,38 @@ class NodesInfoReplyDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<NodesInfoReply> _instance;
 } _NodesInfoReply_default_instance_;
+class PeersReplyDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeersReply> _instance;
+} _PeersReply_default_instance_;
 }  // namespace remote
+static void InitDefaultsscc_info_BlockReply_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_BlockReply_default_instance_;
+    new (ptr) ::remote::BlockReply();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_BlockReply_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_BlockReply_remote_2fethbackend_2eproto}, {}};
+
+static void InitDefaultsscc_info_BlockRequest_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_BlockRequest_default_instance_;
+    new (ptr) ::remote::BlockRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_BlockRequest_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_BlockRequest_remote_2fethbackend_2eproto}, {
+      &scc_info_H256_types_2ftypes_2eproto.base,}};
+
 static void InitDefaultsscc_info_ClientVersionReply_remote_2fethbackend_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -99,6 +183,91 @@ static void InitDefaultsscc_info_ClientVersionRequest_remote_2fethbackend_2eprot
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_ClientVersionRequest_remote_2fethbackend_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_ClientVersionRequest_remote_2fethbackend_2eproto}, {}};
+
+static void InitDefaultsscc_info_EngineForkChoiceState_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_EngineForkChoiceState_default_instance_;
+    new (ptr) ::remote::EngineForkChoiceState();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_EngineForkChoiceState_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_EngineForkChoiceState_remote_2fethbackend_2eproto}, {
+      &scc_info_H256_types_2ftypes_2eproto.base,}};
+
+static void InitDefaultsscc_info_EngineForkChoiceUpdatedReply_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_EngineForkChoiceUpdatedReply_default_instance_;
+    new (ptr) ::remote::EngineForkChoiceUpdatedReply();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_EngineForkChoiceUpdatedReply_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_EngineForkChoiceUpdatedReply_remote_2fethbackend_2eproto}, {
+      &scc_info_EnginePayloadStatus_remote_2fethbackend_2eproto.base,}};
+
+static void InitDefaultsscc_info_EngineForkChoiceUpdatedRequest_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_EngineForkChoiceUpdatedRequest_default_instance_;
+    new (ptr) ::remote::EngineForkChoiceUpdatedRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_EngineForkChoiceUpdatedRequest_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_EngineForkChoiceUpdatedRequest_remote_2fethbackend_2eproto}, {
+      &scc_info_EngineForkChoiceState_remote_2fethbackend_2eproto.base,
+      &scc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto.base,}};
+
+static void InitDefaultsscc_info_EngineGetPayloadRequest_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_EngineGetPayloadRequest_default_instance_;
+    new (ptr) ::remote::EngineGetPayloadRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_EngineGetPayloadRequest_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_EngineGetPayloadRequest_remote_2fethbackend_2eproto}, {}};
+
+static void InitDefaultsscc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_EnginePayloadAttributes_default_instance_;
+    new (ptr) ::remote::EnginePayloadAttributes();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto}, {
+      &scc_info_H256_types_2ftypes_2eproto.base,
+      &scc_info_H160_types_2ftypes_2eproto.base,}};
+
+static void InitDefaultsscc_info_EnginePayloadStatus_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_EnginePayloadStatus_default_instance_;
+    new (ptr) ::remote::EnginePayloadStatus();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_EnginePayloadStatus_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_EnginePayloadStatus_remote_2fethbackend_2eproto}, {
+      &scc_info_H256_types_2ftypes_2eproto.base,}};
 
 static void InitDefaultsscc_info_EtherbaseReply_remote_2fethbackend_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -126,6 +295,21 @@ static void InitDefaultsscc_info_EtherbaseRequest_remote_2fethbackend_2eproto() 
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_EtherbaseRequest_remote_2fethbackend_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_EtherbaseRequest_remote_2fethbackend_2eproto}, {}};
+
+static void InitDefaultsscc_info_LogsFilterRequest_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_LogsFilterRequest_default_instance_;
+    new (ptr) ::remote::LogsFilterRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_LogsFilterRequest_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_LogsFilterRequest_remote_2fethbackend_2eproto}, {
+      &scc_info_H160_types_2ftypes_2eproto.base,
+      &scc_info_H256_types_2ftypes_2eproto.base,}};
 
 static void InitDefaultsscc_info_NetPeerCountReply_remote_2fethbackend_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -206,6 +390,20 @@ static void InitDefaultsscc_info_NodesInfoRequest_remote_2fethbackend_2eproto() 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_NodesInfoRequest_remote_2fethbackend_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_NodesInfoRequest_remote_2fethbackend_2eproto}, {}};
 
+static void InitDefaultsscc_info_PeersReply_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_PeersReply_default_instance_;
+    new (ptr) ::remote::PeersReply();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_PeersReply_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_PeersReply_remote_2fethbackend_2eproto}, {
+      &scc_info_PeerInfo_types_2ftypes_2eproto.base,}};
+
 static void InitDefaultsscc_info_ProtocolVersionReply_remote_2fethbackend_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -231,6 +429,21 @@ static void InitDefaultsscc_info_ProtocolVersionRequest_remote_2fethbackend_2epr
 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_ProtocolVersionRequest_remote_2fethbackend_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_ProtocolVersionRequest_remote_2fethbackend_2eproto}, {}};
+
+static void InitDefaultsscc_info_SubscribeLogsReply_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_SubscribeLogsReply_default_instance_;
+    new (ptr) ::remote::SubscribeLogsReply();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<2> scc_info_SubscribeLogsReply_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 2, 0, InitDefaultsscc_info_SubscribeLogsReply_remote_2fethbackend_2eproto}, {
+      &scc_info_H160_types_2ftypes_2eproto.base,
+      &scc_info_H256_types_2ftypes_2eproto.base,}};
 
 static void InitDefaultsscc_info_SubscribeReply_remote_2fethbackend_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -258,8 +471,35 @@ static void InitDefaultsscc_info_SubscribeRequest_remote_2fethbackend_2eproto() 
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_SubscribeRequest_remote_2fethbackend_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_SubscribeRequest_remote_2fethbackend_2eproto}, {}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_remote_2fethbackend_2eproto[14];
-static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_remote_2fethbackend_2eproto[1];
+static void InitDefaultsscc_info_TxnLookupReply_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_TxnLookupReply_default_instance_;
+    new (ptr) ::remote::TxnLookupReply();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_TxnLookupReply_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_TxnLookupReply_remote_2fethbackend_2eproto}, {}};
+
+static void InitDefaultsscc_info_TxnLookupRequest_remote_2fethbackend_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::remote::_TxnLookupRequest_default_instance_;
+    new (ptr) ::remote::TxnLookupRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_TxnLookupRequest_remote_2fethbackend_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_TxnLookupRequest_remote_2fethbackend_2eproto}, {
+      &scc_info_H256_types_2ftypes_2eproto.base,}};
+
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_remote_2fethbackend_2eproto[27];
+static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_remote_2fethbackend_2eproto[2];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_remote_2fethbackend_2eproto = nullptr;
 
 const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_remote_2fethbackend_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
@@ -297,6 +537,50 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_remote_2fethbackend_2eproto::o
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::remote::NetPeerCountReply, count_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineGetPayloadRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineGetPayloadRequest, payloadid_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadStatus, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadStatus, status_),
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadStatus, latestvalidhash_),
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadStatus, validationerror_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadAttributes, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadAttributes, timestamp_),
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadAttributes, prevrandao_),
+  PROTOBUF_FIELD_OFFSET(::remote::EnginePayloadAttributes, suggestedfeerecipient_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceState, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceState, headblockhash_),
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceState, safeblockhash_),
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceState, finalizedblockhash_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceUpdatedRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceUpdatedRequest, forkchoicestate_),
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceUpdatedRequest, payloadattributes_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceUpdatedReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceUpdatedReply, payloadstatus_),
+  PROTOBUF_FIELD_OFFSET(::remote::EngineForkChoiceUpdatedReply, payloadid_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::remote::ProtocolVersionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -332,6 +616,55 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_remote_2fethbackend_2eproto::o
   PROTOBUF_FIELD_OFFSET(::remote::SubscribeReply, type_),
   PROTOBUF_FIELD_OFFSET(::remote::SubscribeReply, data_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::LogsFilterRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::LogsFilterRequest, alladdresses_),
+  PROTOBUF_FIELD_OFFSET(::remote::LogsFilterRequest, addresses_),
+  PROTOBUF_FIELD_OFFSET(::remote::LogsFilterRequest, alltopics_),
+  PROTOBUF_FIELD_OFFSET(::remote::LogsFilterRequest, topics_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, address_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, blockhash_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, blocknumber_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, data_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, logindex_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, topics_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, transactionhash_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, transactionindex_),
+  PROTOBUF_FIELD_OFFSET(::remote::SubscribeLogsReply, removed_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::BlockRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::BlockRequest, blockheight_),
+  PROTOBUF_FIELD_OFFSET(::remote::BlockRequest, blockhash_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::BlockReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::BlockReply, blockrlp_),
+  PROTOBUF_FIELD_OFFSET(::remote::BlockReply, senders_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::TxnLookupRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::TxnLookupRequest, txnhash_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::TxnLookupReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::TxnLookupReply, blocknumber_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::remote::NodesInfoRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -343,6 +676,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_remote_2fethbackend_2eproto::o
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::remote::NodesInfoReply, nodesinfo_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::remote::PeersReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::remote::PeersReply, peers_),
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::remote::EtherbaseRequest)},
@@ -351,14 +690,27 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 16, -1, sizeof(::remote::NetVersionReply)},
   { 22, -1, sizeof(::remote::NetPeerCountRequest)},
   { 27, -1, sizeof(::remote::NetPeerCountReply)},
-  { 33, -1, sizeof(::remote::ProtocolVersionRequest)},
-  { 38, -1, sizeof(::remote::ProtocolVersionReply)},
-  { 44, -1, sizeof(::remote::ClientVersionRequest)},
-  { 49, -1, sizeof(::remote::ClientVersionReply)},
-  { 55, -1, sizeof(::remote::SubscribeRequest)},
-  { 61, -1, sizeof(::remote::SubscribeReply)},
-  { 68, -1, sizeof(::remote::NodesInfoRequest)},
-  { 74, -1, sizeof(::remote::NodesInfoReply)},
+  { 33, -1, sizeof(::remote::EngineGetPayloadRequest)},
+  { 39, -1, sizeof(::remote::EnginePayloadStatus)},
+  { 47, -1, sizeof(::remote::EnginePayloadAttributes)},
+  { 55, -1, sizeof(::remote::EngineForkChoiceState)},
+  { 63, -1, sizeof(::remote::EngineForkChoiceUpdatedRequest)},
+  { 70, -1, sizeof(::remote::EngineForkChoiceUpdatedReply)},
+  { 77, -1, sizeof(::remote::ProtocolVersionRequest)},
+  { 82, -1, sizeof(::remote::ProtocolVersionReply)},
+  { 88, -1, sizeof(::remote::ClientVersionRequest)},
+  { 93, -1, sizeof(::remote::ClientVersionReply)},
+  { 99, -1, sizeof(::remote::SubscribeRequest)},
+  { 105, -1, sizeof(::remote::SubscribeReply)},
+  { 112, -1, sizeof(::remote::LogsFilterRequest)},
+  { 121, -1, sizeof(::remote::SubscribeLogsReply)},
+  { 135, -1, sizeof(::remote::BlockRequest)},
+  { 142, -1, sizeof(::remote::BlockReply)},
+  { 149, -1, sizeof(::remote::TxnLookupRequest)},
+  { 155, -1, sizeof(::remote::TxnLookupReply)},
+  { 161, -1, sizeof(::remote::NodesInfoRequest)},
+  { 167, -1, sizeof(::remote::NodesInfoReply)},
+  { 173, -1, sizeof(::remote::PeersReply)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -368,14 +720,27 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_NetVersionReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_NetPeerCountRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_NetPeerCountReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_EngineGetPayloadRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_EnginePayloadStatus_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_EnginePayloadAttributes_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_EngineForkChoiceState_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_EngineForkChoiceUpdatedRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_EngineForkChoiceUpdatedReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_ProtocolVersionRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_ProtocolVersionReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_ClientVersionRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_ClientVersionReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_SubscribeRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_SubscribeReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_LogsFilterRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_SubscribeLogsReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_BlockRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_BlockReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_TxnLookupRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_TxnLookupReply_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_NodesInfoRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_NodesInfoReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::remote::_PeersReply_default_instance_),
 };
 
 const char descriptor_table_protodef_remote_2fethbackend_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
@@ -385,58 +750,119 @@ const char descriptor_table_protodef_remote_2fethbackend_2eproto[] PROTOBUF_SECT
   "\034\n\007address\030\001 \001(\0132\013.types.H160\"\023\n\021NetVers"
   "ionRequest\"\035\n\017NetVersionReply\022\n\n\002id\030\001 \001("
   "\004\"\025\n\023NetPeerCountRequest\"\"\n\021NetPeerCount"
-  "Reply\022\r\n\005count\030\001 \001(\004\"\030\n\026ProtocolVersionR"
-  "equest\"\"\n\024ProtocolVersionReply\022\n\n\002id\030\001 \001"
-  "(\004\"\026\n\024ClientVersionRequest\"&\n\022ClientVers"
-  "ionReply\022\020\n\010nodeName\030\001 \001(\t\"/\n\020SubscribeR"
-  "equest\022\033\n\004type\030\001 \001(\0162\r.remote.Event\";\n\016S"
-  "ubscribeReply\022\033\n\004type\030\001 \001(\0162\r.remote.Eve"
-  "nt\022\014\n\004data\030\002 \001(\014\"!\n\020NodesInfoRequest\022\r\n\005"
-  "limit\030\001 \001(\r\"9\n\016NodesInfoReply\022\'\n\tnodesIn"
-  "fo\030\001 \003(\0132\024.types.NodeInfoReply*8\n\005Event\022"
-  "\n\n\006HEADER\020\000\022\020\n\014PENDING_LOGS\020\001\022\021\n\rPENDING"
-  "_BLOCK\020\0022\250\004\n\nETHBACKEND\022=\n\tEtherbase\022\030.r"
-  "emote.EtherbaseRequest\032\026.remote.Etherbas"
-  "eReply\022@\n\nNetVersion\022\031.remote.NetVersion"
-  "Request\032\027.remote.NetVersionReply\022F\n\014NetP"
-  "eerCount\022\033.remote.NetPeerCountRequest\032\031."
-  "remote.NetPeerCountReply\0226\n\007Version\022\026.go"
-  "ogle.protobuf.Empty\032\023.types.VersionReply"
-  "\022O\n\017ProtocolVersion\022\036.remote.ProtocolVer"
-  "sionRequest\032\034.remote.ProtocolVersionRepl"
-  "y\022I\n\rClientVersion\022\034.remote.ClientVersio"
-  "nRequest\032\032.remote.ClientVersionReply\022\?\n\t"
-  "Subscribe\022\030.remote.SubscribeRequest\032\026.re"
-  "mote.SubscribeReply0\001\022<\n\010NodeInfo\022\030.remo"
-  "te.NodesInfoRequest\032\026.remote.NodesInfoRe"
-  "plyB\021Z\017./remote;remoteb\006proto3"
+  "Reply\022\r\n\005count\030\001 \001(\004\",\n\027EngineGetPayload"
+  "Request\022\021\n\tpayloadId\030\001 \001(\004\"z\n\023EnginePayl"
+  "oadStatus\022$\n\006status\030\001 \001(\0162\024.remote.Engin"
+  "eStatus\022$\n\017latestValidHash\030\002 \001(\0132\013.types"
+  ".H256\022\027\n\017validationError\030\003 \001(\t\"y\n\027Engine"
+  "PayloadAttributes\022\021\n\ttimestamp\030\001 \001(\004\022\037\n\n"
+  "prevRandao\030\002 \001(\0132\013.types.H256\022*\n\025suggest"
+  "edFeeRecipient\030\003 \001(\0132\013.types.H160\"\210\001\n\025En"
+  "gineForkChoiceState\022\"\n\rheadBlockHash\030\001 \001"
+  "(\0132\013.types.H256\022\"\n\rsafeBlockHash\030\002 \001(\0132\013"
+  ".types.H256\022\'\n\022finalizedBlockHash\030\003 \001(\0132"
+  "\013.types.H256\"\224\001\n\036EngineForkChoiceUpdated"
+  "Request\0226\n\017forkchoiceState\030\001 \001(\0132\035.remot"
+  "e.EngineForkChoiceState\022:\n\021payloadAttrib"
+  "utes\030\002 \001(\0132\037.remote.EnginePayloadAttribu"
+  "tes\"e\n\034EngineForkChoiceUpdatedReply\0222\n\rp"
+  "ayloadStatus\030\001 \001(\0132\033.remote.EnginePayloa"
+  "dStatus\022\021\n\tpayloadId\030\002 \001(\004\"\030\n\026ProtocolVe"
+  "rsionRequest\"\"\n\024ProtocolVersionReply\022\n\n\002"
+  "id\030\001 \001(\004\"\026\n\024ClientVersionRequest\"&\n\022Clie"
+  "ntVersionReply\022\020\n\010nodeName\030\001 \001(\t\"/\n\020Subs"
+  "cribeRequest\022\033\n\004type\030\001 \001(\0162\r.remote.Even"
+  "t\";\n\016SubscribeReply\022\033\n\004type\030\001 \001(\0162\r.remo"
+  "te.Event\022\014\n\004data\030\002 \001(\014\"y\n\021LogsFilterRequ"
+  "est\022\024\n\014allAddresses\030\001 \001(\010\022\036\n\taddresses\030\002"
+  " \003(\0132\013.types.H160\022\021\n\tallTopics\030\003 \001(\010\022\033\n\006"
+  "topics\030\004 \003(\0132\013.types.H256\"\365\001\n\022SubscribeL"
+  "ogsReply\022\034\n\007address\030\001 \001(\0132\013.types.H160\022\036"
+  "\n\tblockHash\030\002 \001(\0132\013.types.H256\022\023\n\013blockN"
+  "umber\030\003 \001(\004\022\014\n\004data\030\004 \001(\014\022\020\n\010logIndex\030\005 "
+  "\001(\004\022\033\n\006topics\030\006 \003(\0132\013.types.H256\022$\n\017tran"
+  "sactionHash\030\007 \001(\0132\013.types.H256\022\030\n\020transa"
+  "ctionIndex\030\010 \001(\004\022\017\n\007removed\030\t \001(\010\"C\n\014Blo"
+  "ckRequest\022\023\n\013blockHeight\030\002 \001(\004\022\036\n\tblockH"
+  "ash\030\003 \001(\0132\013.types.H256\"/\n\nBlockReply\022\020\n\010"
+  "blockRlp\030\001 \001(\014\022\017\n\007senders\030\002 \001(\014\"0\n\020TxnLo"
+  "okupRequest\022\034\n\007txnHash\030\001 \001(\0132\013.types.H25"
+  "6\"%\n\016TxnLookupReply\022\023\n\013blockNumber\030\001 \001(\004"
+  "\"!\n\020NodesInfoRequest\022\r\n\005limit\030\001 \001(\r\"9\n\016N"
+  "odesInfoReply\022\'\n\tnodesInfo\030\001 \003(\0132\024.types"
+  ".NodeInfoReply\",\n\nPeersReply\022\036\n\005peers\030\001 "
+  "\003(\0132\017.types.PeerInfo*J\n\005Event\022\n\n\006HEADER\020"
+  "\000\022\020\n\014PENDING_LOGS\020\001\022\021\n\rPENDING_BLOCK\020\002\022\020"
+  "\n\014NEW_SNAPSHOT\020\003*Y\n\014EngineStatus\022\t\n\005VALI"
+  "D\020\000\022\013\n\007INVALID\020\001\022\013\n\007SYNCING\020\002\022\014\n\010ACCEPTE"
+  "D\020\003\022\026\n\022INVALID_BLOCK_HASH\020\0042\242\010\n\nETHBACKE"
+  "ND\022=\n\tEtherbase\022\030.remote.EtherbaseReques"
+  "t\032\026.remote.EtherbaseReply\022@\n\nNetVersion\022"
+  "\031.remote.NetVersionRequest\032\027.remote.NetV"
+  "ersionReply\022F\n\014NetPeerCount\022\033.remote.Net"
+  "PeerCountRequest\032\031.remote.NetPeerCountRe"
+  "ply\022N\n\022EngineGetPayloadV1\022\037.remote.Engin"
+  "eGetPayloadRequest\032\027.types.ExecutionPayl"
+  "oad\022J\n\022EngineNewPayloadV1\022\027.types.Execut"
+  "ionPayload\032\033.remote.EnginePayloadStatus\022"
+  "i\n\031EngineForkChoiceUpdatedV1\022&.remote.En"
+  "gineForkChoiceUpdatedRequest\032$.remote.En"
+  "gineForkChoiceUpdatedReply\0226\n\007Version\022\026."
+  "google.protobuf.Empty\032\023.types.VersionRep"
+  "ly\022O\n\017ProtocolVersion\022\036.remote.ProtocolV"
+  "ersionRequest\032\034.remote.ProtocolVersionRe"
+  "ply\022I\n\rClientVersion\022\034.remote.ClientVers"
+  "ionRequest\032\032.remote.ClientVersionReply\022\?"
+  "\n\tSubscribe\022\030.remote.SubscribeRequest\032\026."
+  "remote.SubscribeReply0\001\022J\n\rSubscribeLogs"
+  "\022\031.remote.LogsFilterRequest\032\032.remote.Sub"
+  "scribeLogsReply(\0010\001\0221\n\005Block\022\024.remote.Bl"
+  "ockRequest\032\022.remote.BlockReply\022=\n\tTxnLoo"
+  "kup\022\030.remote.TxnLookupRequest\032\026.remote.T"
+  "xnLookupReply\022<\n\010NodeInfo\022\030.remote.Nodes"
+  "InfoRequest\032\026.remote.NodesInfoReply\0223\n\005P"
+  "eers\022\026.google.protobuf.Empty\032\022.remote.Pe"
+  "ersReplyB\021Z\017./remote;remoteb\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_remote_2fethbackend_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
   &::descriptor_table_types_2ftypes_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_remote_2fethbackend_2eproto_sccs[14] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_remote_2fethbackend_2eproto_sccs[27] = {
+  &scc_info_BlockReply_remote_2fethbackend_2eproto.base,
+  &scc_info_BlockRequest_remote_2fethbackend_2eproto.base,
   &scc_info_ClientVersionReply_remote_2fethbackend_2eproto.base,
   &scc_info_ClientVersionRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_EngineForkChoiceState_remote_2fethbackend_2eproto.base,
+  &scc_info_EngineForkChoiceUpdatedReply_remote_2fethbackend_2eproto.base,
+  &scc_info_EngineForkChoiceUpdatedRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_EngineGetPayloadRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto.base,
+  &scc_info_EnginePayloadStatus_remote_2fethbackend_2eproto.base,
   &scc_info_EtherbaseReply_remote_2fethbackend_2eproto.base,
   &scc_info_EtherbaseRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_LogsFilterRequest_remote_2fethbackend_2eproto.base,
   &scc_info_NetPeerCountReply_remote_2fethbackend_2eproto.base,
   &scc_info_NetPeerCountRequest_remote_2fethbackend_2eproto.base,
   &scc_info_NetVersionReply_remote_2fethbackend_2eproto.base,
   &scc_info_NetVersionRequest_remote_2fethbackend_2eproto.base,
   &scc_info_NodesInfoReply_remote_2fethbackend_2eproto.base,
   &scc_info_NodesInfoRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_PeersReply_remote_2fethbackend_2eproto.base,
   &scc_info_ProtocolVersionReply_remote_2fethbackend_2eproto.base,
   &scc_info_ProtocolVersionRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_SubscribeLogsReply_remote_2fethbackend_2eproto.base,
   &scc_info_SubscribeReply_remote_2fethbackend_2eproto.base,
   &scc_info_SubscribeRequest_remote_2fethbackend_2eproto.base,
+  &scc_info_TxnLookupReply_remote_2fethbackend_2eproto.base,
+  &scc_info_TxnLookupRequest_remote_2fethbackend_2eproto.base,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_remote_2fethbackend_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_remote_2fethbackend_2eproto = {
-  false, false, descriptor_table_protodef_remote_2fethbackend_2eproto, "remote/ethbackend.proto", 1230,
-  &descriptor_table_remote_2fethbackend_2eproto_once, descriptor_table_remote_2fethbackend_2eproto_sccs, descriptor_table_remote_2fethbackend_2eproto_deps, 14, 2,
+  false, false, descriptor_table_protodef_remote_2fethbackend_2eproto, "remote/ethbackend.proto", 3155,
+  &descriptor_table_remote_2fethbackend_2eproto_once, descriptor_table_remote_2fethbackend_2eproto_sccs, descriptor_table_remote_2fethbackend_2eproto_deps, 27, 2,
   schemas, file_default_instances, TableStruct_remote_2fethbackend_2eproto::offsets,
-  file_level_metadata_remote_2fethbackend_2eproto, 14, file_level_enum_descriptors_remote_2fethbackend_2eproto, file_level_service_descriptors_remote_2fethbackend_2eproto,
+  file_level_metadata_remote_2fethbackend_2eproto, 27, file_level_enum_descriptors_remote_2fethbackend_2eproto, file_level_service_descriptors_remote_2fethbackend_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -451,6 +877,24 @@ bool Event_IsValid(int value) {
     case 0:
     case 1:
     case 2:
+    case 3:
+      return true;
+    default:
+      return false;
+  }
+}
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* EngineStatus_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_remote_2fethbackend_2eproto);
+  return file_level_enum_descriptors_remote_2fethbackend_2eproto[1];
+}
+bool EngineStatus_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
       return true;
     default:
       return false;
@@ -1544,6 +1988,1600 @@ void NetPeerCountReply::InternalSwap(NetPeerCountReply* other) {
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata NetPeerCountReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class EngineGetPayloadRequest::_Internal {
+ public:
+};
+
+EngineGetPayloadRequest::EngineGetPayloadRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.EngineGetPayloadRequest)
+}
+EngineGetPayloadRequest::EngineGetPayloadRequest(const EngineGetPayloadRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  payloadid_ = from.payloadid_;
+  // @@protoc_insertion_point(copy_constructor:remote.EngineGetPayloadRequest)
+}
+
+void EngineGetPayloadRequest::SharedCtor() {
+  payloadid_ = PROTOBUF_ULONGLONG(0);
+}
+
+EngineGetPayloadRequest::~EngineGetPayloadRequest() {
+  // @@protoc_insertion_point(destructor:remote.EngineGetPayloadRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void EngineGetPayloadRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void EngineGetPayloadRequest::ArenaDtor(void* object) {
+  EngineGetPayloadRequest* _this = reinterpret_cast< EngineGetPayloadRequest* >(object);
+  (void)_this;
+}
+void EngineGetPayloadRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void EngineGetPayloadRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const EngineGetPayloadRequest& EngineGetPayloadRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_EngineGetPayloadRequest_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void EngineGetPayloadRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.EngineGetPayloadRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  payloadid_ = PROTOBUF_ULONGLONG(0);
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* EngineGetPayloadRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // uint64 payloadId = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          payloadid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* EngineGetPayloadRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.EngineGetPayloadRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint64 payloadId = 1;
+  if (this->payloadid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(1, this->_internal_payloadid(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.EngineGetPayloadRequest)
+  return target;
+}
+
+size_t EngineGetPayloadRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.EngineGetPayloadRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // uint64 payloadId = 1;
+  if (this->payloadid() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_payloadid());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void EngineGetPayloadRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.EngineGetPayloadRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const EngineGetPayloadRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<EngineGetPayloadRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.EngineGetPayloadRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.EngineGetPayloadRequest)
+    MergeFrom(*source);
+  }
+}
+
+void EngineGetPayloadRequest::MergeFrom(const EngineGetPayloadRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.EngineGetPayloadRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.payloadid() != 0) {
+    _internal_set_payloadid(from._internal_payloadid());
+  }
+}
+
+void EngineGetPayloadRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.EngineGetPayloadRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void EngineGetPayloadRequest::CopyFrom(const EngineGetPayloadRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.EngineGetPayloadRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool EngineGetPayloadRequest::IsInitialized() const {
+  return true;
+}
+
+void EngineGetPayloadRequest::InternalSwap(EngineGetPayloadRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(payloadid_, other->payloadid_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata EngineGetPayloadRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class EnginePayloadStatus::_Internal {
+ public:
+  static const ::types::H256& latestvalidhash(const EnginePayloadStatus* msg);
+};
+
+const ::types::H256&
+EnginePayloadStatus::_Internal::latestvalidhash(const EnginePayloadStatus* msg) {
+  return *msg->latestvalidhash_;
+}
+void EnginePayloadStatus::clear_latestvalidhash() {
+  if (GetArena() == nullptr && latestvalidhash_ != nullptr) {
+    delete latestvalidhash_;
+  }
+  latestvalidhash_ = nullptr;
+}
+EnginePayloadStatus::EnginePayloadStatus(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.EnginePayloadStatus)
+}
+EnginePayloadStatus::EnginePayloadStatus(const EnginePayloadStatus& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  validationerror_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_validationerror().empty()) {
+    validationerror_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_validationerror(), 
+      GetArena());
+  }
+  if (from._internal_has_latestvalidhash()) {
+    latestvalidhash_ = new ::types::H256(*from.latestvalidhash_);
+  } else {
+    latestvalidhash_ = nullptr;
+  }
+  status_ = from.status_;
+  // @@protoc_insertion_point(copy_constructor:remote.EnginePayloadStatus)
+}
+
+void EnginePayloadStatus::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_EnginePayloadStatus_remote_2fethbackend_2eproto.base);
+  validationerror_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&latestvalidhash_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&status_) -
+      reinterpret_cast<char*>(&latestvalidhash_)) + sizeof(status_));
+}
+
+EnginePayloadStatus::~EnginePayloadStatus() {
+  // @@protoc_insertion_point(destructor:remote.EnginePayloadStatus)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void EnginePayloadStatus::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  validationerror_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete latestvalidhash_;
+}
+
+void EnginePayloadStatus::ArenaDtor(void* object) {
+  EnginePayloadStatus* _this = reinterpret_cast< EnginePayloadStatus* >(object);
+  (void)_this;
+}
+void EnginePayloadStatus::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void EnginePayloadStatus::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const EnginePayloadStatus& EnginePayloadStatus::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_EnginePayloadStatus_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void EnginePayloadStatus::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.EnginePayloadStatus)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  validationerror_.ClearToEmpty();
+  if (GetArena() == nullptr && latestvalidhash_ != nullptr) {
+    delete latestvalidhash_;
+  }
+  latestvalidhash_ = nullptr;
+  status_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* EnginePayloadStatus::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .remote.EngineStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          ::PROTOBUF_NAMESPACE_ID::uint64 val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::remote::EngineStatus>(val));
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 latestValidHash = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_latestvalidhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string validationError = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_validationerror();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "remote.EnginePayloadStatus.validationError"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* EnginePayloadStatus::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.EnginePayloadStatus)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .remote.EngineStatus status = 1;
+  if (this->status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // .types.H256 latestValidHash = 2;
+  if (this->has_latestvalidhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::latestvalidhash(this), target, stream);
+  }
+
+  // string validationError = 3;
+  if (this->validationerror().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_validationerror().data(), static_cast<int>(this->_internal_validationerror().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "remote.EnginePayloadStatus.validationError");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_validationerror(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.EnginePayloadStatus)
+  return target;
+}
+
+size_t EnginePayloadStatus::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.EnginePayloadStatus)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string validationError = 3;
+  if (this->validationerror().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_validationerror());
+  }
+
+  // .types.H256 latestValidHash = 2;
+  if (this->has_latestvalidhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *latestvalidhash_);
+  }
+
+  // .remote.EngineStatus status = 1;
+  if (this->status() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void EnginePayloadStatus::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.EnginePayloadStatus)
+  GOOGLE_DCHECK_NE(&from, this);
+  const EnginePayloadStatus* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<EnginePayloadStatus>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.EnginePayloadStatus)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.EnginePayloadStatus)
+    MergeFrom(*source);
+  }
+}
+
+void EnginePayloadStatus::MergeFrom(const EnginePayloadStatus& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.EnginePayloadStatus)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.validationerror().size() > 0) {
+    _internal_set_validationerror(from._internal_validationerror());
+  }
+  if (from.has_latestvalidhash()) {
+    _internal_mutable_latestvalidhash()->::types::H256::MergeFrom(from._internal_latestvalidhash());
+  }
+  if (from.status() != 0) {
+    _internal_set_status(from._internal_status());
+  }
+}
+
+void EnginePayloadStatus::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.EnginePayloadStatus)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void EnginePayloadStatus::CopyFrom(const EnginePayloadStatus& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.EnginePayloadStatus)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool EnginePayloadStatus::IsInitialized() const {
+  return true;
+}
+
+void EnginePayloadStatus::InternalSwap(EnginePayloadStatus* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  validationerror_.Swap(&other->validationerror_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(EnginePayloadStatus, status_)
+      + sizeof(EnginePayloadStatus::status_)
+      - PROTOBUF_FIELD_OFFSET(EnginePayloadStatus, latestvalidhash_)>(
+          reinterpret_cast<char*>(&latestvalidhash_),
+          reinterpret_cast<char*>(&other->latestvalidhash_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata EnginePayloadStatus::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class EnginePayloadAttributes::_Internal {
+ public:
+  static const ::types::H256& prevrandao(const EnginePayloadAttributes* msg);
+  static const ::types::H160& suggestedfeerecipient(const EnginePayloadAttributes* msg);
+};
+
+const ::types::H256&
+EnginePayloadAttributes::_Internal::prevrandao(const EnginePayloadAttributes* msg) {
+  return *msg->prevrandao_;
+}
+const ::types::H160&
+EnginePayloadAttributes::_Internal::suggestedfeerecipient(const EnginePayloadAttributes* msg) {
+  return *msg->suggestedfeerecipient_;
+}
+void EnginePayloadAttributes::clear_prevrandao() {
+  if (GetArena() == nullptr && prevrandao_ != nullptr) {
+    delete prevrandao_;
+  }
+  prevrandao_ = nullptr;
+}
+void EnginePayloadAttributes::clear_suggestedfeerecipient() {
+  if (GetArena() == nullptr && suggestedfeerecipient_ != nullptr) {
+    delete suggestedfeerecipient_;
+  }
+  suggestedfeerecipient_ = nullptr;
+}
+EnginePayloadAttributes::EnginePayloadAttributes(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.EnginePayloadAttributes)
+}
+EnginePayloadAttributes::EnginePayloadAttributes(const EnginePayloadAttributes& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_prevrandao()) {
+    prevrandao_ = new ::types::H256(*from.prevrandao_);
+  } else {
+    prevrandao_ = nullptr;
+  }
+  if (from._internal_has_suggestedfeerecipient()) {
+    suggestedfeerecipient_ = new ::types::H160(*from.suggestedfeerecipient_);
+  } else {
+    suggestedfeerecipient_ = nullptr;
+  }
+  timestamp_ = from.timestamp_;
+  // @@protoc_insertion_point(copy_constructor:remote.EnginePayloadAttributes)
+}
+
+void EnginePayloadAttributes::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&prevrandao_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&timestamp_) -
+      reinterpret_cast<char*>(&prevrandao_)) + sizeof(timestamp_));
+}
+
+EnginePayloadAttributes::~EnginePayloadAttributes() {
+  // @@protoc_insertion_point(destructor:remote.EnginePayloadAttributes)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void EnginePayloadAttributes::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete prevrandao_;
+  if (this != internal_default_instance()) delete suggestedfeerecipient_;
+}
+
+void EnginePayloadAttributes::ArenaDtor(void* object) {
+  EnginePayloadAttributes* _this = reinterpret_cast< EnginePayloadAttributes* >(object);
+  (void)_this;
+}
+void EnginePayloadAttributes::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void EnginePayloadAttributes::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const EnginePayloadAttributes& EnginePayloadAttributes::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_EnginePayloadAttributes_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void EnginePayloadAttributes::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.EnginePayloadAttributes)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && prevrandao_ != nullptr) {
+    delete prevrandao_;
+  }
+  prevrandao_ = nullptr;
+  if (GetArena() == nullptr && suggestedfeerecipient_ != nullptr) {
+    delete suggestedfeerecipient_;
+  }
+  suggestedfeerecipient_ = nullptr;
+  timestamp_ = PROTOBUF_ULONGLONG(0);
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* EnginePayloadAttributes::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // uint64 timestamp = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          timestamp_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 prevRandao = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_prevrandao(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H160 suggestedFeeRecipient = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_suggestedfeerecipient(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* EnginePayloadAttributes::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.EnginePayloadAttributes)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint64 timestamp = 1;
+  if (this->timestamp() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(1, this->_internal_timestamp(), target);
+  }
+
+  // .types.H256 prevRandao = 2;
+  if (this->has_prevrandao()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::prevrandao(this), target, stream);
+  }
+
+  // .types.H160 suggestedFeeRecipient = 3;
+  if (this->has_suggestedfeerecipient()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::suggestedfeerecipient(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.EnginePayloadAttributes)
+  return target;
+}
+
+size_t EnginePayloadAttributes::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.EnginePayloadAttributes)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .types.H256 prevRandao = 2;
+  if (this->has_prevrandao()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *prevrandao_);
+  }
+
+  // .types.H160 suggestedFeeRecipient = 3;
+  if (this->has_suggestedfeerecipient()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *suggestedfeerecipient_);
+  }
+
+  // uint64 timestamp = 1;
+  if (this->timestamp() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_timestamp());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void EnginePayloadAttributes::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.EnginePayloadAttributes)
+  GOOGLE_DCHECK_NE(&from, this);
+  const EnginePayloadAttributes* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<EnginePayloadAttributes>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.EnginePayloadAttributes)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.EnginePayloadAttributes)
+    MergeFrom(*source);
+  }
+}
+
+void EnginePayloadAttributes::MergeFrom(const EnginePayloadAttributes& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.EnginePayloadAttributes)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_prevrandao()) {
+    _internal_mutable_prevrandao()->::types::H256::MergeFrom(from._internal_prevrandao());
+  }
+  if (from.has_suggestedfeerecipient()) {
+    _internal_mutable_suggestedfeerecipient()->::types::H160::MergeFrom(from._internal_suggestedfeerecipient());
+  }
+  if (from.timestamp() != 0) {
+    _internal_set_timestamp(from._internal_timestamp());
+  }
+}
+
+void EnginePayloadAttributes::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.EnginePayloadAttributes)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void EnginePayloadAttributes::CopyFrom(const EnginePayloadAttributes& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.EnginePayloadAttributes)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool EnginePayloadAttributes::IsInitialized() const {
+  return true;
+}
+
+void EnginePayloadAttributes::InternalSwap(EnginePayloadAttributes* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(EnginePayloadAttributes, timestamp_)
+      + sizeof(EnginePayloadAttributes::timestamp_)
+      - PROTOBUF_FIELD_OFFSET(EnginePayloadAttributes, prevrandao_)>(
+          reinterpret_cast<char*>(&prevrandao_),
+          reinterpret_cast<char*>(&other->prevrandao_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata EnginePayloadAttributes::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class EngineForkChoiceState::_Internal {
+ public:
+  static const ::types::H256& headblockhash(const EngineForkChoiceState* msg);
+  static const ::types::H256& safeblockhash(const EngineForkChoiceState* msg);
+  static const ::types::H256& finalizedblockhash(const EngineForkChoiceState* msg);
+};
+
+const ::types::H256&
+EngineForkChoiceState::_Internal::headblockhash(const EngineForkChoiceState* msg) {
+  return *msg->headblockhash_;
+}
+const ::types::H256&
+EngineForkChoiceState::_Internal::safeblockhash(const EngineForkChoiceState* msg) {
+  return *msg->safeblockhash_;
+}
+const ::types::H256&
+EngineForkChoiceState::_Internal::finalizedblockhash(const EngineForkChoiceState* msg) {
+  return *msg->finalizedblockhash_;
+}
+void EngineForkChoiceState::clear_headblockhash() {
+  if (GetArena() == nullptr && headblockhash_ != nullptr) {
+    delete headblockhash_;
+  }
+  headblockhash_ = nullptr;
+}
+void EngineForkChoiceState::clear_safeblockhash() {
+  if (GetArena() == nullptr && safeblockhash_ != nullptr) {
+    delete safeblockhash_;
+  }
+  safeblockhash_ = nullptr;
+}
+void EngineForkChoiceState::clear_finalizedblockhash() {
+  if (GetArena() == nullptr && finalizedblockhash_ != nullptr) {
+    delete finalizedblockhash_;
+  }
+  finalizedblockhash_ = nullptr;
+}
+EngineForkChoiceState::EngineForkChoiceState(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.EngineForkChoiceState)
+}
+EngineForkChoiceState::EngineForkChoiceState(const EngineForkChoiceState& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_headblockhash()) {
+    headblockhash_ = new ::types::H256(*from.headblockhash_);
+  } else {
+    headblockhash_ = nullptr;
+  }
+  if (from._internal_has_safeblockhash()) {
+    safeblockhash_ = new ::types::H256(*from.safeblockhash_);
+  } else {
+    safeblockhash_ = nullptr;
+  }
+  if (from._internal_has_finalizedblockhash()) {
+    finalizedblockhash_ = new ::types::H256(*from.finalizedblockhash_);
+  } else {
+    finalizedblockhash_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:remote.EngineForkChoiceState)
+}
+
+void EngineForkChoiceState::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_EngineForkChoiceState_remote_2fethbackend_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&headblockhash_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&finalizedblockhash_) -
+      reinterpret_cast<char*>(&headblockhash_)) + sizeof(finalizedblockhash_));
+}
+
+EngineForkChoiceState::~EngineForkChoiceState() {
+  // @@protoc_insertion_point(destructor:remote.EngineForkChoiceState)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void EngineForkChoiceState::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete headblockhash_;
+  if (this != internal_default_instance()) delete safeblockhash_;
+  if (this != internal_default_instance()) delete finalizedblockhash_;
+}
+
+void EngineForkChoiceState::ArenaDtor(void* object) {
+  EngineForkChoiceState* _this = reinterpret_cast< EngineForkChoiceState* >(object);
+  (void)_this;
+}
+void EngineForkChoiceState::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void EngineForkChoiceState::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const EngineForkChoiceState& EngineForkChoiceState::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_EngineForkChoiceState_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void EngineForkChoiceState::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.EngineForkChoiceState)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && headblockhash_ != nullptr) {
+    delete headblockhash_;
+  }
+  headblockhash_ = nullptr;
+  if (GetArena() == nullptr && safeblockhash_ != nullptr) {
+    delete safeblockhash_;
+  }
+  safeblockhash_ = nullptr;
+  if (GetArena() == nullptr && finalizedblockhash_ != nullptr) {
+    delete finalizedblockhash_;
+  }
+  finalizedblockhash_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* EngineForkChoiceState::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .types.H256 headBlockHash = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_headblockhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 safeBlockHash = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_safeblockhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 finalizedBlockHash = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_finalizedblockhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* EngineForkChoiceState::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.EngineForkChoiceState)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H256 headBlockHash = 1;
+  if (this->has_headblockhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::headblockhash(this), target, stream);
+  }
+
+  // .types.H256 safeBlockHash = 2;
+  if (this->has_safeblockhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::safeblockhash(this), target, stream);
+  }
+
+  // .types.H256 finalizedBlockHash = 3;
+  if (this->has_finalizedblockhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::finalizedblockhash(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.EngineForkChoiceState)
+  return target;
+}
+
+size_t EngineForkChoiceState::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.EngineForkChoiceState)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .types.H256 headBlockHash = 1;
+  if (this->has_headblockhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *headblockhash_);
+  }
+
+  // .types.H256 safeBlockHash = 2;
+  if (this->has_safeblockhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *safeblockhash_);
+  }
+
+  // .types.H256 finalizedBlockHash = 3;
+  if (this->has_finalizedblockhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *finalizedblockhash_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void EngineForkChoiceState::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.EngineForkChoiceState)
+  GOOGLE_DCHECK_NE(&from, this);
+  const EngineForkChoiceState* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<EngineForkChoiceState>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.EngineForkChoiceState)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.EngineForkChoiceState)
+    MergeFrom(*source);
+  }
+}
+
+void EngineForkChoiceState::MergeFrom(const EngineForkChoiceState& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.EngineForkChoiceState)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_headblockhash()) {
+    _internal_mutable_headblockhash()->::types::H256::MergeFrom(from._internal_headblockhash());
+  }
+  if (from.has_safeblockhash()) {
+    _internal_mutable_safeblockhash()->::types::H256::MergeFrom(from._internal_safeblockhash());
+  }
+  if (from.has_finalizedblockhash()) {
+    _internal_mutable_finalizedblockhash()->::types::H256::MergeFrom(from._internal_finalizedblockhash());
+  }
+}
+
+void EngineForkChoiceState::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.EngineForkChoiceState)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void EngineForkChoiceState::CopyFrom(const EngineForkChoiceState& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.EngineForkChoiceState)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool EngineForkChoiceState::IsInitialized() const {
+  return true;
+}
+
+void EngineForkChoiceState::InternalSwap(EngineForkChoiceState* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(EngineForkChoiceState, finalizedblockhash_)
+      + sizeof(EngineForkChoiceState::finalizedblockhash_)
+      - PROTOBUF_FIELD_OFFSET(EngineForkChoiceState, headblockhash_)>(
+          reinterpret_cast<char*>(&headblockhash_),
+          reinterpret_cast<char*>(&other->headblockhash_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata EngineForkChoiceState::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class EngineForkChoiceUpdatedRequest::_Internal {
+ public:
+  static const ::remote::EngineForkChoiceState& forkchoicestate(const EngineForkChoiceUpdatedRequest* msg);
+  static const ::remote::EnginePayloadAttributes& payloadattributes(const EngineForkChoiceUpdatedRequest* msg);
+};
+
+const ::remote::EngineForkChoiceState&
+EngineForkChoiceUpdatedRequest::_Internal::forkchoicestate(const EngineForkChoiceUpdatedRequest* msg) {
+  return *msg->forkchoicestate_;
+}
+const ::remote::EnginePayloadAttributes&
+EngineForkChoiceUpdatedRequest::_Internal::payloadattributes(const EngineForkChoiceUpdatedRequest* msg) {
+  return *msg->payloadattributes_;
+}
+EngineForkChoiceUpdatedRequest::EngineForkChoiceUpdatedRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.EngineForkChoiceUpdatedRequest)
+}
+EngineForkChoiceUpdatedRequest::EngineForkChoiceUpdatedRequest(const EngineForkChoiceUpdatedRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_forkchoicestate()) {
+    forkchoicestate_ = new ::remote::EngineForkChoiceState(*from.forkchoicestate_);
+  } else {
+    forkchoicestate_ = nullptr;
+  }
+  if (from._internal_has_payloadattributes()) {
+    payloadattributes_ = new ::remote::EnginePayloadAttributes(*from.payloadattributes_);
+  } else {
+    payloadattributes_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:remote.EngineForkChoiceUpdatedRequest)
+}
+
+void EngineForkChoiceUpdatedRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_EngineForkChoiceUpdatedRequest_remote_2fethbackend_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&forkchoicestate_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&payloadattributes_) -
+      reinterpret_cast<char*>(&forkchoicestate_)) + sizeof(payloadattributes_));
+}
+
+EngineForkChoiceUpdatedRequest::~EngineForkChoiceUpdatedRequest() {
+  // @@protoc_insertion_point(destructor:remote.EngineForkChoiceUpdatedRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void EngineForkChoiceUpdatedRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete forkchoicestate_;
+  if (this != internal_default_instance()) delete payloadattributes_;
+}
+
+void EngineForkChoiceUpdatedRequest::ArenaDtor(void* object) {
+  EngineForkChoiceUpdatedRequest* _this = reinterpret_cast< EngineForkChoiceUpdatedRequest* >(object);
+  (void)_this;
+}
+void EngineForkChoiceUpdatedRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void EngineForkChoiceUpdatedRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const EngineForkChoiceUpdatedRequest& EngineForkChoiceUpdatedRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_EngineForkChoiceUpdatedRequest_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void EngineForkChoiceUpdatedRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.EngineForkChoiceUpdatedRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && forkchoicestate_ != nullptr) {
+    delete forkchoicestate_;
+  }
+  forkchoicestate_ = nullptr;
+  if (GetArena() == nullptr && payloadattributes_ != nullptr) {
+    delete payloadattributes_;
+  }
+  payloadattributes_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* EngineForkChoiceUpdatedRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .remote.EngineForkChoiceState forkchoiceState = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_forkchoicestate(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .remote.EnginePayloadAttributes payloadAttributes = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_payloadattributes(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* EngineForkChoiceUpdatedRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.EngineForkChoiceUpdatedRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .remote.EngineForkChoiceState forkchoiceState = 1;
+  if (this->has_forkchoicestate()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::forkchoicestate(this), target, stream);
+  }
+
+  // .remote.EnginePayloadAttributes payloadAttributes = 2;
+  if (this->has_payloadattributes()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::payloadattributes(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.EngineForkChoiceUpdatedRequest)
+  return target;
+}
+
+size_t EngineForkChoiceUpdatedRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.EngineForkChoiceUpdatedRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .remote.EngineForkChoiceState forkchoiceState = 1;
+  if (this->has_forkchoicestate()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *forkchoicestate_);
+  }
+
+  // .remote.EnginePayloadAttributes payloadAttributes = 2;
+  if (this->has_payloadattributes()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *payloadattributes_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void EngineForkChoiceUpdatedRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.EngineForkChoiceUpdatedRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const EngineForkChoiceUpdatedRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<EngineForkChoiceUpdatedRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.EngineForkChoiceUpdatedRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.EngineForkChoiceUpdatedRequest)
+    MergeFrom(*source);
+  }
+}
+
+void EngineForkChoiceUpdatedRequest::MergeFrom(const EngineForkChoiceUpdatedRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.EngineForkChoiceUpdatedRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_forkchoicestate()) {
+    _internal_mutable_forkchoicestate()->::remote::EngineForkChoiceState::MergeFrom(from._internal_forkchoicestate());
+  }
+  if (from.has_payloadattributes()) {
+    _internal_mutable_payloadattributes()->::remote::EnginePayloadAttributes::MergeFrom(from._internal_payloadattributes());
+  }
+}
+
+void EngineForkChoiceUpdatedRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.EngineForkChoiceUpdatedRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void EngineForkChoiceUpdatedRequest::CopyFrom(const EngineForkChoiceUpdatedRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.EngineForkChoiceUpdatedRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool EngineForkChoiceUpdatedRequest::IsInitialized() const {
+  return true;
+}
+
+void EngineForkChoiceUpdatedRequest::InternalSwap(EngineForkChoiceUpdatedRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(EngineForkChoiceUpdatedRequest, payloadattributes_)
+      + sizeof(EngineForkChoiceUpdatedRequest::payloadattributes_)
+      - PROTOBUF_FIELD_OFFSET(EngineForkChoiceUpdatedRequest, forkchoicestate_)>(
+          reinterpret_cast<char*>(&forkchoicestate_),
+          reinterpret_cast<char*>(&other->forkchoicestate_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata EngineForkChoiceUpdatedRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class EngineForkChoiceUpdatedReply::_Internal {
+ public:
+  static const ::remote::EnginePayloadStatus& payloadstatus(const EngineForkChoiceUpdatedReply* msg);
+};
+
+const ::remote::EnginePayloadStatus&
+EngineForkChoiceUpdatedReply::_Internal::payloadstatus(const EngineForkChoiceUpdatedReply* msg) {
+  return *msg->payloadstatus_;
+}
+EngineForkChoiceUpdatedReply::EngineForkChoiceUpdatedReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.EngineForkChoiceUpdatedReply)
+}
+EngineForkChoiceUpdatedReply::EngineForkChoiceUpdatedReply(const EngineForkChoiceUpdatedReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_payloadstatus()) {
+    payloadstatus_ = new ::remote::EnginePayloadStatus(*from.payloadstatus_);
+  } else {
+    payloadstatus_ = nullptr;
+  }
+  payloadid_ = from.payloadid_;
+  // @@protoc_insertion_point(copy_constructor:remote.EngineForkChoiceUpdatedReply)
+}
+
+void EngineForkChoiceUpdatedReply::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_EngineForkChoiceUpdatedReply_remote_2fethbackend_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&payloadstatus_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&payloadid_) -
+      reinterpret_cast<char*>(&payloadstatus_)) + sizeof(payloadid_));
+}
+
+EngineForkChoiceUpdatedReply::~EngineForkChoiceUpdatedReply() {
+  // @@protoc_insertion_point(destructor:remote.EngineForkChoiceUpdatedReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void EngineForkChoiceUpdatedReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete payloadstatus_;
+}
+
+void EngineForkChoiceUpdatedReply::ArenaDtor(void* object) {
+  EngineForkChoiceUpdatedReply* _this = reinterpret_cast< EngineForkChoiceUpdatedReply* >(object);
+  (void)_this;
+}
+void EngineForkChoiceUpdatedReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void EngineForkChoiceUpdatedReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const EngineForkChoiceUpdatedReply& EngineForkChoiceUpdatedReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_EngineForkChoiceUpdatedReply_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void EngineForkChoiceUpdatedReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.EngineForkChoiceUpdatedReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && payloadstatus_ != nullptr) {
+    delete payloadstatus_;
+  }
+  payloadstatus_ = nullptr;
+  payloadid_ = PROTOBUF_ULONGLONG(0);
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* EngineForkChoiceUpdatedReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .remote.EnginePayloadStatus payloadStatus = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_payloadstatus(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 payloadId = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
+          payloadid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* EngineForkChoiceUpdatedReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.EngineForkChoiceUpdatedReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .remote.EnginePayloadStatus payloadStatus = 1;
+  if (this->has_payloadstatus()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::payloadstatus(this), target, stream);
+  }
+
+  // uint64 payloadId = 2;
+  if (this->payloadid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(2, this->_internal_payloadid(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.EngineForkChoiceUpdatedReply)
+  return target;
+}
+
+size_t EngineForkChoiceUpdatedReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.EngineForkChoiceUpdatedReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .remote.EnginePayloadStatus payloadStatus = 1;
+  if (this->has_payloadstatus()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *payloadstatus_);
+  }
+
+  // uint64 payloadId = 2;
+  if (this->payloadid() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_payloadid());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void EngineForkChoiceUpdatedReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.EngineForkChoiceUpdatedReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  const EngineForkChoiceUpdatedReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<EngineForkChoiceUpdatedReply>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.EngineForkChoiceUpdatedReply)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.EngineForkChoiceUpdatedReply)
+    MergeFrom(*source);
+  }
+}
+
+void EngineForkChoiceUpdatedReply::MergeFrom(const EngineForkChoiceUpdatedReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.EngineForkChoiceUpdatedReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_payloadstatus()) {
+    _internal_mutable_payloadstatus()->::remote::EnginePayloadStatus::MergeFrom(from._internal_payloadstatus());
+  }
+  if (from.payloadid() != 0) {
+    _internal_set_payloadid(from._internal_payloadid());
+  }
+}
+
+void EngineForkChoiceUpdatedReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.EngineForkChoiceUpdatedReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void EngineForkChoiceUpdatedReply::CopyFrom(const EngineForkChoiceUpdatedReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.EngineForkChoiceUpdatedReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool EngineForkChoiceUpdatedReply::IsInitialized() const {
+  return true;
+}
+
+void EngineForkChoiceUpdatedReply::InternalSwap(EngineForkChoiceUpdatedReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(EngineForkChoiceUpdatedReply, payloadid_)
+      + sizeof(EngineForkChoiceUpdatedReply::payloadid_)
+      - PROTOBUF_FIELD_OFFSET(EngineForkChoiceUpdatedReply, payloadstatus_)>(
+          reinterpret_cast<char*>(&payloadstatus_),
+          reinterpret_cast<char*>(&other->payloadstatus_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata EngineForkChoiceUpdatedReply::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -2698,6 +4736,1675 @@ void SubscribeReply::InternalSwap(SubscribeReply* other) {
 
 // ===================================================================
 
+class LogsFilterRequest::_Internal {
+ public:
+};
+
+void LogsFilterRequest::clear_addresses() {
+  addresses_.Clear();
+}
+void LogsFilterRequest::clear_topics() {
+  topics_.Clear();
+}
+LogsFilterRequest::LogsFilterRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  addresses_(arena),
+  topics_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.LogsFilterRequest)
+}
+LogsFilterRequest::LogsFilterRequest(const LogsFilterRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      addresses_(from.addresses_),
+      topics_(from.topics_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&alladdresses_, &from.alladdresses_,
+    static_cast<size_t>(reinterpret_cast<char*>(&alltopics_) -
+    reinterpret_cast<char*>(&alladdresses_)) + sizeof(alltopics_));
+  // @@protoc_insertion_point(copy_constructor:remote.LogsFilterRequest)
+}
+
+void LogsFilterRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_LogsFilterRequest_remote_2fethbackend_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&alladdresses_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&alltopics_) -
+      reinterpret_cast<char*>(&alladdresses_)) + sizeof(alltopics_));
+}
+
+LogsFilterRequest::~LogsFilterRequest() {
+  // @@protoc_insertion_point(destructor:remote.LogsFilterRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void LogsFilterRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void LogsFilterRequest::ArenaDtor(void* object) {
+  LogsFilterRequest* _this = reinterpret_cast< LogsFilterRequest* >(object);
+  (void)_this;
+}
+void LogsFilterRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void LogsFilterRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const LogsFilterRequest& LogsFilterRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_LogsFilterRequest_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void LogsFilterRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.LogsFilterRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  addresses_.Clear();
+  topics_.Clear();
+  ::memset(&alladdresses_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&alltopics_) -
+      reinterpret_cast<char*>(&alladdresses_)) + sizeof(alltopics_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* LogsFilterRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // bool allAddresses = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          alladdresses_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated .types.H160 addresses = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_addresses(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // bool allTopics = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
+          alltopics_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated .types.H256 topics = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_topics(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<34>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* LogsFilterRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.LogsFilterRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool allAddresses = 1;
+  if (this->alladdresses() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(1, this->_internal_alladdresses(), target);
+  }
+
+  // repeated .types.H160 addresses = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_addresses_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(2, this->_internal_addresses(i), target, stream);
+  }
+
+  // bool allTopics = 3;
+  if (this->alltopics() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(3, this->_internal_alltopics(), target);
+  }
+
+  // repeated .types.H256 topics = 4;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_topics_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(4, this->_internal_topics(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.LogsFilterRequest)
+  return target;
+}
+
+size_t LogsFilterRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.LogsFilterRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .types.H160 addresses = 2;
+  total_size += 1UL * this->_internal_addresses_size();
+  for (const auto& msg : this->addresses_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated .types.H256 topics = 4;
+  total_size += 1UL * this->_internal_topics_size();
+  for (const auto& msg : this->topics_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // bool allAddresses = 1;
+  if (this->alladdresses() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // bool allTopics = 3;
+  if (this->alltopics() != 0) {
+    total_size += 1 + 1;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void LogsFilterRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.LogsFilterRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const LogsFilterRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<LogsFilterRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.LogsFilterRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.LogsFilterRequest)
+    MergeFrom(*source);
+  }
+}
+
+void LogsFilterRequest::MergeFrom(const LogsFilterRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.LogsFilterRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  addresses_.MergeFrom(from.addresses_);
+  topics_.MergeFrom(from.topics_);
+  if (from.alladdresses() != 0) {
+    _internal_set_alladdresses(from._internal_alladdresses());
+  }
+  if (from.alltopics() != 0) {
+    _internal_set_alltopics(from._internal_alltopics());
+  }
+}
+
+void LogsFilterRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.LogsFilterRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void LogsFilterRequest::CopyFrom(const LogsFilterRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.LogsFilterRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool LogsFilterRequest::IsInitialized() const {
+  return true;
+}
+
+void LogsFilterRequest::InternalSwap(LogsFilterRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  addresses_.InternalSwap(&other->addresses_);
+  topics_.InternalSwap(&other->topics_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(LogsFilterRequest, alltopics_)
+      + sizeof(LogsFilterRequest::alltopics_)
+      - PROTOBUF_FIELD_OFFSET(LogsFilterRequest, alladdresses_)>(
+          reinterpret_cast<char*>(&alladdresses_),
+          reinterpret_cast<char*>(&other->alladdresses_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata LogsFilterRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class SubscribeLogsReply::_Internal {
+ public:
+  static const ::types::H160& address(const SubscribeLogsReply* msg);
+  static const ::types::H256& blockhash(const SubscribeLogsReply* msg);
+  static const ::types::H256& transactionhash(const SubscribeLogsReply* msg);
+};
+
+const ::types::H160&
+SubscribeLogsReply::_Internal::address(const SubscribeLogsReply* msg) {
+  return *msg->address_;
+}
+const ::types::H256&
+SubscribeLogsReply::_Internal::blockhash(const SubscribeLogsReply* msg) {
+  return *msg->blockhash_;
+}
+const ::types::H256&
+SubscribeLogsReply::_Internal::transactionhash(const SubscribeLogsReply* msg) {
+  return *msg->transactionhash_;
+}
+void SubscribeLogsReply::clear_address() {
+  if (GetArena() == nullptr && address_ != nullptr) {
+    delete address_;
+  }
+  address_ = nullptr;
+}
+void SubscribeLogsReply::clear_blockhash() {
+  if (GetArena() == nullptr && blockhash_ != nullptr) {
+    delete blockhash_;
+  }
+  blockhash_ = nullptr;
+}
+void SubscribeLogsReply::clear_topics() {
+  topics_.Clear();
+}
+void SubscribeLogsReply::clear_transactionhash() {
+  if (GetArena() == nullptr && transactionhash_ != nullptr) {
+    delete transactionhash_;
+  }
+  transactionhash_ = nullptr;
+}
+SubscribeLogsReply::SubscribeLogsReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  topics_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.SubscribeLogsReply)
+}
+SubscribeLogsReply::SubscribeLogsReply(const SubscribeLogsReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      topics_(from.topics_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  data_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_data().empty()) {
+    data_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_data(), 
+      GetArena());
+  }
+  if (from._internal_has_address()) {
+    address_ = new ::types::H160(*from.address_);
+  } else {
+    address_ = nullptr;
+  }
+  if (from._internal_has_blockhash()) {
+    blockhash_ = new ::types::H256(*from.blockhash_);
+  } else {
+    blockhash_ = nullptr;
+  }
+  if (from._internal_has_transactionhash()) {
+    transactionhash_ = new ::types::H256(*from.transactionhash_);
+  } else {
+    transactionhash_ = nullptr;
+  }
+  ::memcpy(&blocknumber_, &from.blocknumber_,
+    static_cast<size_t>(reinterpret_cast<char*>(&removed_) -
+    reinterpret_cast<char*>(&blocknumber_)) + sizeof(removed_));
+  // @@protoc_insertion_point(copy_constructor:remote.SubscribeLogsReply)
+}
+
+void SubscribeLogsReply::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_SubscribeLogsReply_remote_2fethbackend_2eproto.base);
+  data_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&address_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&removed_) -
+      reinterpret_cast<char*>(&address_)) + sizeof(removed_));
+}
+
+SubscribeLogsReply::~SubscribeLogsReply() {
+  // @@protoc_insertion_point(destructor:remote.SubscribeLogsReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SubscribeLogsReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  data_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete address_;
+  if (this != internal_default_instance()) delete blockhash_;
+  if (this != internal_default_instance()) delete transactionhash_;
+}
+
+void SubscribeLogsReply::ArenaDtor(void* object) {
+  SubscribeLogsReply* _this = reinterpret_cast< SubscribeLogsReply* >(object);
+  (void)_this;
+}
+void SubscribeLogsReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SubscribeLogsReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const SubscribeLogsReply& SubscribeLogsReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_SubscribeLogsReply_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void SubscribeLogsReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.SubscribeLogsReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  topics_.Clear();
+  data_.ClearToEmpty();
+  if (GetArena() == nullptr && address_ != nullptr) {
+    delete address_;
+  }
+  address_ = nullptr;
+  if (GetArena() == nullptr && blockhash_ != nullptr) {
+    delete blockhash_;
+  }
+  blockhash_ = nullptr;
+  if (GetArena() == nullptr && transactionhash_ != nullptr) {
+    delete transactionhash_;
+  }
+  transactionhash_ = nullptr;
+  ::memset(&blocknumber_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&removed_) -
+      reinterpret_cast<char*>(&blocknumber_)) + sizeof(removed_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SubscribeLogsReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .types.H160 address = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_address(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 blockHash = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_blockhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 blockNumber = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
+          blocknumber_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bytes data = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          auto str = _internal_mutable_data();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 logIndex = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 40)) {
+          logindex_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated .types.H256 topics = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 50)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_topics(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<50>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 transactionHash = 7;
+      case 7:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 58)) {
+          ptr = ctx->ParseMessage(_internal_mutable_transactionhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 transactionIndex = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 64)) {
+          transactionindex_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool removed = 9;
+      case 9:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 72)) {
+          removed_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SubscribeLogsReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.SubscribeLogsReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H160 address = 1;
+  if (this->has_address()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::address(this), target, stream);
+  }
+
+  // .types.H256 blockHash = 2;
+  if (this->has_blockhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::blockhash(this), target, stream);
+  }
+
+  // uint64 blockNumber = 3;
+  if (this->blocknumber() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(3, this->_internal_blocknumber(), target);
+  }
+
+  // bytes data = 4;
+  if (this->data().size() > 0) {
+    target = stream->WriteBytesMaybeAliased(
+        4, this->_internal_data(), target);
+  }
+
+  // uint64 logIndex = 5;
+  if (this->logindex() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(5, this->_internal_logindex(), target);
+  }
+
+  // repeated .types.H256 topics = 6;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_topics_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(6, this->_internal_topics(i), target, stream);
+  }
+
+  // .types.H256 transactionHash = 7;
+  if (this->has_transactionhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        7, _Internal::transactionhash(this), target, stream);
+  }
+
+  // uint64 transactionIndex = 8;
+  if (this->transactionindex() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(8, this->_internal_transactionindex(), target);
+  }
+
+  // bool removed = 9;
+  if (this->removed() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(9, this->_internal_removed(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.SubscribeLogsReply)
+  return target;
+}
+
+size_t SubscribeLogsReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.SubscribeLogsReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .types.H256 topics = 6;
+  total_size += 1UL * this->_internal_topics_size();
+  for (const auto& msg : this->topics_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // bytes data = 4;
+  if (this->data().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_data());
+  }
+
+  // .types.H160 address = 1;
+  if (this->has_address()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *address_);
+  }
+
+  // .types.H256 blockHash = 2;
+  if (this->has_blockhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *blockhash_);
+  }
+
+  // .types.H256 transactionHash = 7;
+  if (this->has_transactionhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *transactionhash_);
+  }
+
+  // uint64 blockNumber = 3;
+  if (this->blocknumber() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_blocknumber());
+  }
+
+  // uint64 logIndex = 5;
+  if (this->logindex() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_logindex());
+  }
+
+  // uint64 transactionIndex = 8;
+  if (this->transactionindex() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_transactionindex());
+  }
+
+  // bool removed = 9;
+  if (this->removed() != 0) {
+    total_size += 1 + 1;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SubscribeLogsReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.SubscribeLogsReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SubscribeLogsReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SubscribeLogsReply>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.SubscribeLogsReply)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.SubscribeLogsReply)
+    MergeFrom(*source);
+  }
+}
+
+void SubscribeLogsReply::MergeFrom(const SubscribeLogsReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.SubscribeLogsReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  topics_.MergeFrom(from.topics_);
+  if (from.data().size() > 0) {
+    _internal_set_data(from._internal_data());
+  }
+  if (from.has_address()) {
+    _internal_mutable_address()->::types::H160::MergeFrom(from._internal_address());
+  }
+  if (from.has_blockhash()) {
+    _internal_mutable_blockhash()->::types::H256::MergeFrom(from._internal_blockhash());
+  }
+  if (from.has_transactionhash()) {
+    _internal_mutable_transactionhash()->::types::H256::MergeFrom(from._internal_transactionhash());
+  }
+  if (from.blocknumber() != 0) {
+    _internal_set_blocknumber(from._internal_blocknumber());
+  }
+  if (from.logindex() != 0) {
+    _internal_set_logindex(from._internal_logindex());
+  }
+  if (from.transactionindex() != 0) {
+    _internal_set_transactionindex(from._internal_transactionindex());
+  }
+  if (from.removed() != 0) {
+    _internal_set_removed(from._internal_removed());
+  }
+}
+
+void SubscribeLogsReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.SubscribeLogsReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SubscribeLogsReply::CopyFrom(const SubscribeLogsReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.SubscribeLogsReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SubscribeLogsReply::IsInitialized() const {
+  return true;
+}
+
+void SubscribeLogsReply::InternalSwap(SubscribeLogsReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  topics_.InternalSwap(&other->topics_);
+  data_.Swap(&other->data_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SubscribeLogsReply, removed_)
+      + sizeof(SubscribeLogsReply::removed_)
+      - PROTOBUF_FIELD_OFFSET(SubscribeLogsReply, address_)>(
+          reinterpret_cast<char*>(&address_),
+          reinterpret_cast<char*>(&other->address_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SubscribeLogsReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class BlockRequest::_Internal {
+ public:
+  static const ::types::H256& blockhash(const BlockRequest* msg);
+};
+
+const ::types::H256&
+BlockRequest::_Internal::blockhash(const BlockRequest* msg) {
+  return *msg->blockhash_;
+}
+void BlockRequest::clear_blockhash() {
+  if (GetArena() == nullptr && blockhash_ != nullptr) {
+    delete blockhash_;
+  }
+  blockhash_ = nullptr;
+}
+BlockRequest::BlockRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.BlockRequest)
+}
+BlockRequest::BlockRequest(const BlockRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_blockhash()) {
+    blockhash_ = new ::types::H256(*from.blockhash_);
+  } else {
+    blockhash_ = nullptr;
+  }
+  blockheight_ = from.blockheight_;
+  // @@protoc_insertion_point(copy_constructor:remote.BlockRequest)
+}
+
+void BlockRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_BlockRequest_remote_2fethbackend_2eproto.base);
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&blockhash_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&blockheight_) -
+      reinterpret_cast<char*>(&blockhash_)) + sizeof(blockheight_));
+}
+
+BlockRequest::~BlockRequest() {
+  // @@protoc_insertion_point(destructor:remote.BlockRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void BlockRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete blockhash_;
+}
+
+void BlockRequest::ArenaDtor(void* object) {
+  BlockRequest* _this = reinterpret_cast< BlockRequest* >(object);
+  (void)_this;
+}
+void BlockRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void BlockRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const BlockRequest& BlockRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_BlockRequest_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void BlockRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.BlockRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && blockhash_ != nullptr) {
+    delete blockhash_;
+  }
+  blockhash_ = nullptr;
+  blockheight_ = PROTOBUF_ULONGLONG(0);
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* BlockRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // uint64 blockHeight = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
+          blockheight_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 blockHash = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_blockhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* BlockRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.BlockRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint64 blockHeight = 2;
+  if (this->blockheight() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(2, this->_internal_blockheight(), target);
+  }
+
+  // .types.H256 blockHash = 3;
+  if (this->has_blockhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::blockhash(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.BlockRequest)
+  return target;
+}
+
+size_t BlockRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.BlockRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .types.H256 blockHash = 3;
+  if (this->has_blockhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *blockhash_);
+  }
+
+  // uint64 blockHeight = 2;
+  if (this->blockheight() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_blockheight());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void BlockRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.BlockRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const BlockRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<BlockRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.BlockRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.BlockRequest)
+    MergeFrom(*source);
+  }
+}
+
+void BlockRequest::MergeFrom(const BlockRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.BlockRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_blockhash()) {
+    _internal_mutable_blockhash()->::types::H256::MergeFrom(from._internal_blockhash());
+  }
+  if (from.blockheight() != 0) {
+    _internal_set_blockheight(from._internal_blockheight());
+  }
+}
+
+void BlockRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.BlockRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void BlockRequest::CopyFrom(const BlockRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.BlockRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool BlockRequest::IsInitialized() const {
+  return true;
+}
+
+void BlockRequest::InternalSwap(BlockRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(BlockRequest, blockheight_)
+      + sizeof(BlockRequest::blockheight_)
+      - PROTOBUF_FIELD_OFFSET(BlockRequest, blockhash_)>(
+          reinterpret_cast<char*>(&blockhash_),
+          reinterpret_cast<char*>(&other->blockhash_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata BlockRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class BlockReply::_Internal {
+ public:
+};
+
+BlockReply::BlockReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.BlockReply)
+}
+BlockReply::BlockReply(const BlockReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  blockrlp_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_blockrlp().empty()) {
+    blockrlp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_blockrlp(), 
+      GetArena());
+  }
+  senders_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_senders().empty()) {
+    senders_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_senders(), 
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:remote.BlockReply)
+}
+
+void BlockReply::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_BlockReply_remote_2fethbackend_2eproto.base);
+  blockrlp_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  senders_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+BlockReply::~BlockReply() {
+  // @@protoc_insertion_point(destructor:remote.BlockReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void BlockReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  blockrlp_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  senders_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void BlockReply::ArenaDtor(void* object) {
+  BlockReply* _this = reinterpret_cast< BlockReply* >(object);
+  (void)_this;
+}
+void BlockReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void BlockReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const BlockReply& BlockReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_BlockReply_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void BlockReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.BlockReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  blockrlp_.ClearToEmpty();
+  senders_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* BlockReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // bytes blockRlp = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_blockrlp();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bytes senders = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_senders();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* BlockReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.BlockReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bytes blockRlp = 1;
+  if (this->blockrlp().size() > 0) {
+    target = stream->WriteBytesMaybeAliased(
+        1, this->_internal_blockrlp(), target);
+  }
+
+  // bytes senders = 2;
+  if (this->senders().size() > 0) {
+    target = stream->WriteBytesMaybeAliased(
+        2, this->_internal_senders(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.BlockReply)
+  return target;
+}
+
+size_t BlockReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.BlockReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bytes blockRlp = 1;
+  if (this->blockrlp().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_blockrlp());
+  }
+
+  // bytes senders = 2;
+  if (this->senders().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_senders());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void BlockReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.BlockReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  const BlockReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<BlockReply>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.BlockReply)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.BlockReply)
+    MergeFrom(*source);
+  }
+}
+
+void BlockReply::MergeFrom(const BlockReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.BlockReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.blockrlp().size() > 0) {
+    _internal_set_blockrlp(from._internal_blockrlp());
+  }
+  if (from.senders().size() > 0) {
+    _internal_set_senders(from._internal_senders());
+  }
+}
+
+void BlockReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.BlockReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void BlockReply::CopyFrom(const BlockReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.BlockReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool BlockReply::IsInitialized() const {
+  return true;
+}
+
+void BlockReply::InternalSwap(BlockReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  blockrlp_.Swap(&other->blockrlp_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  senders_.Swap(&other->senders_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata BlockReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class TxnLookupRequest::_Internal {
+ public:
+  static const ::types::H256& txnhash(const TxnLookupRequest* msg);
+};
+
+const ::types::H256&
+TxnLookupRequest::_Internal::txnhash(const TxnLookupRequest* msg) {
+  return *msg->txnhash_;
+}
+void TxnLookupRequest::clear_txnhash() {
+  if (GetArena() == nullptr && txnhash_ != nullptr) {
+    delete txnhash_;
+  }
+  txnhash_ = nullptr;
+}
+TxnLookupRequest::TxnLookupRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.TxnLookupRequest)
+}
+TxnLookupRequest::TxnLookupRequest(const TxnLookupRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_txnhash()) {
+    txnhash_ = new ::types::H256(*from.txnhash_);
+  } else {
+    txnhash_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:remote.TxnLookupRequest)
+}
+
+void TxnLookupRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_TxnLookupRequest_remote_2fethbackend_2eproto.base);
+  txnhash_ = nullptr;
+}
+
+TxnLookupRequest::~TxnLookupRequest() {
+  // @@protoc_insertion_point(destructor:remote.TxnLookupRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void TxnLookupRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete txnhash_;
+}
+
+void TxnLookupRequest::ArenaDtor(void* object) {
+  TxnLookupRequest* _this = reinterpret_cast< TxnLookupRequest* >(object);
+  (void)_this;
+}
+void TxnLookupRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void TxnLookupRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const TxnLookupRequest& TxnLookupRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_TxnLookupRequest_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void TxnLookupRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.TxnLookupRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && txnhash_ != nullptr) {
+    delete txnhash_;
+  }
+  txnhash_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* TxnLookupRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .types.H256 txnHash = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_txnhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* TxnLookupRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.TxnLookupRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H256 txnHash = 1;
+  if (this->has_txnhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::txnhash(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.TxnLookupRequest)
+  return target;
+}
+
+size_t TxnLookupRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.TxnLookupRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .types.H256 txnHash = 1;
+  if (this->has_txnhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *txnhash_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void TxnLookupRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.TxnLookupRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TxnLookupRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<TxnLookupRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.TxnLookupRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.TxnLookupRequest)
+    MergeFrom(*source);
+  }
+}
+
+void TxnLookupRequest::MergeFrom(const TxnLookupRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.TxnLookupRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_txnhash()) {
+    _internal_mutable_txnhash()->::types::H256::MergeFrom(from._internal_txnhash());
+  }
+}
+
+void TxnLookupRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.TxnLookupRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TxnLookupRequest::CopyFrom(const TxnLookupRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.TxnLookupRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TxnLookupRequest::IsInitialized() const {
+  return true;
+}
+
+void TxnLookupRequest::InternalSwap(TxnLookupRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(txnhash_, other->txnhash_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata TxnLookupRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class TxnLookupReply::_Internal {
+ public:
+};
+
+TxnLookupReply::TxnLookupReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.TxnLookupReply)
+}
+TxnLookupReply::TxnLookupReply(const TxnLookupReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  blocknumber_ = from.blocknumber_;
+  // @@protoc_insertion_point(copy_constructor:remote.TxnLookupReply)
+}
+
+void TxnLookupReply::SharedCtor() {
+  blocknumber_ = PROTOBUF_ULONGLONG(0);
+}
+
+TxnLookupReply::~TxnLookupReply() {
+  // @@protoc_insertion_point(destructor:remote.TxnLookupReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void TxnLookupReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void TxnLookupReply::ArenaDtor(void* object) {
+  TxnLookupReply* _this = reinterpret_cast< TxnLookupReply* >(object);
+  (void)_this;
+}
+void TxnLookupReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void TxnLookupReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const TxnLookupReply& TxnLookupReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_TxnLookupReply_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void TxnLookupReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.TxnLookupReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  blocknumber_ = PROTOBUF_ULONGLONG(0);
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* TxnLookupReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // uint64 blockNumber = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          blocknumber_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* TxnLookupReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.TxnLookupReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint64 blockNumber = 1;
+  if (this->blocknumber() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(1, this->_internal_blocknumber(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.TxnLookupReply)
+  return target;
+}
+
+size_t TxnLookupReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.TxnLookupReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // uint64 blockNumber = 1;
+  if (this->blocknumber() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_blocknumber());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void TxnLookupReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.TxnLookupReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TxnLookupReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<TxnLookupReply>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.TxnLookupReply)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.TxnLookupReply)
+    MergeFrom(*source);
+  }
+}
+
+void TxnLookupReply::MergeFrom(const TxnLookupReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.TxnLookupReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.blocknumber() != 0) {
+    _internal_set_blocknumber(from._internal_blocknumber());
+  }
+}
+
+void TxnLookupReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.TxnLookupReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TxnLookupReply::CopyFrom(const TxnLookupReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.TxnLookupReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TxnLookupReply::IsInitialized() const {
+  return true;
+}
+
+void TxnLookupReply::InternalSwap(TxnLookupReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(blocknumber_, other->blocknumber_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata TxnLookupReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 class NodesInfoRequest::_Internal {
  public:
 };
@@ -3093,6 +6800,209 @@ void NodesInfoReply::InternalSwap(NodesInfoReply* other) {
 }
 
 
+// ===================================================================
+
+class PeersReply::_Internal {
+ public:
+};
+
+void PeersReply::clear_peers() {
+  peers_.Clear();
+}
+PeersReply::PeersReply(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  peers_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:remote.PeersReply)
+}
+PeersReply::PeersReply(const PeersReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      peers_(from.peers_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:remote.PeersReply)
+}
+
+void PeersReply::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeersReply_remote_2fethbackend_2eproto.base);
+}
+
+PeersReply::~PeersReply() {
+  // @@protoc_insertion_point(destructor:remote.PeersReply)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void PeersReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void PeersReply::ArenaDtor(void* object) {
+  PeersReply* _this = reinterpret_cast< PeersReply* >(object);
+  (void)_this;
+}
+void PeersReply::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PeersReply::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const PeersReply& PeersReply::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeersReply_remote_2fethbackend_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void PeersReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.PeersReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  peers_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PeersReply::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // repeated .types.PeerInfo peers = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_peers(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PeersReply::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:remote.PeersReply)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .types.PeerInfo peers = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_peers_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, this->_internal_peers(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:remote.PeersReply)
+  return target;
+}
+
+size_t PeersReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.PeersReply)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .types.PeerInfo peers = 1;
+  total_size += 1UL * this->_internal_peers_size();
+  for (const auto& msg : this->peers_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void PeersReply::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:remote.PeersReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  const PeersReply* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeersReply>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:remote.PeersReply)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:remote.PeersReply)
+    MergeFrom(*source);
+  }
+}
+
+void PeersReply::MergeFrom(const PeersReply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:remote.PeersReply)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  peers_.MergeFrom(from.peers_);
+}
+
+void PeersReply::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:remote.PeersReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void PeersReply::CopyFrom(const PeersReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.PeersReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PeersReply::IsInitialized() const {
+  return true;
+}
+
+void PeersReply::InternalSwap(PeersReply* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  peers_.InternalSwap(&other->peers_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PeersReply::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace remote
 PROTOBUF_NAMESPACE_OPEN
@@ -3114,6 +7024,24 @@ template<> PROTOBUF_NOINLINE ::remote::NetPeerCountRequest* Arena::CreateMaybeMe
 template<> PROTOBUF_NOINLINE ::remote::NetPeerCountReply* Arena::CreateMaybeMessage< ::remote::NetPeerCountReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::NetPeerCountReply >(arena);
 }
+template<> PROTOBUF_NOINLINE ::remote::EngineGetPayloadRequest* Arena::CreateMaybeMessage< ::remote::EngineGetPayloadRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::EngineGetPayloadRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::EnginePayloadStatus* Arena::CreateMaybeMessage< ::remote::EnginePayloadStatus >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::EnginePayloadStatus >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::EnginePayloadAttributes* Arena::CreateMaybeMessage< ::remote::EnginePayloadAttributes >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::EnginePayloadAttributes >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::EngineForkChoiceState* Arena::CreateMaybeMessage< ::remote::EngineForkChoiceState >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::EngineForkChoiceState >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::EngineForkChoiceUpdatedRequest* Arena::CreateMaybeMessage< ::remote::EngineForkChoiceUpdatedRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::EngineForkChoiceUpdatedRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::EngineForkChoiceUpdatedReply* Arena::CreateMaybeMessage< ::remote::EngineForkChoiceUpdatedReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::EngineForkChoiceUpdatedReply >(arena);
+}
 template<> PROTOBUF_NOINLINE ::remote::ProtocolVersionRequest* Arena::CreateMaybeMessage< ::remote::ProtocolVersionRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::ProtocolVersionRequest >(arena);
 }
@@ -3132,11 +7060,32 @@ template<> PROTOBUF_NOINLINE ::remote::SubscribeRequest* Arena::CreateMaybeMessa
 template<> PROTOBUF_NOINLINE ::remote::SubscribeReply* Arena::CreateMaybeMessage< ::remote::SubscribeReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::SubscribeReply >(arena);
 }
+template<> PROTOBUF_NOINLINE ::remote::LogsFilterRequest* Arena::CreateMaybeMessage< ::remote::LogsFilterRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::LogsFilterRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::SubscribeLogsReply* Arena::CreateMaybeMessage< ::remote::SubscribeLogsReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::SubscribeLogsReply >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::BlockRequest* Arena::CreateMaybeMessage< ::remote::BlockRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::BlockRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::BlockReply* Arena::CreateMaybeMessage< ::remote::BlockReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::BlockReply >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::TxnLookupRequest* Arena::CreateMaybeMessage< ::remote::TxnLookupRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::TxnLookupRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::TxnLookupReply* Arena::CreateMaybeMessage< ::remote::TxnLookupReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::TxnLookupReply >(arena);
+}
 template<> PROTOBUF_NOINLINE ::remote::NodesInfoRequest* Arena::CreateMaybeMessage< ::remote::NodesInfoRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::NodesInfoRequest >(arena);
 }
 template<> PROTOBUF_NOINLINE ::remote::NodesInfoReply* Arena::CreateMaybeMessage< ::remote::NodesInfoReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::NodesInfoReply >(arena);
+}
+template<> PROTOBUF_NOINLINE ::remote::PeersReply* Arena::CreateMaybeMessage< ::remote::PeersReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::PeersReply >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/interfaces/remote/ethbackend.pb.h
+++ b/interfaces/remote/ethbackend.pb.h
@@ -49,7 +49,7 @@ struct TableStruct_remote_2fethbackend_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[14]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[27]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -57,18 +57,45 @@ struct TableStruct_remote_2fethbackend_2eproto {
 };
 extern const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_remote_2fethbackend_2eproto;
 namespace remote {
+class BlockReply;
+class BlockReplyDefaultTypeInternal;
+extern BlockReplyDefaultTypeInternal _BlockReply_default_instance_;
+class BlockRequest;
+class BlockRequestDefaultTypeInternal;
+extern BlockRequestDefaultTypeInternal _BlockRequest_default_instance_;
 class ClientVersionReply;
 class ClientVersionReplyDefaultTypeInternal;
 extern ClientVersionReplyDefaultTypeInternal _ClientVersionReply_default_instance_;
 class ClientVersionRequest;
 class ClientVersionRequestDefaultTypeInternal;
 extern ClientVersionRequestDefaultTypeInternal _ClientVersionRequest_default_instance_;
+class EngineForkChoiceState;
+class EngineForkChoiceStateDefaultTypeInternal;
+extern EngineForkChoiceStateDefaultTypeInternal _EngineForkChoiceState_default_instance_;
+class EngineForkChoiceUpdatedReply;
+class EngineForkChoiceUpdatedReplyDefaultTypeInternal;
+extern EngineForkChoiceUpdatedReplyDefaultTypeInternal _EngineForkChoiceUpdatedReply_default_instance_;
+class EngineForkChoiceUpdatedRequest;
+class EngineForkChoiceUpdatedRequestDefaultTypeInternal;
+extern EngineForkChoiceUpdatedRequestDefaultTypeInternal _EngineForkChoiceUpdatedRequest_default_instance_;
+class EngineGetPayloadRequest;
+class EngineGetPayloadRequestDefaultTypeInternal;
+extern EngineGetPayloadRequestDefaultTypeInternal _EngineGetPayloadRequest_default_instance_;
+class EnginePayloadAttributes;
+class EnginePayloadAttributesDefaultTypeInternal;
+extern EnginePayloadAttributesDefaultTypeInternal _EnginePayloadAttributes_default_instance_;
+class EnginePayloadStatus;
+class EnginePayloadStatusDefaultTypeInternal;
+extern EnginePayloadStatusDefaultTypeInternal _EnginePayloadStatus_default_instance_;
 class EtherbaseReply;
 class EtherbaseReplyDefaultTypeInternal;
 extern EtherbaseReplyDefaultTypeInternal _EtherbaseReply_default_instance_;
 class EtherbaseRequest;
 class EtherbaseRequestDefaultTypeInternal;
 extern EtherbaseRequestDefaultTypeInternal _EtherbaseRequest_default_instance_;
+class LogsFilterRequest;
+class LogsFilterRequestDefaultTypeInternal;
+extern LogsFilterRequestDefaultTypeInternal _LogsFilterRequest_default_instance_;
 class NetPeerCountReply;
 class NetPeerCountReplyDefaultTypeInternal;
 extern NetPeerCountReplyDefaultTypeInternal _NetPeerCountReply_default_instance_;
@@ -87,34 +114,59 @@ extern NodesInfoReplyDefaultTypeInternal _NodesInfoReply_default_instance_;
 class NodesInfoRequest;
 class NodesInfoRequestDefaultTypeInternal;
 extern NodesInfoRequestDefaultTypeInternal _NodesInfoRequest_default_instance_;
+class PeersReply;
+class PeersReplyDefaultTypeInternal;
+extern PeersReplyDefaultTypeInternal _PeersReply_default_instance_;
 class ProtocolVersionReply;
 class ProtocolVersionReplyDefaultTypeInternal;
 extern ProtocolVersionReplyDefaultTypeInternal _ProtocolVersionReply_default_instance_;
 class ProtocolVersionRequest;
 class ProtocolVersionRequestDefaultTypeInternal;
 extern ProtocolVersionRequestDefaultTypeInternal _ProtocolVersionRequest_default_instance_;
+class SubscribeLogsReply;
+class SubscribeLogsReplyDefaultTypeInternal;
+extern SubscribeLogsReplyDefaultTypeInternal _SubscribeLogsReply_default_instance_;
 class SubscribeReply;
 class SubscribeReplyDefaultTypeInternal;
 extern SubscribeReplyDefaultTypeInternal _SubscribeReply_default_instance_;
 class SubscribeRequest;
 class SubscribeRequestDefaultTypeInternal;
 extern SubscribeRequestDefaultTypeInternal _SubscribeRequest_default_instance_;
+class TxnLookupReply;
+class TxnLookupReplyDefaultTypeInternal;
+extern TxnLookupReplyDefaultTypeInternal _TxnLookupReply_default_instance_;
+class TxnLookupRequest;
+class TxnLookupRequestDefaultTypeInternal;
+extern TxnLookupRequestDefaultTypeInternal _TxnLookupRequest_default_instance_;
 }  // namespace remote
 PROTOBUF_NAMESPACE_OPEN
+template<> ::remote::BlockReply* Arena::CreateMaybeMessage<::remote::BlockReply>(Arena*);
+template<> ::remote::BlockRequest* Arena::CreateMaybeMessage<::remote::BlockRequest>(Arena*);
 template<> ::remote::ClientVersionReply* Arena::CreateMaybeMessage<::remote::ClientVersionReply>(Arena*);
 template<> ::remote::ClientVersionRequest* Arena::CreateMaybeMessage<::remote::ClientVersionRequest>(Arena*);
+template<> ::remote::EngineForkChoiceState* Arena::CreateMaybeMessage<::remote::EngineForkChoiceState>(Arena*);
+template<> ::remote::EngineForkChoiceUpdatedReply* Arena::CreateMaybeMessage<::remote::EngineForkChoiceUpdatedReply>(Arena*);
+template<> ::remote::EngineForkChoiceUpdatedRequest* Arena::CreateMaybeMessage<::remote::EngineForkChoiceUpdatedRequest>(Arena*);
+template<> ::remote::EngineGetPayloadRequest* Arena::CreateMaybeMessage<::remote::EngineGetPayloadRequest>(Arena*);
+template<> ::remote::EnginePayloadAttributes* Arena::CreateMaybeMessage<::remote::EnginePayloadAttributes>(Arena*);
+template<> ::remote::EnginePayloadStatus* Arena::CreateMaybeMessage<::remote::EnginePayloadStatus>(Arena*);
 template<> ::remote::EtherbaseReply* Arena::CreateMaybeMessage<::remote::EtherbaseReply>(Arena*);
 template<> ::remote::EtherbaseRequest* Arena::CreateMaybeMessage<::remote::EtherbaseRequest>(Arena*);
+template<> ::remote::LogsFilterRequest* Arena::CreateMaybeMessage<::remote::LogsFilterRequest>(Arena*);
 template<> ::remote::NetPeerCountReply* Arena::CreateMaybeMessage<::remote::NetPeerCountReply>(Arena*);
 template<> ::remote::NetPeerCountRequest* Arena::CreateMaybeMessage<::remote::NetPeerCountRequest>(Arena*);
 template<> ::remote::NetVersionReply* Arena::CreateMaybeMessage<::remote::NetVersionReply>(Arena*);
 template<> ::remote::NetVersionRequest* Arena::CreateMaybeMessage<::remote::NetVersionRequest>(Arena*);
 template<> ::remote::NodesInfoReply* Arena::CreateMaybeMessage<::remote::NodesInfoReply>(Arena*);
 template<> ::remote::NodesInfoRequest* Arena::CreateMaybeMessage<::remote::NodesInfoRequest>(Arena*);
+template<> ::remote::PeersReply* Arena::CreateMaybeMessage<::remote::PeersReply>(Arena*);
 template<> ::remote::ProtocolVersionReply* Arena::CreateMaybeMessage<::remote::ProtocolVersionReply>(Arena*);
 template<> ::remote::ProtocolVersionRequest* Arena::CreateMaybeMessage<::remote::ProtocolVersionRequest>(Arena*);
+template<> ::remote::SubscribeLogsReply* Arena::CreateMaybeMessage<::remote::SubscribeLogsReply>(Arena*);
 template<> ::remote::SubscribeReply* Arena::CreateMaybeMessage<::remote::SubscribeReply>(Arena*);
 template<> ::remote::SubscribeRequest* Arena::CreateMaybeMessage<::remote::SubscribeRequest>(Arena*);
+template<> ::remote::TxnLookupReply* Arena::CreateMaybeMessage<::remote::TxnLookupReply>(Arena*);
+template<> ::remote::TxnLookupRequest* Arena::CreateMaybeMessage<::remote::TxnLookupRequest>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace remote {
 
@@ -122,12 +174,13 @@ enum Event : int {
   HEADER = 0,
   PENDING_LOGS = 1,
   PENDING_BLOCK = 2,
+  NEW_SNAPSHOT = 3,
   Event_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
   Event_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
 };
 bool Event_IsValid(int value);
 constexpr Event Event_MIN = HEADER;
-constexpr Event Event_MAX = PENDING_BLOCK;
+constexpr Event Event_MAX = NEW_SNAPSHOT;
 constexpr int Event_ARRAYSIZE = Event_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* Event_descriptor();
@@ -143,6 +196,34 @@ inline bool Event_Parse(
     ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, Event* value) {
   return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<Event>(
     Event_descriptor(), name, value);
+}
+enum EngineStatus : int {
+  VALID = 0,
+  INVALID = 1,
+  SYNCING = 2,
+  ACCEPTED = 3,
+  INVALID_BLOCK_HASH = 4,
+  EngineStatus_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::min(),
+  EngineStatus_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<::PROTOBUF_NAMESPACE_ID::int32>::max()
+};
+bool EngineStatus_IsValid(int value);
+constexpr EngineStatus EngineStatus_MIN = VALID;
+constexpr EngineStatus EngineStatus_MAX = INVALID_BLOCK_HASH;
+constexpr int EngineStatus_ARRAYSIZE = EngineStatus_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* EngineStatus_descriptor();
+template<typename T>
+inline const std::string& EngineStatus_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, EngineStatus>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function EngineStatus_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    EngineStatus_descriptor(), enum_t_value);
+}
+inline bool EngineStatus_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, EngineStatus* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<EngineStatus>(
+    EngineStatus_descriptor(), name, value);
 }
 // ===================================================================
 
@@ -932,6 +1013,998 @@ class NetPeerCountReply PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class EngineGetPayloadRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.EngineGetPayloadRequest) */ {
+ public:
+  inline EngineGetPayloadRequest() : EngineGetPayloadRequest(nullptr) {}
+  virtual ~EngineGetPayloadRequest();
+
+  EngineGetPayloadRequest(const EngineGetPayloadRequest& from);
+  EngineGetPayloadRequest(EngineGetPayloadRequest&& from) noexcept
+    : EngineGetPayloadRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline EngineGetPayloadRequest& operator=(const EngineGetPayloadRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EngineGetPayloadRequest& operator=(EngineGetPayloadRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const EngineGetPayloadRequest& default_instance();
+
+  static inline const EngineGetPayloadRequest* internal_default_instance() {
+    return reinterpret_cast<const EngineGetPayloadRequest*>(
+               &_EngineGetPayloadRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    6;
+
+  friend void swap(EngineGetPayloadRequest& a, EngineGetPayloadRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(EngineGetPayloadRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EngineGetPayloadRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline EngineGetPayloadRequest* New() const final {
+    return CreateMaybeMessage<EngineGetPayloadRequest>(nullptr);
+  }
+
+  EngineGetPayloadRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<EngineGetPayloadRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const EngineGetPayloadRequest& from);
+  void MergeFrom(const EngineGetPayloadRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(EngineGetPayloadRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.EngineGetPayloadRequest";
+  }
+  protected:
+  explicit EngineGetPayloadRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPayloadIdFieldNumber = 1,
+  };
+  // uint64 payloadId = 1;
+  void clear_payloadid();
+  ::PROTOBUF_NAMESPACE_ID::uint64 payloadid() const;
+  void set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_payloadid() const;
+  void _internal_set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.EngineGetPayloadRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 payloadid_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class EnginePayloadStatus PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.EnginePayloadStatus) */ {
+ public:
+  inline EnginePayloadStatus() : EnginePayloadStatus(nullptr) {}
+  virtual ~EnginePayloadStatus();
+
+  EnginePayloadStatus(const EnginePayloadStatus& from);
+  EnginePayloadStatus(EnginePayloadStatus&& from) noexcept
+    : EnginePayloadStatus() {
+    *this = ::std::move(from);
+  }
+
+  inline EnginePayloadStatus& operator=(const EnginePayloadStatus& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EnginePayloadStatus& operator=(EnginePayloadStatus&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const EnginePayloadStatus& default_instance();
+
+  static inline const EnginePayloadStatus* internal_default_instance() {
+    return reinterpret_cast<const EnginePayloadStatus*>(
+               &_EnginePayloadStatus_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    7;
+
+  friend void swap(EnginePayloadStatus& a, EnginePayloadStatus& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(EnginePayloadStatus* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EnginePayloadStatus* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline EnginePayloadStatus* New() const final {
+    return CreateMaybeMessage<EnginePayloadStatus>(nullptr);
+  }
+
+  EnginePayloadStatus* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<EnginePayloadStatus>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const EnginePayloadStatus& from);
+  void MergeFrom(const EnginePayloadStatus& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(EnginePayloadStatus* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.EnginePayloadStatus";
+  }
+  protected:
+  explicit EnginePayloadStatus(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kValidationErrorFieldNumber = 3,
+    kLatestValidHashFieldNumber = 2,
+    kStatusFieldNumber = 1,
+  };
+  // string validationError = 3;
+  void clear_validationerror();
+  const std::string& validationerror() const;
+  void set_validationerror(const std::string& value);
+  void set_validationerror(std::string&& value);
+  void set_validationerror(const char* value);
+  void set_validationerror(const char* value, size_t size);
+  std::string* mutable_validationerror();
+  std::string* release_validationerror();
+  void set_allocated_validationerror(std::string* validationerror);
+  private:
+  const std::string& _internal_validationerror() const;
+  void _internal_set_validationerror(const std::string& value);
+  std::string* _internal_mutable_validationerror();
+  public:
+
+  // .types.H256 latestValidHash = 2;
+  bool has_latestvalidhash() const;
+  private:
+  bool _internal_has_latestvalidhash() const;
+  public:
+  void clear_latestvalidhash();
+  const ::types::H256& latestvalidhash() const;
+  ::types::H256* release_latestvalidhash();
+  ::types::H256* mutable_latestvalidhash();
+  void set_allocated_latestvalidhash(::types::H256* latestvalidhash);
+  private:
+  const ::types::H256& _internal_latestvalidhash() const;
+  ::types::H256* _internal_mutable_latestvalidhash();
+  public:
+  void unsafe_arena_set_allocated_latestvalidhash(
+      ::types::H256* latestvalidhash);
+  ::types::H256* unsafe_arena_release_latestvalidhash();
+
+  // .remote.EngineStatus status = 1;
+  void clear_status();
+  ::remote::EngineStatus status() const;
+  void set_status(::remote::EngineStatus value);
+  private:
+  ::remote::EngineStatus _internal_status() const;
+  void _internal_set_status(::remote::EngineStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.EnginePayloadStatus)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr validationerror_;
+  ::types::H256* latestvalidhash_;
+  int status_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class EnginePayloadAttributes PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.EnginePayloadAttributes) */ {
+ public:
+  inline EnginePayloadAttributes() : EnginePayloadAttributes(nullptr) {}
+  virtual ~EnginePayloadAttributes();
+
+  EnginePayloadAttributes(const EnginePayloadAttributes& from);
+  EnginePayloadAttributes(EnginePayloadAttributes&& from) noexcept
+    : EnginePayloadAttributes() {
+    *this = ::std::move(from);
+  }
+
+  inline EnginePayloadAttributes& operator=(const EnginePayloadAttributes& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EnginePayloadAttributes& operator=(EnginePayloadAttributes&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const EnginePayloadAttributes& default_instance();
+
+  static inline const EnginePayloadAttributes* internal_default_instance() {
+    return reinterpret_cast<const EnginePayloadAttributes*>(
+               &_EnginePayloadAttributes_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  friend void swap(EnginePayloadAttributes& a, EnginePayloadAttributes& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(EnginePayloadAttributes* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EnginePayloadAttributes* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline EnginePayloadAttributes* New() const final {
+    return CreateMaybeMessage<EnginePayloadAttributes>(nullptr);
+  }
+
+  EnginePayloadAttributes* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<EnginePayloadAttributes>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const EnginePayloadAttributes& from);
+  void MergeFrom(const EnginePayloadAttributes& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(EnginePayloadAttributes* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.EnginePayloadAttributes";
+  }
+  protected:
+  explicit EnginePayloadAttributes(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPrevRandaoFieldNumber = 2,
+    kSuggestedFeeRecipientFieldNumber = 3,
+    kTimestampFieldNumber = 1,
+  };
+  // .types.H256 prevRandao = 2;
+  bool has_prevrandao() const;
+  private:
+  bool _internal_has_prevrandao() const;
+  public:
+  void clear_prevrandao();
+  const ::types::H256& prevrandao() const;
+  ::types::H256* release_prevrandao();
+  ::types::H256* mutable_prevrandao();
+  void set_allocated_prevrandao(::types::H256* prevrandao);
+  private:
+  const ::types::H256& _internal_prevrandao() const;
+  ::types::H256* _internal_mutable_prevrandao();
+  public:
+  void unsafe_arena_set_allocated_prevrandao(
+      ::types::H256* prevrandao);
+  ::types::H256* unsafe_arena_release_prevrandao();
+
+  // .types.H160 suggestedFeeRecipient = 3;
+  bool has_suggestedfeerecipient() const;
+  private:
+  bool _internal_has_suggestedfeerecipient() const;
+  public:
+  void clear_suggestedfeerecipient();
+  const ::types::H160& suggestedfeerecipient() const;
+  ::types::H160* release_suggestedfeerecipient();
+  ::types::H160* mutable_suggestedfeerecipient();
+  void set_allocated_suggestedfeerecipient(::types::H160* suggestedfeerecipient);
+  private:
+  const ::types::H160& _internal_suggestedfeerecipient() const;
+  ::types::H160* _internal_mutable_suggestedfeerecipient();
+  public:
+  void unsafe_arena_set_allocated_suggestedfeerecipient(
+      ::types::H160* suggestedfeerecipient);
+  ::types::H160* unsafe_arena_release_suggestedfeerecipient();
+
+  // uint64 timestamp = 1;
+  void clear_timestamp();
+  ::PROTOBUF_NAMESPACE_ID::uint64 timestamp() const;
+  void set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_timestamp() const;
+  void _internal_set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.EnginePayloadAttributes)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::types::H256* prevrandao_;
+  ::types::H160* suggestedfeerecipient_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 timestamp_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class EngineForkChoiceState PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.EngineForkChoiceState) */ {
+ public:
+  inline EngineForkChoiceState() : EngineForkChoiceState(nullptr) {}
+  virtual ~EngineForkChoiceState();
+
+  EngineForkChoiceState(const EngineForkChoiceState& from);
+  EngineForkChoiceState(EngineForkChoiceState&& from) noexcept
+    : EngineForkChoiceState() {
+    *this = ::std::move(from);
+  }
+
+  inline EngineForkChoiceState& operator=(const EngineForkChoiceState& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EngineForkChoiceState& operator=(EngineForkChoiceState&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const EngineForkChoiceState& default_instance();
+
+  static inline const EngineForkChoiceState* internal_default_instance() {
+    return reinterpret_cast<const EngineForkChoiceState*>(
+               &_EngineForkChoiceState_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    9;
+
+  friend void swap(EngineForkChoiceState& a, EngineForkChoiceState& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(EngineForkChoiceState* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EngineForkChoiceState* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline EngineForkChoiceState* New() const final {
+    return CreateMaybeMessage<EngineForkChoiceState>(nullptr);
+  }
+
+  EngineForkChoiceState* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<EngineForkChoiceState>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const EngineForkChoiceState& from);
+  void MergeFrom(const EngineForkChoiceState& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(EngineForkChoiceState* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.EngineForkChoiceState";
+  }
+  protected:
+  explicit EngineForkChoiceState(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kHeadBlockHashFieldNumber = 1,
+    kSafeBlockHashFieldNumber = 2,
+    kFinalizedBlockHashFieldNumber = 3,
+  };
+  // .types.H256 headBlockHash = 1;
+  bool has_headblockhash() const;
+  private:
+  bool _internal_has_headblockhash() const;
+  public:
+  void clear_headblockhash();
+  const ::types::H256& headblockhash() const;
+  ::types::H256* release_headblockhash();
+  ::types::H256* mutable_headblockhash();
+  void set_allocated_headblockhash(::types::H256* headblockhash);
+  private:
+  const ::types::H256& _internal_headblockhash() const;
+  ::types::H256* _internal_mutable_headblockhash();
+  public:
+  void unsafe_arena_set_allocated_headblockhash(
+      ::types::H256* headblockhash);
+  ::types::H256* unsafe_arena_release_headblockhash();
+
+  // .types.H256 safeBlockHash = 2;
+  bool has_safeblockhash() const;
+  private:
+  bool _internal_has_safeblockhash() const;
+  public:
+  void clear_safeblockhash();
+  const ::types::H256& safeblockhash() const;
+  ::types::H256* release_safeblockhash();
+  ::types::H256* mutable_safeblockhash();
+  void set_allocated_safeblockhash(::types::H256* safeblockhash);
+  private:
+  const ::types::H256& _internal_safeblockhash() const;
+  ::types::H256* _internal_mutable_safeblockhash();
+  public:
+  void unsafe_arena_set_allocated_safeblockhash(
+      ::types::H256* safeblockhash);
+  ::types::H256* unsafe_arena_release_safeblockhash();
+
+  // .types.H256 finalizedBlockHash = 3;
+  bool has_finalizedblockhash() const;
+  private:
+  bool _internal_has_finalizedblockhash() const;
+  public:
+  void clear_finalizedblockhash();
+  const ::types::H256& finalizedblockhash() const;
+  ::types::H256* release_finalizedblockhash();
+  ::types::H256* mutable_finalizedblockhash();
+  void set_allocated_finalizedblockhash(::types::H256* finalizedblockhash);
+  private:
+  const ::types::H256& _internal_finalizedblockhash() const;
+  ::types::H256* _internal_mutable_finalizedblockhash();
+  public:
+  void unsafe_arena_set_allocated_finalizedblockhash(
+      ::types::H256* finalizedblockhash);
+  ::types::H256* unsafe_arena_release_finalizedblockhash();
+
+  // @@protoc_insertion_point(class_scope:remote.EngineForkChoiceState)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::types::H256* headblockhash_;
+  ::types::H256* safeblockhash_;
+  ::types::H256* finalizedblockhash_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class EngineForkChoiceUpdatedRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.EngineForkChoiceUpdatedRequest) */ {
+ public:
+  inline EngineForkChoiceUpdatedRequest() : EngineForkChoiceUpdatedRequest(nullptr) {}
+  virtual ~EngineForkChoiceUpdatedRequest();
+
+  EngineForkChoiceUpdatedRequest(const EngineForkChoiceUpdatedRequest& from);
+  EngineForkChoiceUpdatedRequest(EngineForkChoiceUpdatedRequest&& from) noexcept
+    : EngineForkChoiceUpdatedRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline EngineForkChoiceUpdatedRequest& operator=(const EngineForkChoiceUpdatedRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EngineForkChoiceUpdatedRequest& operator=(EngineForkChoiceUpdatedRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const EngineForkChoiceUpdatedRequest& default_instance();
+
+  static inline const EngineForkChoiceUpdatedRequest* internal_default_instance() {
+    return reinterpret_cast<const EngineForkChoiceUpdatedRequest*>(
+               &_EngineForkChoiceUpdatedRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  friend void swap(EngineForkChoiceUpdatedRequest& a, EngineForkChoiceUpdatedRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(EngineForkChoiceUpdatedRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EngineForkChoiceUpdatedRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline EngineForkChoiceUpdatedRequest* New() const final {
+    return CreateMaybeMessage<EngineForkChoiceUpdatedRequest>(nullptr);
+  }
+
+  EngineForkChoiceUpdatedRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<EngineForkChoiceUpdatedRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const EngineForkChoiceUpdatedRequest& from);
+  void MergeFrom(const EngineForkChoiceUpdatedRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(EngineForkChoiceUpdatedRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.EngineForkChoiceUpdatedRequest";
+  }
+  protected:
+  explicit EngineForkChoiceUpdatedRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kForkchoiceStateFieldNumber = 1,
+    kPayloadAttributesFieldNumber = 2,
+  };
+  // .remote.EngineForkChoiceState forkchoiceState = 1;
+  bool has_forkchoicestate() const;
+  private:
+  bool _internal_has_forkchoicestate() const;
+  public:
+  void clear_forkchoicestate();
+  const ::remote::EngineForkChoiceState& forkchoicestate() const;
+  ::remote::EngineForkChoiceState* release_forkchoicestate();
+  ::remote::EngineForkChoiceState* mutable_forkchoicestate();
+  void set_allocated_forkchoicestate(::remote::EngineForkChoiceState* forkchoicestate);
+  private:
+  const ::remote::EngineForkChoiceState& _internal_forkchoicestate() const;
+  ::remote::EngineForkChoiceState* _internal_mutable_forkchoicestate();
+  public:
+  void unsafe_arena_set_allocated_forkchoicestate(
+      ::remote::EngineForkChoiceState* forkchoicestate);
+  ::remote::EngineForkChoiceState* unsafe_arena_release_forkchoicestate();
+
+  // .remote.EnginePayloadAttributes payloadAttributes = 2;
+  bool has_payloadattributes() const;
+  private:
+  bool _internal_has_payloadattributes() const;
+  public:
+  void clear_payloadattributes();
+  const ::remote::EnginePayloadAttributes& payloadattributes() const;
+  ::remote::EnginePayloadAttributes* release_payloadattributes();
+  ::remote::EnginePayloadAttributes* mutable_payloadattributes();
+  void set_allocated_payloadattributes(::remote::EnginePayloadAttributes* payloadattributes);
+  private:
+  const ::remote::EnginePayloadAttributes& _internal_payloadattributes() const;
+  ::remote::EnginePayloadAttributes* _internal_mutable_payloadattributes();
+  public:
+  void unsafe_arena_set_allocated_payloadattributes(
+      ::remote::EnginePayloadAttributes* payloadattributes);
+  ::remote::EnginePayloadAttributes* unsafe_arena_release_payloadattributes();
+
+  // @@protoc_insertion_point(class_scope:remote.EngineForkChoiceUpdatedRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::remote::EngineForkChoiceState* forkchoicestate_;
+  ::remote::EnginePayloadAttributes* payloadattributes_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class EngineForkChoiceUpdatedReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.EngineForkChoiceUpdatedReply) */ {
+ public:
+  inline EngineForkChoiceUpdatedReply() : EngineForkChoiceUpdatedReply(nullptr) {}
+  virtual ~EngineForkChoiceUpdatedReply();
+
+  EngineForkChoiceUpdatedReply(const EngineForkChoiceUpdatedReply& from);
+  EngineForkChoiceUpdatedReply(EngineForkChoiceUpdatedReply&& from) noexcept
+    : EngineForkChoiceUpdatedReply() {
+    *this = ::std::move(from);
+  }
+
+  inline EngineForkChoiceUpdatedReply& operator=(const EngineForkChoiceUpdatedReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EngineForkChoiceUpdatedReply& operator=(EngineForkChoiceUpdatedReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const EngineForkChoiceUpdatedReply& default_instance();
+
+  static inline const EngineForkChoiceUpdatedReply* internal_default_instance() {
+    return reinterpret_cast<const EngineForkChoiceUpdatedReply*>(
+               &_EngineForkChoiceUpdatedReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    11;
+
+  friend void swap(EngineForkChoiceUpdatedReply& a, EngineForkChoiceUpdatedReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(EngineForkChoiceUpdatedReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EngineForkChoiceUpdatedReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline EngineForkChoiceUpdatedReply* New() const final {
+    return CreateMaybeMessage<EngineForkChoiceUpdatedReply>(nullptr);
+  }
+
+  EngineForkChoiceUpdatedReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<EngineForkChoiceUpdatedReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const EngineForkChoiceUpdatedReply& from);
+  void MergeFrom(const EngineForkChoiceUpdatedReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(EngineForkChoiceUpdatedReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.EngineForkChoiceUpdatedReply";
+  }
+  protected:
+  explicit EngineForkChoiceUpdatedReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPayloadStatusFieldNumber = 1,
+    kPayloadIdFieldNumber = 2,
+  };
+  // .remote.EnginePayloadStatus payloadStatus = 1;
+  bool has_payloadstatus() const;
+  private:
+  bool _internal_has_payloadstatus() const;
+  public:
+  void clear_payloadstatus();
+  const ::remote::EnginePayloadStatus& payloadstatus() const;
+  ::remote::EnginePayloadStatus* release_payloadstatus();
+  ::remote::EnginePayloadStatus* mutable_payloadstatus();
+  void set_allocated_payloadstatus(::remote::EnginePayloadStatus* payloadstatus);
+  private:
+  const ::remote::EnginePayloadStatus& _internal_payloadstatus() const;
+  ::remote::EnginePayloadStatus* _internal_mutable_payloadstatus();
+  public:
+  void unsafe_arena_set_allocated_payloadstatus(
+      ::remote::EnginePayloadStatus* payloadstatus);
+  ::remote::EnginePayloadStatus* unsafe_arena_release_payloadstatus();
+
+  // uint64 payloadId = 2;
+  void clear_payloadid();
+  ::PROTOBUF_NAMESPACE_ID::uint64 payloadid() const;
+  void set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_payloadid() const;
+  void _internal_set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.EngineForkChoiceUpdatedReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::remote::EnginePayloadStatus* payloadstatus_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 payloadid_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ProtocolVersionRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.ProtocolVersionRequest) */ {
  public:
@@ -973,7 +2046,7 @@ class ProtocolVersionRequest PROTOBUF_FINAL :
                &_ProtocolVersionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    12;
 
   friend void swap(ProtocolVersionRequest& a, ProtocolVersionRequest& b) {
     a.Swap(&b);
@@ -1096,7 +2169,7 @@ class ProtocolVersionReply PROTOBUF_FINAL :
                &_ProtocolVersionReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    13;
 
   friend void swap(ProtocolVersionReply& a, ProtocolVersionReply& b) {
     a.Swap(&b);
@@ -1232,7 +2305,7 @@ class ClientVersionRequest PROTOBUF_FINAL :
                &_ClientVersionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    14;
 
   friend void swap(ClientVersionRequest& a, ClientVersionRequest& b) {
     a.Swap(&b);
@@ -1355,7 +2428,7 @@ class ClientVersionReply PROTOBUF_FINAL :
                &_ClientVersionReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    15;
 
   friend void swap(ClientVersionReply& a, ClientVersionReply& b) {
     a.Swap(&b);
@@ -1498,7 +2571,7 @@ class SubscribeRequest PROTOBUF_FINAL :
                &_SubscribeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    16;
 
   friend void swap(SubscribeRequest& a, SubscribeRequest& b) {
     a.Swap(&b);
@@ -1634,7 +2707,7 @@ class SubscribeReply PROTOBUF_FINAL :
                &_SubscribeReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    17;
 
   friend void swap(SubscribeReply& a, SubscribeReply& b) {
     a.Swap(&b);
@@ -1747,6 +2820,1058 @@ class SubscribeReply PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class LogsFilterRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.LogsFilterRequest) */ {
+ public:
+  inline LogsFilterRequest() : LogsFilterRequest(nullptr) {}
+  virtual ~LogsFilterRequest();
+
+  LogsFilterRequest(const LogsFilterRequest& from);
+  LogsFilterRequest(LogsFilterRequest&& from) noexcept
+    : LogsFilterRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline LogsFilterRequest& operator=(const LogsFilterRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline LogsFilterRequest& operator=(LogsFilterRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const LogsFilterRequest& default_instance();
+
+  static inline const LogsFilterRequest* internal_default_instance() {
+    return reinterpret_cast<const LogsFilterRequest*>(
+               &_LogsFilterRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    18;
+
+  friend void swap(LogsFilterRequest& a, LogsFilterRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(LogsFilterRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(LogsFilterRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline LogsFilterRequest* New() const final {
+    return CreateMaybeMessage<LogsFilterRequest>(nullptr);
+  }
+
+  LogsFilterRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<LogsFilterRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const LogsFilterRequest& from);
+  void MergeFrom(const LogsFilterRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(LogsFilterRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.LogsFilterRequest";
+  }
+  protected:
+  explicit LogsFilterRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kAddressesFieldNumber = 2,
+    kTopicsFieldNumber = 4,
+    kAllAddressesFieldNumber = 1,
+    kAllTopicsFieldNumber = 3,
+  };
+  // repeated .types.H160 addresses = 2;
+  int addresses_size() const;
+  private:
+  int _internal_addresses_size() const;
+  public:
+  void clear_addresses();
+  ::types::H160* mutable_addresses(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H160 >*
+      mutable_addresses();
+  private:
+  const ::types::H160& _internal_addresses(int index) const;
+  ::types::H160* _internal_add_addresses();
+  public:
+  const ::types::H160& addresses(int index) const;
+  ::types::H160* add_addresses();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H160 >&
+      addresses() const;
+
+  // repeated .types.H256 topics = 4;
+  int topics_size() const;
+  private:
+  int _internal_topics_size() const;
+  public:
+  void clear_topics();
+  ::types::H256* mutable_topics(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >*
+      mutable_topics();
+  private:
+  const ::types::H256& _internal_topics(int index) const;
+  ::types::H256* _internal_add_topics();
+  public:
+  const ::types::H256& topics(int index) const;
+  ::types::H256* add_topics();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >&
+      topics() const;
+
+  // bool allAddresses = 1;
+  void clear_alladdresses();
+  bool alladdresses() const;
+  void set_alladdresses(bool value);
+  private:
+  bool _internal_alladdresses() const;
+  void _internal_set_alladdresses(bool value);
+  public:
+
+  // bool allTopics = 3;
+  void clear_alltopics();
+  bool alltopics() const;
+  void set_alltopics(bool value);
+  private:
+  bool _internal_alltopics() const;
+  void _internal_set_alltopics(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.LogsFilterRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H160 > addresses_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 > topics_;
+  bool alladdresses_;
+  bool alltopics_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeLogsReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.SubscribeLogsReply) */ {
+ public:
+  inline SubscribeLogsReply() : SubscribeLogsReply(nullptr) {}
+  virtual ~SubscribeLogsReply();
+
+  SubscribeLogsReply(const SubscribeLogsReply& from);
+  SubscribeLogsReply(SubscribeLogsReply&& from) noexcept
+    : SubscribeLogsReply() {
+    *this = ::std::move(from);
+  }
+
+  inline SubscribeLogsReply& operator=(const SubscribeLogsReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeLogsReply& operator=(SubscribeLogsReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SubscribeLogsReply& default_instance();
+
+  static inline const SubscribeLogsReply* internal_default_instance() {
+    return reinterpret_cast<const SubscribeLogsReply*>(
+               &_SubscribeLogsReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    19;
+
+  friend void swap(SubscribeLogsReply& a, SubscribeLogsReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SubscribeLogsReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeLogsReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SubscribeLogsReply* New() const final {
+    return CreateMaybeMessage<SubscribeLogsReply>(nullptr);
+  }
+
+  SubscribeLogsReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SubscribeLogsReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SubscribeLogsReply& from);
+  void MergeFrom(const SubscribeLogsReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SubscribeLogsReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.SubscribeLogsReply";
+  }
+  protected:
+  explicit SubscribeLogsReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kTopicsFieldNumber = 6,
+    kDataFieldNumber = 4,
+    kAddressFieldNumber = 1,
+    kBlockHashFieldNumber = 2,
+    kTransactionHashFieldNumber = 7,
+    kBlockNumberFieldNumber = 3,
+    kLogIndexFieldNumber = 5,
+    kTransactionIndexFieldNumber = 8,
+    kRemovedFieldNumber = 9,
+  };
+  // repeated .types.H256 topics = 6;
+  int topics_size() const;
+  private:
+  int _internal_topics_size() const;
+  public:
+  void clear_topics();
+  ::types::H256* mutable_topics(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >*
+      mutable_topics();
+  private:
+  const ::types::H256& _internal_topics(int index) const;
+  ::types::H256* _internal_add_topics();
+  public:
+  const ::types::H256& topics(int index) const;
+  ::types::H256* add_topics();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >&
+      topics() const;
+
+  // bytes data = 4;
+  void clear_data();
+  const std::string& data() const;
+  void set_data(const std::string& value);
+  void set_data(std::string&& value);
+  void set_data(const char* value);
+  void set_data(const void* value, size_t size);
+  std::string* mutable_data();
+  std::string* release_data();
+  void set_allocated_data(std::string* data);
+  private:
+  const std::string& _internal_data() const;
+  void _internal_set_data(const std::string& value);
+  std::string* _internal_mutable_data();
+  public:
+
+  // .types.H160 address = 1;
+  bool has_address() const;
+  private:
+  bool _internal_has_address() const;
+  public:
+  void clear_address();
+  const ::types::H160& address() const;
+  ::types::H160* release_address();
+  ::types::H160* mutable_address();
+  void set_allocated_address(::types::H160* address);
+  private:
+  const ::types::H160& _internal_address() const;
+  ::types::H160* _internal_mutable_address();
+  public:
+  void unsafe_arena_set_allocated_address(
+      ::types::H160* address);
+  ::types::H160* unsafe_arena_release_address();
+
+  // .types.H256 blockHash = 2;
+  bool has_blockhash() const;
+  private:
+  bool _internal_has_blockhash() const;
+  public:
+  void clear_blockhash();
+  const ::types::H256& blockhash() const;
+  ::types::H256* release_blockhash();
+  ::types::H256* mutable_blockhash();
+  void set_allocated_blockhash(::types::H256* blockhash);
+  private:
+  const ::types::H256& _internal_blockhash() const;
+  ::types::H256* _internal_mutable_blockhash();
+  public:
+  void unsafe_arena_set_allocated_blockhash(
+      ::types::H256* blockhash);
+  ::types::H256* unsafe_arena_release_blockhash();
+
+  // .types.H256 transactionHash = 7;
+  bool has_transactionhash() const;
+  private:
+  bool _internal_has_transactionhash() const;
+  public:
+  void clear_transactionhash();
+  const ::types::H256& transactionhash() const;
+  ::types::H256* release_transactionhash();
+  ::types::H256* mutable_transactionhash();
+  void set_allocated_transactionhash(::types::H256* transactionhash);
+  private:
+  const ::types::H256& _internal_transactionhash() const;
+  ::types::H256* _internal_mutable_transactionhash();
+  public:
+  void unsafe_arena_set_allocated_transactionhash(
+      ::types::H256* transactionhash);
+  ::types::H256* unsafe_arena_release_transactionhash();
+
+  // uint64 blockNumber = 3;
+  void clear_blocknumber();
+  ::PROTOBUF_NAMESPACE_ID::uint64 blocknumber() const;
+  void set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_blocknumber() const;
+  void _internal_set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // uint64 logIndex = 5;
+  void clear_logindex();
+  ::PROTOBUF_NAMESPACE_ID::uint64 logindex() const;
+  void set_logindex(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_logindex() const;
+  void _internal_set_logindex(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // uint64 transactionIndex = 8;
+  void clear_transactionindex();
+  ::PROTOBUF_NAMESPACE_ID::uint64 transactionindex() const;
+  void set_transactionindex(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_transactionindex() const;
+  void _internal_set_transactionindex(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // bool removed = 9;
+  void clear_removed();
+  bool removed() const;
+  void set_removed(bool value);
+  private:
+  bool _internal_removed() const;
+  void _internal_set_removed(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.SubscribeLogsReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 > topics_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr data_;
+  ::types::H160* address_;
+  ::types::H256* blockhash_;
+  ::types::H256* transactionhash_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 blocknumber_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 logindex_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 transactionindex_;
+  bool removed_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class BlockRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.BlockRequest) */ {
+ public:
+  inline BlockRequest() : BlockRequest(nullptr) {}
+  virtual ~BlockRequest();
+
+  BlockRequest(const BlockRequest& from);
+  BlockRequest(BlockRequest&& from) noexcept
+    : BlockRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline BlockRequest& operator=(const BlockRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline BlockRequest& operator=(BlockRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const BlockRequest& default_instance();
+
+  static inline const BlockRequest* internal_default_instance() {
+    return reinterpret_cast<const BlockRequest*>(
+               &_BlockRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    20;
+
+  friend void swap(BlockRequest& a, BlockRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(BlockRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(BlockRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline BlockRequest* New() const final {
+    return CreateMaybeMessage<BlockRequest>(nullptr);
+  }
+
+  BlockRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<BlockRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const BlockRequest& from);
+  void MergeFrom(const BlockRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(BlockRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.BlockRequest";
+  }
+  protected:
+  explicit BlockRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kBlockHashFieldNumber = 3,
+    kBlockHeightFieldNumber = 2,
+  };
+  // .types.H256 blockHash = 3;
+  bool has_blockhash() const;
+  private:
+  bool _internal_has_blockhash() const;
+  public:
+  void clear_blockhash();
+  const ::types::H256& blockhash() const;
+  ::types::H256* release_blockhash();
+  ::types::H256* mutable_blockhash();
+  void set_allocated_blockhash(::types::H256* blockhash);
+  private:
+  const ::types::H256& _internal_blockhash() const;
+  ::types::H256* _internal_mutable_blockhash();
+  public:
+  void unsafe_arena_set_allocated_blockhash(
+      ::types::H256* blockhash);
+  ::types::H256* unsafe_arena_release_blockhash();
+
+  // uint64 blockHeight = 2;
+  void clear_blockheight();
+  ::PROTOBUF_NAMESPACE_ID::uint64 blockheight() const;
+  void set_blockheight(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_blockheight() const;
+  void _internal_set_blockheight(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.BlockRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::types::H256* blockhash_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 blockheight_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class BlockReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.BlockReply) */ {
+ public:
+  inline BlockReply() : BlockReply(nullptr) {}
+  virtual ~BlockReply();
+
+  BlockReply(const BlockReply& from);
+  BlockReply(BlockReply&& from) noexcept
+    : BlockReply() {
+    *this = ::std::move(from);
+  }
+
+  inline BlockReply& operator=(const BlockReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline BlockReply& operator=(BlockReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const BlockReply& default_instance();
+
+  static inline const BlockReply* internal_default_instance() {
+    return reinterpret_cast<const BlockReply*>(
+               &_BlockReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    21;
+
+  friend void swap(BlockReply& a, BlockReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(BlockReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(BlockReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline BlockReply* New() const final {
+    return CreateMaybeMessage<BlockReply>(nullptr);
+  }
+
+  BlockReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<BlockReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const BlockReply& from);
+  void MergeFrom(const BlockReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(BlockReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.BlockReply";
+  }
+  protected:
+  explicit BlockReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kBlockRlpFieldNumber = 1,
+    kSendersFieldNumber = 2,
+  };
+  // bytes blockRlp = 1;
+  void clear_blockrlp();
+  const std::string& blockrlp() const;
+  void set_blockrlp(const std::string& value);
+  void set_blockrlp(std::string&& value);
+  void set_blockrlp(const char* value);
+  void set_blockrlp(const void* value, size_t size);
+  std::string* mutable_blockrlp();
+  std::string* release_blockrlp();
+  void set_allocated_blockrlp(std::string* blockrlp);
+  private:
+  const std::string& _internal_blockrlp() const;
+  void _internal_set_blockrlp(const std::string& value);
+  std::string* _internal_mutable_blockrlp();
+  public:
+
+  // bytes senders = 2;
+  void clear_senders();
+  const std::string& senders() const;
+  void set_senders(const std::string& value);
+  void set_senders(std::string&& value);
+  void set_senders(const char* value);
+  void set_senders(const void* value, size_t size);
+  std::string* mutable_senders();
+  std::string* release_senders();
+  void set_allocated_senders(std::string* senders);
+  private:
+  const std::string& _internal_senders() const;
+  void _internal_set_senders(const std::string& value);
+  std::string* _internal_mutable_senders();
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.BlockReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr blockrlp_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr senders_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class TxnLookupRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.TxnLookupRequest) */ {
+ public:
+  inline TxnLookupRequest() : TxnLookupRequest(nullptr) {}
+  virtual ~TxnLookupRequest();
+
+  TxnLookupRequest(const TxnLookupRequest& from);
+  TxnLookupRequest(TxnLookupRequest&& from) noexcept
+    : TxnLookupRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline TxnLookupRequest& operator=(const TxnLookupRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline TxnLookupRequest& operator=(TxnLookupRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const TxnLookupRequest& default_instance();
+
+  static inline const TxnLookupRequest* internal_default_instance() {
+    return reinterpret_cast<const TxnLookupRequest*>(
+               &_TxnLookupRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    22;
+
+  friend void swap(TxnLookupRequest& a, TxnLookupRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(TxnLookupRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(TxnLookupRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TxnLookupRequest* New() const final {
+    return CreateMaybeMessage<TxnLookupRequest>(nullptr);
+  }
+
+  TxnLookupRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<TxnLookupRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const TxnLookupRequest& from);
+  void MergeFrom(const TxnLookupRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(TxnLookupRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.TxnLookupRequest";
+  }
+  protected:
+  explicit TxnLookupRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kTxnHashFieldNumber = 1,
+  };
+  // .types.H256 txnHash = 1;
+  bool has_txnhash() const;
+  private:
+  bool _internal_has_txnhash() const;
+  public:
+  void clear_txnhash();
+  const ::types::H256& txnhash() const;
+  ::types::H256* release_txnhash();
+  ::types::H256* mutable_txnhash();
+  void set_allocated_txnhash(::types::H256* txnhash);
+  private:
+  const ::types::H256& _internal_txnhash() const;
+  ::types::H256* _internal_mutable_txnhash();
+  public:
+  void unsafe_arena_set_allocated_txnhash(
+      ::types::H256* txnhash);
+  ::types::H256* unsafe_arena_release_txnhash();
+
+  // @@protoc_insertion_point(class_scope:remote.TxnLookupRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::types::H256* txnhash_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class TxnLookupReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.TxnLookupReply) */ {
+ public:
+  inline TxnLookupReply() : TxnLookupReply(nullptr) {}
+  virtual ~TxnLookupReply();
+
+  TxnLookupReply(const TxnLookupReply& from);
+  TxnLookupReply(TxnLookupReply&& from) noexcept
+    : TxnLookupReply() {
+    *this = ::std::move(from);
+  }
+
+  inline TxnLookupReply& operator=(const TxnLookupReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline TxnLookupReply& operator=(TxnLookupReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const TxnLookupReply& default_instance();
+
+  static inline const TxnLookupReply* internal_default_instance() {
+    return reinterpret_cast<const TxnLookupReply*>(
+               &_TxnLookupReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    23;
+
+  friend void swap(TxnLookupReply& a, TxnLookupReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(TxnLookupReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(TxnLookupReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TxnLookupReply* New() const final {
+    return CreateMaybeMessage<TxnLookupReply>(nullptr);
+  }
+
+  TxnLookupReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<TxnLookupReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const TxnLookupReply& from);
+  void MergeFrom(const TxnLookupReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(TxnLookupReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.TxnLookupReply";
+  }
+  protected:
+  explicit TxnLookupReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kBlockNumberFieldNumber = 1,
+  };
+  // uint64 blockNumber = 1;
+  void clear_blocknumber();
+  ::PROTOBUF_NAMESPACE_ID::uint64 blocknumber() const;
+  void set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_blocknumber() const;
+  void _internal_set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:remote.TxnLookupReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 blocknumber_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
 class NodesInfoRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.NodesInfoRequest) */ {
  public:
@@ -1788,7 +3913,7 @@ class NodesInfoRequest PROTOBUF_FINAL :
                &_NodesInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    24;
 
   friend void swap(NodesInfoRequest& a, NodesInfoRequest& b) {
     a.Swap(&b);
@@ -1924,7 +4049,7 @@ class NodesInfoReply PROTOBUF_FINAL :
                &_NodesInfoReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    25;
 
   friend void swap(NodesInfoReply& a, NodesInfoReply& b) {
     a.Swap(&b);
@@ -2023,6 +4148,151 @@ class NodesInfoReply PROTOBUF_FINAL :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::NodeInfoReply > nodesinfo_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_remote_2fethbackend_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PeersReply PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.PeersReply) */ {
+ public:
+  inline PeersReply() : PeersReply(nullptr) {}
+  virtual ~PeersReply();
+
+  PeersReply(const PeersReply& from);
+  PeersReply(PeersReply&& from) noexcept
+    : PeersReply() {
+    *this = ::std::move(from);
+  }
+
+  inline PeersReply& operator=(const PeersReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PeersReply& operator=(PeersReply&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const PeersReply& default_instance();
+
+  static inline const PeersReply* internal_default_instance() {
+    return reinterpret_cast<const PeersReply*>(
+               &_PeersReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    26;
+
+  friend void swap(PeersReply& a, PeersReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PeersReply* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PeersReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PeersReply* New() const final {
+    return CreateMaybeMessage<PeersReply>(nullptr);
+  }
+
+  PeersReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeersReply>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const PeersReply& from);
+  void MergeFrom(const PeersReply& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PeersReply* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "remote.PeersReply";
+  }
+  protected:
+  explicit PeersReply(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_remote_2fethbackend_2eproto);
+    return ::descriptor_table_remote_2fethbackend_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPeersFieldNumber = 1,
+  };
+  // repeated .types.PeerInfo peers = 1;
+  int peers_size() const;
+  private:
+  int _internal_peers_size() const;
+  public:
+  void clear_peers();
+  ::types::PeerInfo* mutable_peers(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >*
+      mutable_peers();
+  private:
+  const ::types::PeerInfo& _internal_peers(int index) const;
+  ::types::PeerInfo* _internal_add_peers();
+  public:
+  const ::types::PeerInfo& peers(int index) const;
+  ::types::PeerInfo* add_peers();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >&
+      peers() const;
+
+  // @@protoc_insertion_point(class_scope:remote.PeersReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo > peers_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_remote_2fethbackend_2eproto;
 };
@@ -2172,6 +4442,882 @@ inline void NetPeerCountReply::_internal_set_count(::PROTOBUF_NAMESPACE_ID::uint
 inline void NetPeerCountReply::set_count(::PROTOBUF_NAMESPACE_ID::uint64 value) {
   _internal_set_count(value);
   // @@protoc_insertion_point(field_set:remote.NetPeerCountReply.count)
+}
+
+// -------------------------------------------------------------------
+
+// EngineGetPayloadRequest
+
+// uint64 payloadId = 1;
+inline void EngineGetPayloadRequest::clear_payloadid() {
+  payloadid_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 EngineGetPayloadRequest::_internal_payloadid() const {
+  return payloadid_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 EngineGetPayloadRequest::payloadid() const {
+  // @@protoc_insertion_point(field_get:remote.EngineGetPayloadRequest.payloadId)
+  return _internal_payloadid();
+}
+inline void EngineGetPayloadRequest::_internal_set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  payloadid_ = value;
+}
+inline void EngineGetPayloadRequest::set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_payloadid(value);
+  // @@protoc_insertion_point(field_set:remote.EngineGetPayloadRequest.payloadId)
+}
+
+// -------------------------------------------------------------------
+
+// EnginePayloadStatus
+
+// .remote.EngineStatus status = 1;
+inline void EnginePayloadStatus::clear_status() {
+  status_ = 0;
+}
+inline ::remote::EngineStatus EnginePayloadStatus::_internal_status() const {
+  return static_cast< ::remote::EngineStatus >(status_);
+}
+inline ::remote::EngineStatus EnginePayloadStatus::status() const {
+  // @@protoc_insertion_point(field_get:remote.EnginePayloadStatus.status)
+  return _internal_status();
+}
+inline void EnginePayloadStatus::_internal_set_status(::remote::EngineStatus value) {
+  
+  status_ = value;
+}
+inline void EnginePayloadStatus::set_status(::remote::EngineStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:remote.EnginePayloadStatus.status)
+}
+
+// .types.H256 latestValidHash = 2;
+inline bool EnginePayloadStatus::_internal_has_latestvalidhash() const {
+  return this != internal_default_instance() && latestvalidhash_ != nullptr;
+}
+inline bool EnginePayloadStatus::has_latestvalidhash() const {
+  return _internal_has_latestvalidhash();
+}
+inline const ::types::H256& EnginePayloadStatus::_internal_latestvalidhash() const {
+  const ::types::H256* p = latestvalidhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& EnginePayloadStatus::latestvalidhash() const {
+  // @@protoc_insertion_point(field_get:remote.EnginePayloadStatus.latestValidHash)
+  return _internal_latestvalidhash();
+}
+inline void EnginePayloadStatus::unsafe_arena_set_allocated_latestvalidhash(
+    ::types::H256* latestvalidhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(latestvalidhash_);
+  }
+  latestvalidhash_ = latestvalidhash;
+  if (latestvalidhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EnginePayloadStatus.latestValidHash)
+}
+inline ::types::H256* EnginePayloadStatus::release_latestvalidhash() {
+  
+  ::types::H256* temp = latestvalidhash_;
+  latestvalidhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* EnginePayloadStatus::unsafe_arena_release_latestvalidhash() {
+  // @@protoc_insertion_point(field_release:remote.EnginePayloadStatus.latestValidHash)
+  
+  ::types::H256* temp = latestvalidhash_;
+  latestvalidhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* EnginePayloadStatus::_internal_mutable_latestvalidhash() {
+  
+  if (latestvalidhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    latestvalidhash_ = p;
+  }
+  return latestvalidhash_;
+}
+inline ::types::H256* EnginePayloadStatus::mutable_latestvalidhash() {
+  // @@protoc_insertion_point(field_mutable:remote.EnginePayloadStatus.latestValidHash)
+  return _internal_mutable_latestvalidhash();
+}
+inline void EnginePayloadStatus::set_allocated_latestvalidhash(::types::H256* latestvalidhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(latestvalidhash_);
+  }
+  if (latestvalidhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(latestvalidhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      latestvalidhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, latestvalidhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  latestvalidhash_ = latestvalidhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.EnginePayloadStatus.latestValidHash)
+}
+
+// string validationError = 3;
+inline void EnginePayloadStatus::clear_validationerror() {
+  validationerror_.ClearToEmpty();
+}
+inline const std::string& EnginePayloadStatus::validationerror() const {
+  // @@protoc_insertion_point(field_get:remote.EnginePayloadStatus.validationError)
+  return _internal_validationerror();
+}
+inline void EnginePayloadStatus::set_validationerror(const std::string& value) {
+  _internal_set_validationerror(value);
+  // @@protoc_insertion_point(field_set:remote.EnginePayloadStatus.validationError)
+}
+inline std::string* EnginePayloadStatus::mutable_validationerror() {
+  // @@protoc_insertion_point(field_mutable:remote.EnginePayloadStatus.validationError)
+  return _internal_mutable_validationerror();
+}
+inline const std::string& EnginePayloadStatus::_internal_validationerror() const {
+  return validationerror_.Get();
+}
+inline void EnginePayloadStatus::_internal_set_validationerror(const std::string& value) {
+  
+  validationerror_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void EnginePayloadStatus::set_validationerror(std::string&& value) {
+  
+  validationerror_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:remote.EnginePayloadStatus.validationError)
+}
+inline void EnginePayloadStatus::set_validationerror(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  validationerror_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:remote.EnginePayloadStatus.validationError)
+}
+inline void EnginePayloadStatus::set_validationerror(const char* value,
+    size_t size) {
+  
+  validationerror_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:remote.EnginePayloadStatus.validationError)
+}
+inline std::string* EnginePayloadStatus::_internal_mutable_validationerror() {
+  
+  return validationerror_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* EnginePayloadStatus::release_validationerror() {
+  // @@protoc_insertion_point(field_release:remote.EnginePayloadStatus.validationError)
+  return validationerror_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void EnginePayloadStatus::set_allocated_validationerror(std::string* validationerror) {
+  if (validationerror != nullptr) {
+    
+  } else {
+    
+  }
+  validationerror_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), validationerror,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:remote.EnginePayloadStatus.validationError)
+}
+
+// -------------------------------------------------------------------
+
+// EnginePayloadAttributes
+
+// uint64 timestamp = 1;
+inline void EnginePayloadAttributes::clear_timestamp() {
+  timestamp_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 EnginePayloadAttributes::_internal_timestamp() const {
+  return timestamp_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 EnginePayloadAttributes::timestamp() const {
+  // @@protoc_insertion_point(field_get:remote.EnginePayloadAttributes.timestamp)
+  return _internal_timestamp();
+}
+inline void EnginePayloadAttributes::_internal_set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  timestamp_ = value;
+}
+inline void EnginePayloadAttributes::set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_timestamp(value);
+  // @@protoc_insertion_point(field_set:remote.EnginePayloadAttributes.timestamp)
+}
+
+// .types.H256 prevRandao = 2;
+inline bool EnginePayloadAttributes::_internal_has_prevrandao() const {
+  return this != internal_default_instance() && prevrandao_ != nullptr;
+}
+inline bool EnginePayloadAttributes::has_prevrandao() const {
+  return _internal_has_prevrandao();
+}
+inline const ::types::H256& EnginePayloadAttributes::_internal_prevrandao() const {
+  const ::types::H256* p = prevrandao_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& EnginePayloadAttributes::prevrandao() const {
+  // @@protoc_insertion_point(field_get:remote.EnginePayloadAttributes.prevRandao)
+  return _internal_prevrandao();
+}
+inline void EnginePayloadAttributes::unsafe_arena_set_allocated_prevrandao(
+    ::types::H256* prevrandao) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(prevrandao_);
+  }
+  prevrandao_ = prevrandao;
+  if (prevrandao) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EnginePayloadAttributes.prevRandao)
+}
+inline ::types::H256* EnginePayloadAttributes::release_prevrandao() {
+  
+  ::types::H256* temp = prevrandao_;
+  prevrandao_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* EnginePayloadAttributes::unsafe_arena_release_prevrandao() {
+  // @@protoc_insertion_point(field_release:remote.EnginePayloadAttributes.prevRandao)
+  
+  ::types::H256* temp = prevrandao_;
+  prevrandao_ = nullptr;
+  return temp;
+}
+inline ::types::H256* EnginePayloadAttributes::_internal_mutable_prevrandao() {
+  
+  if (prevrandao_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    prevrandao_ = p;
+  }
+  return prevrandao_;
+}
+inline ::types::H256* EnginePayloadAttributes::mutable_prevrandao() {
+  // @@protoc_insertion_point(field_mutable:remote.EnginePayloadAttributes.prevRandao)
+  return _internal_mutable_prevrandao();
+}
+inline void EnginePayloadAttributes::set_allocated_prevrandao(::types::H256* prevrandao) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(prevrandao_);
+  }
+  if (prevrandao) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(prevrandao)->GetArena();
+    if (message_arena != submessage_arena) {
+      prevrandao = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, prevrandao, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  prevrandao_ = prevrandao;
+  // @@protoc_insertion_point(field_set_allocated:remote.EnginePayloadAttributes.prevRandao)
+}
+
+// .types.H160 suggestedFeeRecipient = 3;
+inline bool EnginePayloadAttributes::_internal_has_suggestedfeerecipient() const {
+  return this != internal_default_instance() && suggestedfeerecipient_ != nullptr;
+}
+inline bool EnginePayloadAttributes::has_suggestedfeerecipient() const {
+  return _internal_has_suggestedfeerecipient();
+}
+inline const ::types::H160& EnginePayloadAttributes::_internal_suggestedfeerecipient() const {
+  const ::types::H160* p = suggestedfeerecipient_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H160&>(
+      ::types::_H160_default_instance_);
+}
+inline const ::types::H160& EnginePayloadAttributes::suggestedfeerecipient() const {
+  // @@protoc_insertion_point(field_get:remote.EnginePayloadAttributes.suggestedFeeRecipient)
+  return _internal_suggestedfeerecipient();
+}
+inline void EnginePayloadAttributes::unsafe_arena_set_allocated_suggestedfeerecipient(
+    ::types::H160* suggestedfeerecipient) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(suggestedfeerecipient_);
+  }
+  suggestedfeerecipient_ = suggestedfeerecipient;
+  if (suggestedfeerecipient) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EnginePayloadAttributes.suggestedFeeRecipient)
+}
+inline ::types::H160* EnginePayloadAttributes::release_suggestedfeerecipient() {
+  
+  ::types::H160* temp = suggestedfeerecipient_;
+  suggestedfeerecipient_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H160* EnginePayloadAttributes::unsafe_arena_release_suggestedfeerecipient() {
+  // @@protoc_insertion_point(field_release:remote.EnginePayloadAttributes.suggestedFeeRecipient)
+  
+  ::types::H160* temp = suggestedfeerecipient_;
+  suggestedfeerecipient_ = nullptr;
+  return temp;
+}
+inline ::types::H160* EnginePayloadAttributes::_internal_mutable_suggestedfeerecipient() {
+  
+  if (suggestedfeerecipient_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H160>(GetArena());
+    suggestedfeerecipient_ = p;
+  }
+  return suggestedfeerecipient_;
+}
+inline ::types::H160* EnginePayloadAttributes::mutable_suggestedfeerecipient() {
+  // @@protoc_insertion_point(field_mutable:remote.EnginePayloadAttributes.suggestedFeeRecipient)
+  return _internal_mutable_suggestedfeerecipient();
+}
+inline void EnginePayloadAttributes::set_allocated_suggestedfeerecipient(::types::H160* suggestedfeerecipient) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(suggestedfeerecipient_);
+  }
+  if (suggestedfeerecipient) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(suggestedfeerecipient)->GetArena();
+    if (message_arena != submessage_arena) {
+      suggestedfeerecipient = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, suggestedfeerecipient, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  suggestedfeerecipient_ = suggestedfeerecipient;
+  // @@protoc_insertion_point(field_set_allocated:remote.EnginePayloadAttributes.suggestedFeeRecipient)
+}
+
+// -------------------------------------------------------------------
+
+// EngineForkChoiceState
+
+// .types.H256 headBlockHash = 1;
+inline bool EngineForkChoiceState::_internal_has_headblockhash() const {
+  return this != internal_default_instance() && headblockhash_ != nullptr;
+}
+inline bool EngineForkChoiceState::has_headblockhash() const {
+  return _internal_has_headblockhash();
+}
+inline const ::types::H256& EngineForkChoiceState::_internal_headblockhash() const {
+  const ::types::H256* p = headblockhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& EngineForkChoiceState::headblockhash() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceState.headBlockHash)
+  return _internal_headblockhash();
+}
+inline void EngineForkChoiceState::unsafe_arena_set_allocated_headblockhash(
+    ::types::H256* headblockhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(headblockhash_);
+  }
+  headblockhash_ = headblockhash;
+  if (headblockhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EngineForkChoiceState.headBlockHash)
+}
+inline ::types::H256* EngineForkChoiceState::release_headblockhash() {
+  
+  ::types::H256* temp = headblockhash_;
+  headblockhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* EngineForkChoiceState::unsafe_arena_release_headblockhash() {
+  // @@protoc_insertion_point(field_release:remote.EngineForkChoiceState.headBlockHash)
+  
+  ::types::H256* temp = headblockhash_;
+  headblockhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* EngineForkChoiceState::_internal_mutable_headblockhash() {
+  
+  if (headblockhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    headblockhash_ = p;
+  }
+  return headblockhash_;
+}
+inline ::types::H256* EngineForkChoiceState::mutable_headblockhash() {
+  // @@protoc_insertion_point(field_mutable:remote.EngineForkChoiceState.headBlockHash)
+  return _internal_mutable_headblockhash();
+}
+inline void EngineForkChoiceState::set_allocated_headblockhash(::types::H256* headblockhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(headblockhash_);
+  }
+  if (headblockhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(headblockhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      headblockhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, headblockhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  headblockhash_ = headblockhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.EngineForkChoiceState.headBlockHash)
+}
+
+// .types.H256 safeBlockHash = 2;
+inline bool EngineForkChoiceState::_internal_has_safeblockhash() const {
+  return this != internal_default_instance() && safeblockhash_ != nullptr;
+}
+inline bool EngineForkChoiceState::has_safeblockhash() const {
+  return _internal_has_safeblockhash();
+}
+inline const ::types::H256& EngineForkChoiceState::_internal_safeblockhash() const {
+  const ::types::H256* p = safeblockhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& EngineForkChoiceState::safeblockhash() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceState.safeBlockHash)
+  return _internal_safeblockhash();
+}
+inline void EngineForkChoiceState::unsafe_arena_set_allocated_safeblockhash(
+    ::types::H256* safeblockhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(safeblockhash_);
+  }
+  safeblockhash_ = safeblockhash;
+  if (safeblockhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EngineForkChoiceState.safeBlockHash)
+}
+inline ::types::H256* EngineForkChoiceState::release_safeblockhash() {
+  
+  ::types::H256* temp = safeblockhash_;
+  safeblockhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* EngineForkChoiceState::unsafe_arena_release_safeblockhash() {
+  // @@protoc_insertion_point(field_release:remote.EngineForkChoiceState.safeBlockHash)
+  
+  ::types::H256* temp = safeblockhash_;
+  safeblockhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* EngineForkChoiceState::_internal_mutable_safeblockhash() {
+  
+  if (safeblockhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    safeblockhash_ = p;
+  }
+  return safeblockhash_;
+}
+inline ::types::H256* EngineForkChoiceState::mutable_safeblockhash() {
+  // @@protoc_insertion_point(field_mutable:remote.EngineForkChoiceState.safeBlockHash)
+  return _internal_mutable_safeblockhash();
+}
+inline void EngineForkChoiceState::set_allocated_safeblockhash(::types::H256* safeblockhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(safeblockhash_);
+  }
+  if (safeblockhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(safeblockhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      safeblockhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, safeblockhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  safeblockhash_ = safeblockhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.EngineForkChoiceState.safeBlockHash)
+}
+
+// .types.H256 finalizedBlockHash = 3;
+inline bool EngineForkChoiceState::_internal_has_finalizedblockhash() const {
+  return this != internal_default_instance() && finalizedblockhash_ != nullptr;
+}
+inline bool EngineForkChoiceState::has_finalizedblockhash() const {
+  return _internal_has_finalizedblockhash();
+}
+inline const ::types::H256& EngineForkChoiceState::_internal_finalizedblockhash() const {
+  const ::types::H256* p = finalizedblockhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& EngineForkChoiceState::finalizedblockhash() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceState.finalizedBlockHash)
+  return _internal_finalizedblockhash();
+}
+inline void EngineForkChoiceState::unsafe_arena_set_allocated_finalizedblockhash(
+    ::types::H256* finalizedblockhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(finalizedblockhash_);
+  }
+  finalizedblockhash_ = finalizedblockhash;
+  if (finalizedblockhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EngineForkChoiceState.finalizedBlockHash)
+}
+inline ::types::H256* EngineForkChoiceState::release_finalizedblockhash() {
+  
+  ::types::H256* temp = finalizedblockhash_;
+  finalizedblockhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* EngineForkChoiceState::unsafe_arena_release_finalizedblockhash() {
+  // @@protoc_insertion_point(field_release:remote.EngineForkChoiceState.finalizedBlockHash)
+  
+  ::types::H256* temp = finalizedblockhash_;
+  finalizedblockhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* EngineForkChoiceState::_internal_mutable_finalizedblockhash() {
+  
+  if (finalizedblockhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    finalizedblockhash_ = p;
+  }
+  return finalizedblockhash_;
+}
+inline ::types::H256* EngineForkChoiceState::mutable_finalizedblockhash() {
+  // @@protoc_insertion_point(field_mutable:remote.EngineForkChoiceState.finalizedBlockHash)
+  return _internal_mutable_finalizedblockhash();
+}
+inline void EngineForkChoiceState::set_allocated_finalizedblockhash(::types::H256* finalizedblockhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(finalizedblockhash_);
+  }
+  if (finalizedblockhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(finalizedblockhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      finalizedblockhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, finalizedblockhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  finalizedblockhash_ = finalizedblockhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.EngineForkChoiceState.finalizedBlockHash)
+}
+
+// -------------------------------------------------------------------
+
+// EngineForkChoiceUpdatedRequest
+
+// .remote.EngineForkChoiceState forkchoiceState = 1;
+inline bool EngineForkChoiceUpdatedRequest::_internal_has_forkchoicestate() const {
+  return this != internal_default_instance() && forkchoicestate_ != nullptr;
+}
+inline bool EngineForkChoiceUpdatedRequest::has_forkchoicestate() const {
+  return _internal_has_forkchoicestate();
+}
+inline void EngineForkChoiceUpdatedRequest::clear_forkchoicestate() {
+  if (GetArena() == nullptr && forkchoicestate_ != nullptr) {
+    delete forkchoicestate_;
+  }
+  forkchoicestate_ = nullptr;
+}
+inline const ::remote::EngineForkChoiceState& EngineForkChoiceUpdatedRequest::_internal_forkchoicestate() const {
+  const ::remote::EngineForkChoiceState* p = forkchoicestate_;
+  return p != nullptr ? *p : reinterpret_cast<const ::remote::EngineForkChoiceState&>(
+      ::remote::_EngineForkChoiceState_default_instance_);
+}
+inline const ::remote::EngineForkChoiceState& EngineForkChoiceUpdatedRequest::forkchoicestate() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceUpdatedRequest.forkchoiceState)
+  return _internal_forkchoicestate();
+}
+inline void EngineForkChoiceUpdatedRequest::unsafe_arena_set_allocated_forkchoicestate(
+    ::remote::EngineForkChoiceState* forkchoicestate) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(forkchoicestate_);
+  }
+  forkchoicestate_ = forkchoicestate;
+  if (forkchoicestate) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EngineForkChoiceUpdatedRequest.forkchoiceState)
+}
+inline ::remote::EngineForkChoiceState* EngineForkChoiceUpdatedRequest::release_forkchoicestate() {
+  
+  ::remote::EngineForkChoiceState* temp = forkchoicestate_;
+  forkchoicestate_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::remote::EngineForkChoiceState* EngineForkChoiceUpdatedRequest::unsafe_arena_release_forkchoicestate() {
+  // @@protoc_insertion_point(field_release:remote.EngineForkChoiceUpdatedRequest.forkchoiceState)
+  
+  ::remote::EngineForkChoiceState* temp = forkchoicestate_;
+  forkchoicestate_ = nullptr;
+  return temp;
+}
+inline ::remote::EngineForkChoiceState* EngineForkChoiceUpdatedRequest::_internal_mutable_forkchoicestate() {
+  
+  if (forkchoicestate_ == nullptr) {
+    auto* p = CreateMaybeMessage<::remote::EngineForkChoiceState>(GetArena());
+    forkchoicestate_ = p;
+  }
+  return forkchoicestate_;
+}
+inline ::remote::EngineForkChoiceState* EngineForkChoiceUpdatedRequest::mutable_forkchoicestate() {
+  // @@protoc_insertion_point(field_mutable:remote.EngineForkChoiceUpdatedRequest.forkchoiceState)
+  return _internal_mutable_forkchoicestate();
+}
+inline void EngineForkChoiceUpdatedRequest::set_allocated_forkchoicestate(::remote::EngineForkChoiceState* forkchoicestate) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete forkchoicestate_;
+  }
+  if (forkchoicestate) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(forkchoicestate);
+    if (message_arena != submessage_arena) {
+      forkchoicestate = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, forkchoicestate, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  forkchoicestate_ = forkchoicestate;
+  // @@protoc_insertion_point(field_set_allocated:remote.EngineForkChoiceUpdatedRequest.forkchoiceState)
+}
+
+// .remote.EnginePayloadAttributes payloadAttributes = 2;
+inline bool EngineForkChoiceUpdatedRequest::_internal_has_payloadattributes() const {
+  return this != internal_default_instance() && payloadattributes_ != nullptr;
+}
+inline bool EngineForkChoiceUpdatedRequest::has_payloadattributes() const {
+  return _internal_has_payloadattributes();
+}
+inline void EngineForkChoiceUpdatedRequest::clear_payloadattributes() {
+  if (GetArena() == nullptr && payloadattributes_ != nullptr) {
+    delete payloadattributes_;
+  }
+  payloadattributes_ = nullptr;
+}
+inline const ::remote::EnginePayloadAttributes& EngineForkChoiceUpdatedRequest::_internal_payloadattributes() const {
+  const ::remote::EnginePayloadAttributes* p = payloadattributes_;
+  return p != nullptr ? *p : reinterpret_cast<const ::remote::EnginePayloadAttributes&>(
+      ::remote::_EnginePayloadAttributes_default_instance_);
+}
+inline const ::remote::EnginePayloadAttributes& EngineForkChoiceUpdatedRequest::payloadattributes() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceUpdatedRequest.payloadAttributes)
+  return _internal_payloadattributes();
+}
+inline void EngineForkChoiceUpdatedRequest::unsafe_arena_set_allocated_payloadattributes(
+    ::remote::EnginePayloadAttributes* payloadattributes) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(payloadattributes_);
+  }
+  payloadattributes_ = payloadattributes;
+  if (payloadattributes) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EngineForkChoiceUpdatedRequest.payloadAttributes)
+}
+inline ::remote::EnginePayloadAttributes* EngineForkChoiceUpdatedRequest::release_payloadattributes() {
+  
+  ::remote::EnginePayloadAttributes* temp = payloadattributes_;
+  payloadattributes_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::remote::EnginePayloadAttributes* EngineForkChoiceUpdatedRequest::unsafe_arena_release_payloadattributes() {
+  // @@protoc_insertion_point(field_release:remote.EngineForkChoiceUpdatedRequest.payloadAttributes)
+  
+  ::remote::EnginePayloadAttributes* temp = payloadattributes_;
+  payloadattributes_ = nullptr;
+  return temp;
+}
+inline ::remote::EnginePayloadAttributes* EngineForkChoiceUpdatedRequest::_internal_mutable_payloadattributes() {
+  
+  if (payloadattributes_ == nullptr) {
+    auto* p = CreateMaybeMessage<::remote::EnginePayloadAttributes>(GetArena());
+    payloadattributes_ = p;
+  }
+  return payloadattributes_;
+}
+inline ::remote::EnginePayloadAttributes* EngineForkChoiceUpdatedRequest::mutable_payloadattributes() {
+  // @@protoc_insertion_point(field_mutable:remote.EngineForkChoiceUpdatedRequest.payloadAttributes)
+  return _internal_mutable_payloadattributes();
+}
+inline void EngineForkChoiceUpdatedRequest::set_allocated_payloadattributes(::remote::EnginePayloadAttributes* payloadattributes) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete payloadattributes_;
+  }
+  if (payloadattributes) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(payloadattributes);
+    if (message_arena != submessage_arena) {
+      payloadattributes = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, payloadattributes, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  payloadattributes_ = payloadattributes;
+  // @@protoc_insertion_point(field_set_allocated:remote.EngineForkChoiceUpdatedRequest.payloadAttributes)
+}
+
+// -------------------------------------------------------------------
+
+// EngineForkChoiceUpdatedReply
+
+// .remote.EnginePayloadStatus payloadStatus = 1;
+inline bool EngineForkChoiceUpdatedReply::_internal_has_payloadstatus() const {
+  return this != internal_default_instance() && payloadstatus_ != nullptr;
+}
+inline bool EngineForkChoiceUpdatedReply::has_payloadstatus() const {
+  return _internal_has_payloadstatus();
+}
+inline void EngineForkChoiceUpdatedReply::clear_payloadstatus() {
+  if (GetArena() == nullptr && payloadstatus_ != nullptr) {
+    delete payloadstatus_;
+  }
+  payloadstatus_ = nullptr;
+}
+inline const ::remote::EnginePayloadStatus& EngineForkChoiceUpdatedReply::_internal_payloadstatus() const {
+  const ::remote::EnginePayloadStatus* p = payloadstatus_;
+  return p != nullptr ? *p : reinterpret_cast<const ::remote::EnginePayloadStatus&>(
+      ::remote::_EnginePayloadStatus_default_instance_);
+}
+inline const ::remote::EnginePayloadStatus& EngineForkChoiceUpdatedReply::payloadstatus() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceUpdatedReply.payloadStatus)
+  return _internal_payloadstatus();
+}
+inline void EngineForkChoiceUpdatedReply::unsafe_arena_set_allocated_payloadstatus(
+    ::remote::EnginePayloadStatus* payloadstatus) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(payloadstatus_);
+  }
+  payloadstatus_ = payloadstatus;
+  if (payloadstatus) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.EngineForkChoiceUpdatedReply.payloadStatus)
+}
+inline ::remote::EnginePayloadStatus* EngineForkChoiceUpdatedReply::release_payloadstatus() {
+  
+  ::remote::EnginePayloadStatus* temp = payloadstatus_;
+  payloadstatus_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::remote::EnginePayloadStatus* EngineForkChoiceUpdatedReply::unsafe_arena_release_payloadstatus() {
+  // @@protoc_insertion_point(field_release:remote.EngineForkChoiceUpdatedReply.payloadStatus)
+  
+  ::remote::EnginePayloadStatus* temp = payloadstatus_;
+  payloadstatus_ = nullptr;
+  return temp;
+}
+inline ::remote::EnginePayloadStatus* EngineForkChoiceUpdatedReply::_internal_mutable_payloadstatus() {
+  
+  if (payloadstatus_ == nullptr) {
+    auto* p = CreateMaybeMessage<::remote::EnginePayloadStatus>(GetArena());
+    payloadstatus_ = p;
+  }
+  return payloadstatus_;
+}
+inline ::remote::EnginePayloadStatus* EngineForkChoiceUpdatedReply::mutable_payloadstatus() {
+  // @@protoc_insertion_point(field_mutable:remote.EngineForkChoiceUpdatedReply.payloadStatus)
+  return _internal_mutable_payloadstatus();
+}
+inline void EngineForkChoiceUpdatedReply::set_allocated_payloadstatus(::remote::EnginePayloadStatus* payloadstatus) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete payloadstatus_;
+  }
+  if (payloadstatus) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(payloadstatus);
+    if (message_arena != submessage_arena) {
+      payloadstatus = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, payloadstatus, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  payloadstatus_ = payloadstatus;
+  // @@protoc_insertion_point(field_set_allocated:remote.EngineForkChoiceUpdatedReply.payloadStatus)
+}
+
+// uint64 payloadId = 2;
+inline void EngineForkChoiceUpdatedReply::clear_payloadid() {
+  payloadid_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 EngineForkChoiceUpdatedReply::_internal_payloadid() const {
+  return payloadid_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 EngineForkChoiceUpdatedReply::payloadid() const {
+  // @@protoc_insertion_point(field_get:remote.EngineForkChoiceUpdatedReply.payloadId)
+  return _internal_payloadid();
+}
+inline void EngineForkChoiceUpdatedReply::_internal_set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  payloadid_ = value;
+}
+inline void EngineForkChoiceUpdatedReply::set_payloadid(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_payloadid(value);
+  // @@protoc_insertion_point(field_set:remote.EngineForkChoiceUpdatedReply.payloadId)
 }
 
 // -------------------------------------------------------------------
@@ -2382,6 +5528,866 @@ inline void SubscribeReply::set_allocated_data(std::string* data) {
 
 // -------------------------------------------------------------------
 
+// LogsFilterRequest
+
+// bool allAddresses = 1;
+inline void LogsFilterRequest::clear_alladdresses() {
+  alladdresses_ = false;
+}
+inline bool LogsFilterRequest::_internal_alladdresses() const {
+  return alladdresses_;
+}
+inline bool LogsFilterRequest::alladdresses() const {
+  // @@protoc_insertion_point(field_get:remote.LogsFilterRequest.allAddresses)
+  return _internal_alladdresses();
+}
+inline void LogsFilterRequest::_internal_set_alladdresses(bool value) {
+  
+  alladdresses_ = value;
+}
+inline void LogsFilterRequest::set_alladdresses(bool value) {
+  _internal_set_alladdresses(value);
+  // @@protoc_insertion_point(field_set:remote.LogsFilterRequest.allAddresses)
+}
+
+// repeated .types.H160 addresses = 2;
+inline int LogsFilterRequest::_internal_addresses_size() const {
+  return addresses_.size();
+}
+inline int LogsFilterRequest::addresses_size() const {
+  return _internal_addresses_size();
+}
+inline ::types::H160* LogsFilterRequest::mutable_addresses(int index) {
+  // @@protoc_insertion_point(field_mutable:remote.LogsFilterRequest.addresses)
+  return addresses_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H160 >*
+LogsFilterRequest::mutable_addresses() {
+  // @@protoc_insertion_point(field_mutable_list:remote.LogsFilterRequest.addresses)
+  return &addresses_;
+}
+inline const ::types::H160& LogsFilterRequest::_internal_addresses(int index) const {
+  return addresses_.Get(index);
+}
+inline const ::types::H160& LogsFilterRequest::addresses(int index) const {
+  // @@protoc_insertion_point(field_get:remote.LogsFilterRequest.addresses)
+  return _internal_addresses(index);
+}
+inline ::types::H160* LogsFilterRequest::_internal_add_addresses() {
+  return addresses_.Add();
+}
+inline ::types::H160* LogsFilterRequest::add_addresses() {
+  // @@protoc_insertion_point(field_add:remote.LogsFilterRequest.addresses)
+  return _internal_add_addresses();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H160 >&
+LogsFilterRequest::addresses() const {
+  // @@protoc_insertion_point(field_list:remote.LogsFilterRequest.addresses)
+  return addresses_;
+}
+
+// bool allTopics = 3;
+inline void LogsFilterRequest::clear_alltopics() {
+  alltopics_ = false;
+}
+inline bool LogsFilterRequest::_internal_alltopics() const {
+  return alltopics_;
+}
+inline bool LogsFilterRequest::alltopics() const {
+  // @@protoc_insertion_point(field_get:remote.LogsFilterRequest.allTopics)
+  return _internal_alltopics();
+}
+inline void LogsFilterRequest::_internal_set_alltopics(bool value) {
+  
+  alltopics_ = value;
+}
+inline void LogsFilterRequest::set_alltopics(bool value) {
+  _internal_set_alltopics(value);
+  // @@protoc_insertion_point(field_set:remote.LogsFilterRequest.allTopics)
+}
+
+// repeated .types.H256 topics = 4;
+inline int LogsFilterRequest::_internal_topics_size() const {
+  return topics_.size();
+}
+inline int LogsFilterRequest::topics_size() const {
+  return _internal_topics_size();
+}
+inline ::types::H256* LogsFilterRequest::mutable_topics(int index) {
+  // @@protoc_insertion_point(field_mutable:remote.LogsFilterRequest.topics)
+  return topics_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >*
+LogsFilterRequest::mutable_topics() {
+  // @@protoc_insertion_point(field_mutable_list:remote.LogsFilterRequest.topics)
+  return &topics_;
+}
+inline const ::types::H256& LogsFilterRequest::_internal_topics(int index) const {
+  return topics_.Get(index);
+}
+inline const ::types::H256& LogsFilterRequest::topics(int index) const {
+  // @@protoc_insertion_point(field_get:remote.LogsFilterRequest.topics)
+  return _internal_topics(index);
+}
+inline ::types::H256* LogsFilterRequest::_internal_add_topics() {
+  return topics_.Add();
+}
+inline ::types::H256* LogsFilterRequest::add_topics() {
+  // @@protoc_insertion_point(field_add:remote.LogsFilterRequest.topics)
+  return _internal_add_topics();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >&
+LogsFilterRequest::topics() const {
+  // @@protoc_insertion_point(field_list:remote.LogsFilterRequest.topics)
+  return topics_;
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeLogsReply
+
+// .types.H160 address = 1;
+inline bool SubscribeLogsReply::_internal_has_address() const {
+  return this != internal_default_instance() && address_ != nullptr;
+}
+inline bool SubscribeLogsReply::has_address() const {
+  return _internal_has_address();
+}
+inline const ::types::H160& SubscribeLogsReply::_internal_address() const {
+  const ::types::H160* p = address_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H160&>(
+      ::types::_H160_default_instance_);
+}
+inline const ::types::H160& SubscribeLogsReply::address() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.address)
+  return _internal_address();
+}
+inline void SubscribeLogsReply::unsafe_arena_set_allocated_address(
+    ::types::H160* address) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(address_);
+  }
+  address_ = address;
+  if (address) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.SubscribeLogsReply.address)
+}
+inline ::types::H160* SubscribeLogsReply::release_address() {
+  
+  ::types::H160* temp = address_;
+  address_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H160* SubscribeLogsReply::unsafe_arena_release_address() {
+  // @@protoc_insertion_point(field_release:remote.SubscribeLogsReply.address)
+  
+  ::types::H160* temp = address_;
+  address_ = nullptr;
+  return temp;
+}
+inline ::types::H160* SubscribeLogsReply::_internal_mutable_address() {
+  
+  if (address_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H160>(GetArena());
+    address_ = p;
+  }
+  return address_;
+}
+inline ::types::H160* SubscribeLogsReply::mutable_address() {
+  // @@protoc_insertion_point(field_mutable:remote.SubscribeLogsReply.address)
+  return _internal_mutable_address();
+}
+inline void SubscribeLogsReply::set_allocated_address(::types::H160* address) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(address_);
+  }
+  if (address) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(address)->GetArena();
+    if (message_arena != submessage_arena) {
+      address = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, address, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  address_ = address;
+  // @@protoc_insertion_point(field_set_allocated:remote.SubscribeLogsReply.address)
+}
+
+// .types.H256 blockHash = 2;
+inline bool SubscribeLogsReply::_internal_has_blockhash() const {
+  return this != internal_default_instance() && blockhash_ != nullptr;
+}
+inline bool SubscribeLogsReply::has_blockhash() const {
+  return _internal_has_blockhash();
+}
+inline const ::types::H256& SubscribeLogsReply::_internal_blockhash() const {
+  const ::types::H256* p = blockhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& SubscribeLogsReply::blockhash() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.blockHash)
+  return _internal_blockhash();
+}
+inline void SubscribeLogsReply::unsafe_arena_set_allocated_blockhash(
+    ::types::H256* blockhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash_);
+  }
+  blockhash_ = blockhash;
+  if (blockhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.SubscribeLogsReply.blockHash)
+}
+inline ::types::H256* SubscribeLogsReply::release_blockhash() {
+  
+  ::types::H256* temp = blockhash_;
+  blockhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* SubscribeLogsReply::unsafe_arena_release_blockhash() {
+  // @@protoc_insertion_point(field_release:remote.SubscribeLogsReply.blockHash)
+  
+  ::types::H256* temp = blockhash_;
+  blockhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* SubscribeLogsReply::_internal_mutable_blockhash() {
+  
+  if (blockhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    blockhash_ = p;
+  }
+  return blockhash_;
+}
+inline ::types::H256* SubscribeLogsReply::mutable_blockhash() {
+  // @@protoc_insertion_point(field_mutable:remote.SubscribeLogsReply.blockHash)
+  return _internal_mutable_blockhash();
+}
+inline void SubscribeLogsReply::set_allocated_blockhash(::types::H256* blockhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash_);
+  }
+  if (blockhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      blockhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, blockhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  blockhash_ = blockhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.SubscribeLogsReply.blockHash)
+}
+
+// uint64 blockNumber = 3;
+inline void SubscribeLogsReply::clear_blocknumber() {
+  blocknumber_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 SubscribeLogsReply::_internal_blocknumber() const {
+  return blocknumber_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 SubscribeLogsReply::blocknumber() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.blockNumber)
+  return _internal_blocknumber();
+}
+inline void SubscribeLogsReply::_internal_set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  blocknumber_ = value;
+}
+inline void SubscribeLogsReply::set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_blocknumber(value);
+  // @@protoc_insertion_point(field_set:remote.SubscribeLogsReply.blockNumber)
+}
+
+// bytes data = 4;
+inline void SubscribeLogsReply::clear_data() {
+  data_.ClearToEmpty();
+}
+inline const std::string& SubscribeLogsReply::data() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.data)
+  return _internal_data();
+}
+inline void SubscribeLogsReply::set_data(const std::string& value) {
+  _internal_set_data(value);
+  // @@protoc_insertion_point(field_set:remote.SubscribeLogsReply.data)
+}
+inline std::string* SubscribeLogsReply::mutable_data() {
+  // @@protoc_insertion_point(field_mutable:remote.SubscribeLogsReply.data)
+  return _internal_mutable_data();
+}
+inline const std::string& SubscribeLogsReply::_internal_data() const {
+  return data_.Get();
+}
+inline void SubscribeLogsReply::_internal_set_data(const std::string& value) {
+  
+  data_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SubscribeLogsReply::set_data(std::string&& value) {
+  
+  data_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:remote.SubscribeLogsReply.data)
+}
+inline void SubscribeLogsReply::set_data(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  data_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:remote.SubscribeLogsReply.data)
+}
+inline void SubscribeLogsReply::set_data(const void* value,
+    size_t size) {
+  
+  data_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:remote.SubscribeLogsReply.data)
+}
+inline std::string* SubscribeLogsReply::_internal_mutable_data() {
+  
+  return data_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SubscribeLogsReply::release_data() {
+  // @@protoc_insertion_point(field_release:remote.SubscribeLogsReply.data)
+  return data_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SubscribeLogsReply::set_allocated_data(std::string* data) {
+  if (data != nullptr) {
+    
+  } else {
+    
+  }
+  data_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), data,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:remote.SubscribeLogsReply.data)
+}
+
+// uint64 logIndex = 5;
+inline void SubscribeLogsReply::clear_logindex() {
+  logindex_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 SubscribeLogsReply::_internal_logindex() const {
+  return logindex_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 SubscribeLogsReply::logindex() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.logIndex)
+  return _internal_logindex();
+}
+inline void SubscribeLogsReply::_internal_set_logindex(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  logindex_ = value;
+}
+inline void SubscribeLogsReply::set_logindex(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_logindex(value);
+  // @@protoc_insertion_point(field_set:remote.SubscribeLogsReply.logIndex)
+}
+
+// repeated .types.H256 topics = 6;
+inline int SubscribeLogsReply::_internal_topics_size() const {
+  return topics_.size();
+}
+inline int SubscribeLogsReply::topics_size() const {
+  return _internal_topics_size();
+}
+inline ::types::H256* SubscribeLogsReply::mutable_topics(int index) {
+  // @@protoc_insertion_point(field_mutable:remote.SubscribeLogsReply.topics)
+  return topics_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >*
+SubscribeLogsReply::mutable_topics() {
+  // @@protoc_insertion_point(field_mutable_list:remote.SubscribeLogsReply.topics)
+  return &topics_;
+}
+inline const ::types::H256& SubscribeLogsReply::_internal_topics(int index) const {
+  return topics_.Get(index);
+}
+inline const ::types::H256& SubscribeLogsReply::topics(int index) const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.topics)
+  return _internal_topics(index);
+}
+inline ::types::H256* SubscribeLogsReply::_internal_add_topics() {
+  return topics_.Add();
+}
+inline ::types::H256* SubscribeLogsReply::add_topics() {
+  // @@protoc_insertion_point(field_add:remote.SubscribeLogsReply.topics)
+  return _internal_add_topics();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::H256 >&
+SubscribeLogsReply::topics() const {
+  // @@protoc_insertion_point(field_list:remote.SubscribeLogsReply.topics)
+  return topics_;
+}
+
+// .types.H256 transactionHash = 7;
+inline bool SubscribeLogsReply::_internal_has_transactionhash() const {
+  return this != internal_default_instance() && transactionhash_ != nullptr;
+}
+inline bool SubscribeLogsReply::has_transactionhash() const {
+  return _internal_has_transactionhash();
+}
+inline const ::types::H256& SubscribeLogsReply::_internal_transactionhash() const {
+  const ::types::H256* p = transactionhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& SubscribeLogsReply::transactionhash() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.transactionHash)
+  return _internal_transactionhash();
+}
+inline void SubscribeLogsReply::unsafe_arena_set_allocated_transactionhash(
+    ::types::H256* transactionhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(transactionhash_);
+  }
+  transactionhash_ = transactionhash;
+  if (transactionhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.SubscribeLogsReply.transactionHash)
+}
+inline ::types::H256* SubscribeLogsReply::release_transactionhash() {
+  
+  ::types::H256* temp = transactionhash_;
+  transactionhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* SubscribeLogsReply::unsafe_arena_release_transactionhash() {
+  // @@protoc_insertion_point(field_release:remote.SubscribeLogsReply.transactionHash)
+  
+  ::types::H256* temp = transactionhash_;
+  transactionhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* SubscribeLogsReply::_internal_mutable_transactionhash() {
+  
+  if (transactionhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    transactionhash_ = p;
+  }
+  return transactionhash_;
+}
+inline ::types::H256* SubscribeLogsReply::mutable_transactionhash() {
+  // @@protoc_insertion_point(field_mutable:remote.SubscribeLogsReply.transactionHash)
+  return _internal_mutable_transactionhash();
+}
+inline void SubscribeLogsReply::set_allocated_transactionhash(::types::H256* transactionhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(transactionhash_);
+  }
+  if (transactionhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(transactionhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      transactionhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, transactionhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  transactionhash_ = transactionhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.SubscribeLogsReply.transactionHash)
+}
+
+// uint64 transactionIndex = 8;
+inline void SubscribeLogsReply::clear_transactionindex() {
+  transactionindex_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 SubscribeLogsReply::_internal_transactionindex() const {
+  return transactionindex_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 SubscribeLogsReply::transactionindex() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.transactionIndex)
+  return _internal_transactionindex();
+}
+inline void SubscribeLogsReply::_internal_set_transactionindex(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  transactionindex_ = value;
+}
+inline void SubscribeLogsReply::set_transactionindex(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_transactionindex(value);
+  // @@protoc_insertion_point(field_set:remote.SubscribeLogsReply.transactionIndex)
+}
+
+// bool removed = 9;
+inline void SubscribeLogsReply::clear_removed() {
+  removed_ = false;
+}
+inline bool SubscribeLogsReply::_internal_removed() const {
+  return removed_;
+}
+inline bool SubscribeLogsReply::removed() const {
+  // @@protoc_insertion_point(field_get:remote.SubscribeLogsReply.removed)
+  return _internal_removed();
+}
+inline void SubscribeLogsReply::_internal_set_removed(bool value) {
+  
+  removed_ = value;
+}
+inline void SubscribeLogsReply::set_removed(bool value) {
+  _internal_set_removed(value);
+  // @@protoc_insertion_point(field_set:remote.SubscribeLogsReply.removed)
+}
+
+// -------------------------------------------------------------------
+
+// BlockRequest
+
+// uint64 blockHeight = 2;
+inline void BlockRequest::clear_blockheight() {
+  blockheight_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 BlockRequest::_internal_blockheight() const {
+  return blockheight_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 BlockRequest::blockheight() const {
+  // @@protoc_insertion_point(field_get:remote.BlockRequest.blockHeight)
+  return _internal_blockheight();
+}
+inline void BlockRequest::_internal_set_blockheight(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  blockheight_ = value;
+}
+inline void BlockRequest::set_blockheight(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_blockheight(value);
+  // @@protoc_insertion_point(field_set:remote.BlockRequest.blockHeight)
+}
+
+// .types.H256 blockHash = 3;
+inline bool BlockRequest::_internal_has_blockhash() const {
+  return this != internal_default_instance() && blockhash_ != nullptr;
+}
+inline bool BlockRequest::has_blockhash() const {
+  return _internal_has_blockhash();
+}
+inline const ::types::H256& BlockRequest::_internal_blockhash() const {
+  const ::types::H256* p = blockhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& BlockRequest::blockhash() const {
+  // @@protoc_insertion_point(field_get:remote.BlockRequest.blockHash)
+  return _internal_blockhash();
+}
+inline void BlockRequest::unsafe_arena_set_allocated_blockhash(
+    ::types::H256* blockhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash_);
+  }
+  blockhash_ = blockhash;
+  if (blockhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.BlockRequest.blockHash)
+}
+inline ::types::H256* BlockRequest::release_blockhash() {
+  
+  ::types::H256* temp = blockhash_;
+  blockhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* BlockRequest::unsafe_arena_release_blockhash() {
+  // @@protoc_insertion_point(field_release:remote.BlockRequest.blockHash)
+  
+  ::types::H256* temp = blockhash_;
+  blockhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* BlockRequest::_internal_mutable_blockhash() {
+  
+  if (blockhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    blockhash_ = p;
+  }
+  return blockhash_;
+}
+inline ::types::H256* BlockRequest::mutable_blockhash() {
+  // @@protoc_insertion_point(field_mutable:remote.BlockRequest.blockHash)
+  return _internal_mutable_blockhash();
+}
+inline void BlockRequest::set_allocated_blockhash(::types::H256* blockhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash_);
+  }
+  if (blockhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      blockhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, blockhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  blockhash_ = blockhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.BlockRequest.blockHash)
+}
+
+// -------------------------------------------------------------------
+
+// BlockReply
+
+// bytes blockRlp = 1;
+inline void BlockReply::clear_blockrlp() {
+  blockrlp_.ClearToEmpty();
+}
+inline const std::string& BlockReply::blockrlp() const {
+  // @@protoc_insertion_point(field_get:remote.BlockReply.blockRlp)
+  return _internal_blockrlp();
+}
+inline void BlockReply::set_blockrlp(const std::string& value) {
+  _internal_set_blockrlp(value);
+  // @@protoc_insertion_point(field_set:remote.BlockReply.blockRlp)
+}
+inline std::string* BlockReply::mutable_blockrlp() {
+  // @@protoc_insertion_point(field_mutable:remote.BlockReply.blockRlp)
+  return _internal_mutable_blockrlp();
+}
+inline const std::string& BlockReply::_internal_blockrlp() const {
+  return blockrlp_.Get();
+}
+inline void BlockReply::_internal_set_blockrlp(const std::string& value) {
+  
+  blockrlp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void BlockReply::set_blockrlp(std::string&& value) {
+  
+  blockrlp_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:remote.BlockReply.blockRlp)
+}
+inline void BlockReply::set_blockrlp(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  blockrlp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:remote.BlockReply.blockRlp)
+}
+inline void BlockReply::set_blockrlp(const void* value,
+    size_t size) {
+  
+  blockrlp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:remote.BlockReply.blockRlp)
+}
+inline std::string* BlockReply::_internal_mutable_blockrlp() {
+  
+  return blockrlp_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* BlockReply::release_blockrlp() {
+  // @@protoc_insertion_point(field_release:remote.BlockReply.blockRlp)
+  return blockrlp_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void BlockReply::set_allocated_blockrlp(std::string* blockrlp) {
+  if (blockrlp != nullptr) {
+    
+  } else {
+    
+  }
+  blockrlp_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), blockrlp,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:remote.BlockReply.blockRlp)
+}
+
+// bytes senders = 2;
+inline void BlockReply::clear_senders() {
+  senders_.ClearToEmpty();
+}
+inline const std::string& BlockReply::senders() const {
+  // @@protoc_insertion_point(field_get:remote.BlockReply.senders)
+  return _internal_senders();
+}
+inline void BlockReply::set_senders(const std::string& value) {
+  _internal_set_senders(value);
+  // @@protoc_insertion_point(field_set:remote.BlockReply.senders)
+}
+inline std::string* BlockReply::mutable_senders() {
+  // @@protoc_insertion_point(field_mutable:remote.BlockReply.senders)
+  return _internal_mutable_senders();
+}
+inline const std::string& BlockReply::_internal_senders() const {
+  return senders_.Get();
+}
+inline void BlockReply::_internal_set_senders(const std::string& value) {
+  
+  senders_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void BlockReply::set_senders(std::string&& value) {
+  
+  senders_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:remote.BlockReply.senders)
+}
+inline void BlockReply::set_senders(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  senders_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:remote.BlockReply.senders)
+}
+inline void BlockReply::set_senders(const void* value,
+    size_t size) {
+  
+  senders_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:remote.BlockReply.senders)
+}
+inline std::string* BlockReply::_internal_mutable_senders() {
+  
+  return senders_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* BlockReply::release_senders() {
+  // @@protoc_insertion_point(field_release:remote.BlockReply.senders)
+  return senders_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void BlockReply::set_allocated_senders(std::string* senders) {
+  if (senders != nullptr) {
+    
+  } else {
+    
+  }
+  senders_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), senders,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:remote.BlockReply.senders)
+}
+
+// -------------------------------------------------------------------
+
+// TxnLookupRequest
+
+// .types.H256 txnHash = 1;
+inline bool TxnLookupRequest::_internal_has_txnhash() const {
+  return this != internal_default_instance() && txnhash_ != nullptr;
+}
+inline bool TxnLookupRequest::has_txnhash() const {
+  return _internal_has_txnhash();
+}
+inline const ::types::H256& TxnLookupRequest::_internal_txnhash() const {
+  const ::types::H256* p = txnhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& TxnLookupRequest::txnhash() const {
+  // @@protoc_insertion_point(field_get:remote.TxnLookupRequest.txnHash)
+  return _internal_txnhash();
+}
+inline void TxnLookupRequest::unsafe_arena_set_allocated_txnhash(
+    ::types::H256* txnhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(txnhash_);
+  }
+  txnhash_ = txnhash;
+  if (txnhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:remote.TxnLookupRequest.txnHash)
+}
+inline ::types::H256* TxnLookupRequest::release_txnhash() {
+  
+  ::types::H256* temp = txnhash_;
+  txnhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* TxnLookupRequest::unsafe_arena_release_txnhash() {
+  // @@protoc_insertion_point(field_release:remote.TxnLookupRequest.txnHash)
+  
+  ::types::H256* temp = txnhash_;
+  txnhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* TxnLookupRequest::_internal_mutable_txnhash() {
+  
+  if (txnhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    txnhash_ = p;
+  }
+  return txnhash_;
+}
+inline ::types::H256* TxnLookupRequest::mutable_txnhash() {
+  // @@protoc_insertion_point(field_mutable:remote.TxnLookupRequest.txnHash)
+  return _internal_mutable_txnhash();
+}
+inline void TxnLookupRequest::set_allocated_txnhash(::types::H256* txnhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(txnhash_);
+  }
+  if (txnhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(txnhash)->GetArena();
+    if (message_arena != submessage_arena) {
+      txnhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, txnhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  txnhash_ = txnhash;
+  // @@protoc_insertion_point(field_set_allocated:remote.TxnLookupRequest.txnHash)
+}
+
+// -------------------------------------------------------------------
+
+// TxnLookupReply
+
+// uint64 blockNumber = 1;
+inline void TxnLookupReply::clear_blocknumber() {
+  blocknumber_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 TxnLookupReply::_internal_blocknumber() const {
+  return blocknumber_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 TxnLookupReply::blocknumber() const {
+  // @@protoc_insertion_point(field_get:remote.TxnLookupReply.blockNumber)
+  return _internal_blocknumber();
+}
+inline void TxnLookupReply::_internal_set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  blocknumber_ = value;
+}
+inline void TxnLookupReply::set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_blocknumber(value);
+  // @@protoc_insertion_point(field_set:remote.TxnLookupReply.blockNumber)
+}
+
+// -------------------------------------------------------------------
+
 // NodesInfoRequest
 
 // uint32 limit = 1;
@@ -2444,9 +6450,75 @@ NodesInfoReply::nodesinfo() const {
   return nodesinfo_;
 }
 
+// -------------------------------------------------------------------
+
+// PeersReply
+
+// repeated .types.PeerInfo peers = 1;
+inline int PeersReply::_internal_peers_size() const {
+  return peers_.size();
+}
+inline int PeersReply::peers_size() const {
+  return _internal_peers_size();
+}
+inline ::types::PeerInfo* PeersReply::mutable_peers(int index) {
+  // @@protoc_insertion_point(field_mutable:remote.PeersReply.peers)
+  return peers_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >*
+PeersReply::mutable_peers() {
+  // @@protoc_insertion_point(field_mutable_list:remote.PeersReply.peers)
+  return &peers_;
+}
+inline const ::types::PeerInfo& PeersReply::_internal_peers(int index) const {
+  return peers_.Get(index);
+}
+inline const ::types::PeerInfo& PeersReply::peers(int index) const {
+  // @@protoc_insertion_point(field_get:remote.PeersReply.peers)
+  return _internal_peers(index);
+}
+inline ::types::PeerInfo* PeersReply::_internal_add_peers() {
+  return peers_.Add();
+}
+inline ::types::PeerInfo* PeersReply::add_peers() {
+  // @@protoc_insertion_point(field_add:remote.PeersReply.peers)
+  return _internal_add_peers();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::PeerInfo >&
+PeersReply::peers() const {
+  // @@protoc_insertion_point(field_list:remote.PeersReply.peers)
+  return peers_;
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -2484,6 +6556,11 @@ template <> struct is_proto_enum< ::remote::Event> : ::std::true_type {};
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::remote::Event>() {
   return ::remote::Event_descriptor();
+}
+template <> struct is_proto_enum< ::remote::EngineStatus> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::remote::EngineStatus>() {
+  return ::remote::EngineStatus_descriptor();
 }
 
 PROTOBUF_NAMESPACE_CLOSE

--- a/interfaces/types/types.pb.cc
+++ b/interfaces/types/types.pb.cc
@@ -16,6 +16,8 @@
 #include <google/protobuf/port_def.inc>
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H1024_types_2ftypes_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_H128_types_2ftypes_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H160_types_2ftypes_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H2048_types_2ftypes_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H256_types_2ftypes_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_H512_types_2ftypes_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_types_2ftypes_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_NodeInfoPorts_types_2ftypes_2eproto;
@@ -48,6 +50,10 @@ class VersionReplyDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<VersionReply> _instance;
 } _VersionReply_default_instance_;
+class ExecutionPayloadDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<ExecutionPayload> _instance;
+} _ExecutionPayload_default_instance_;
 class NodeInfoPortsDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<NodeInfoPorts> _instance;
@@ -56,7 +62,27 @@ class NodeInfoReplyDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<NodeInfoReply> _instance;
 } _NodeInfoReply_default_instance_;
+class PeerInfoDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<PeerInfo> _instance;
+} _PeerInfo_default_instance_;
 }  // namespace types
+static void InitDefaultsscc_info_ExecutionPayload_types_2ftypes_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::types::_ExecutionPayload_default_instance_;
+    new (ptr) ::types::ExecutionPayload();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<3> scc_info_ExecutionPayload_types_2ftypes_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 3, 0, InitDefaultsscc_info_ExecutionPayload_types_2ftypes_2eproto}, {
+      &scc_info_H256_types_2ftypes_2eproto.base,
+      &scc_info_H160_types_2ftypes_2eproto.base,
+      &scc_info_H2048_types_2ftypes_2eproto.base,}};
+
 static void InitDefaultsscc_info_H1024_types_2ftypes_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -167,6 +193,19 @@ static void InitDefaultsscc_info_NodeInfoReply_types_2ftypes_2eproto() {
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_NodeInfoReply_types_2ftypes_2eproto}, {
       &scc_info_NodeInfoPorts_types_2ftypes_2eproto.base,}};
 
+static void InitDefaultsscc_info_PeerInfo_types_2ftypes_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::types::_PeerInfo_default_instance_;
+    new (ptr) ::types::PeerInfo();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_PeerInfo_types_2ftypes_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_PeerInfo_types_2ftypes_2eproto}, {}};
+
 static void InitDefaultsscc_info_VersionReply_types_2ftypes_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -180,7 +219,7 @@ static void InitDefaultsscc_info_VersionReply_types_2ftypes_2eproto() {
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_VersionReply_types_2ftypes_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_VersionReply_types_2ftypes_2eproto}, {}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_types_2ftypes_2eproto[9];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_types_2ftypes_2eproto[11];
 static constexpr ::PROTOBUF_NAMESPACE_ID::EnumDescriptor const** file_level_enum_descriptors_types_2ftypes_2eproto = nullptr;
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_types_2ftypes_2eproto = nullptr;
 
@@ -236,6 +275,25 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_types_2ftypes_2eproto::offsets
   PROTOBUF_FIELD_OFFSET(::types::VersionReply, minor_),
   PROTOBUF_FIELD_OFFSET(::types::VersionReply, patch_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, parenthash_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, coinbase_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, stateroot_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, receiptroot_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, logsbloom_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, prevrandao_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, blocknumber_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, gaslimit_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, gasused_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, timestamp_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, extradata_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, basefeepergas_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, blockhash_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, transactions_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::types::NodeInfoPorts, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -254,6 +312,21 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_types_2ftypes_2eproto::offsets
   PROTOBUF_FIELD_OFFSET(::types::NodeInfoReply, ports_),
   PROTOBUF_FIELD_OFFSET(::types::NodeInfoReply, listeneraddr_),
   PROTOBUF_FIELD_OFFSET(::types::NodeInfoReply, protocols_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, id_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, name_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, enode_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, enr_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, caps_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, connlocaladdr_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, connremoteaddr_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, connisinbound_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, connistrusted_),
+  PROTOBUF_FIELD_OFFSET(::types::PeerInfo, connisstatic_),
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::types::H128)},
@@ -263,8 +336,10 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 28, -1, sizeof(::types::H1024)},
   { 35, -1, sizeof(::types::H2048)},
   { 42, -1, sizeof(::types::VersionReply)},
-  { 50, -1, sizeof(::types::NodeInfoPorts)},
-  { 57, -1, sizeof(::types::NodeInfoReply)},
+  { 50, -1, sizeof(::types::ExecutionPayload)},
+  { 69, -1, sizeof(::types::NodeInfoPorts)},
+  { 76, -1, sizeof(::types::NodeInfoReply)},
+  { 88, -1, sizeof(::types::PeerInfo)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -275,8 +350,10 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_H1024_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_H2048_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_VersionReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_ExecutionPayload_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_NodeInfoPorts_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_NodeInfoReply_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::types::_PeerInfo_default_instance_),
 };
 
 const char descriptor_table_protodef_types_2ftypes_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
@@ -290,23 +367,39 @@ const char descriptor_table_protodef_types_2ftypes_2eproto[] PROTOBUF_SECTION_VA
   "es.H512\022\027\n\002lo\030\002 \001(\0132\013.types.H512\";\n\005H204"
   "8\022\030\n\002hi\030\001 \001(\0132\014.types.H1024\022\030\n\002lo\030\002 \001(\0132"
   "\014.types.H1024\";\n\014VersionReply\022\r\n\005major\030\001"
-  " \001(\r\022\r\n\005minor\030\002 \001(\r\022\r\n\005patch\030\003 \001(\r\"4\n\rNo"
-  "deInfoPorts\022\021\n\tdiscovery\030\001 \001(\r\022\020\n\010listen"
-  "er\030\002 \001(\r\"\223\001\n\rNodeInfoReply\022\n\n\002id\030\001 \001(\t\022\014"
-  "\n\004name\030\002 \001(\t\022\r\n\005enode\030\003 \001(\t\022\013\n\003enr\030\004 \001(\t"
-  "\022#\n\005ports\030\005 \001(\0132\024.types.NodeInfoPorts\022\024\n"
-  "\014listenerAddr\030\006 \001(\t\022\021\n\tprotocols\030\007 \001(\014:="
-  "\n\025service_major_version\022\034.google.protobu"
-  "f.FileOptions\030\321\206\003 \001(\r:=\n\025service_minor_v"
-  "ersion\022\034.google.protobuf.FileOptions\030\322\206\003"
-  " \001(\r:=\n\025service_patch_version\022\034.google.p"
-  "rotobuf.FileOptions\030\323\206\003 \001(\rB\017Z\r./types;t"
-  "ypesb\006proto3"
+  " \001(\r\022\r\n\005minor\030\002 \001(\r\022\r\n\005patch\030\003 \001(\r\"\216\003\n\020E"
+  "xecutionPayload\022\037\n\nparentHash\030\001 \001(\0132\013.ty"
+  "pes.H256\022\035\n\010coinbase\030\002 \001(\0132\013.types.H160\022"
+  "\036\n\tstateRoot\030\003 \001(\0132\013.types.H256\022 \n\013recei"
+  "ptRoot\030\004 \001(\0132\013.types.H256\022\037\n\tlogsBloom\030\005"
+  " \001(\0132\014.types.H2048\022\037\n\nprevRandao\030\006 \001(\0132\013"
+  ".types.H256\022\023\n\013blockNumber\030\007 \001(\004\022\020\n\010gasL"
+  "imit\030\010 \001(\004\022\017\n\007gasUsed\030\t \001(\004\022\021\n\ttimestamp"
+  "\030\n \001(\004\022\021\n\textraData\030\013 \001(\014\022\"\n\rbaseFeePerG"
+  "as\030\014 \001(\0132\013.types.H256\022\036\n\tblockHash\030\r \001(\013"
+  "2\013.types.H256\022\024\n\014transactions\030\016 \003(\014\"4\n\rN"
+  "odeInfoPorts\022\021\n\tdiscovery\030\001 \001(\r\022\020\n\010liste"
+  "ner\030\002 \001(\r\"\223\001\n\rNodeInfoReply\022\n\n\002id\030\001 \001(\t\022"
+  "\014\n\004name\030\002 \001(\t\022\r\n\005enode\030\003 \001(\t\022\013\n\003enr\030\004 \001("
+  "\t\022#\n\005ports\030\005 \001(\0132\024.types.NodeInfoPorts\022\024"
+  "\n\014listenerAddr\030\006 \001(\t\022\021\n\tprotocols\030\007 \001(\014\""
+  "\301\001\n\010PeerInfo\022\n\n\002id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\r"
+  "\n\005enode\030\003 \001(\t\022\013\n\003enr\030\004 \001(\t\022\014\n\004caps\030\005 \003(\t"
+  "\022\025\n\rconnLocalAddr\030\006 \001(\t\022\026\n\016connRemoteAdd"
+  "r\030\007 \001(\t\022\025\n\rconnIsInbound\030\010 \001(\010\022\025\n\rconnIs"
+  "Trusted\030\t \001(\010\022\024\n\014connIsStatic\030\n \001(\010:=\n\025s"
+  "ervice_major_version\022\034.google.protobuf.F"
+  "ileOptions\030\321\206\003 \001(\r:=\n\025service_minor_vers"
+  "ion\022\034.google.protobuf.FileOptions\030\322\206\003 \001("
+  "\r:=\n\025service_patch_version\022\034.google.prot"
+  "obuf.FileOptions\030\323\206\003 \001(\rB\017Z\r./types;type"
+  "sb\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_types_2ftypes_2eproto_deps[1] = {
   &::descriptor_table_google_2fprotobuf_2fdescriptor_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_types_2ftypes_2eproto_sccs[9] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_types_2ftypes_2eproto_sccs[11] = {
+  &scc_info_ExecutionPayload_types_2ftypes_2eproto.base,
   &scc_info_H1024_types_2ftypes_2eproto.base,
   &scc_info_H128_types_2ftypes_2eproto.base,
   &scc_info_H160_types_2ftypes_2eproto.base,
@@ -315,14 +408,15 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_typ
   &scc_info_H512_types_2ftypes_2eproto.base,
   &scc_info_NodeInfoPorts_types_2ftypes_2eproto.base,
   &scc_info_NodeInfoReply_types_2ftypes_2eproto.base,
+  &scc_info_PeerInfo_types_2ftypes_2eproto.base,
   &scc_info_VersionReply_types_2ftypes_2eproto.base,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_types_2ftypes_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_types_2ftypes_2eproto = {
-  false, false, descriptor_table_protodef_types_2ftypes_2eproto, "types/types.proto", 852,
-  &descriptor_table_types_2ftypes_2eproto_once, descriptor_table_types_2ftypes_2eproto_sccs, descriptor_table_types_2ftypes_2eproto_deps, 9, 1,
+  false, false, descriptor_table_protodef_types_2ftypes_2eproto, "types/types.proto", 1449,
+  &descriptor_table_types_2ftypes_2eproto_once, descriptor_table_types_2ftypes_2eproto_sccs, descriptor_table_types_2ftypes_2eproto_deps, 11, 1,
   schemas, file_default_instances, TableStruct_types_2ftypes_2eproto::offsets,
-  file_level_metadata_types_2ftypes_2eproto, 9, file_level_enum_descriptors_types_2ftypes_2eproto, file_level_service_descriptors_types_2ftypes_2eproto,
+  file_level_metadata_types_2ftypes_2eproto, 11, file_level_enum_descriptors_types_2ftypes_2eproto, file_level_service_descriptors_types_2ftypes_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -2087,6 +2181,667 @@ void VersionReply::InternalSwap(VersionReply* other) {
 
 // ===================================================================
 
+class ExecutionPayload::_Internal {
+ public:
+  static const ::types::H256& parenthash(const ExecutionPayload* msg);
+  static const ::types::H160& coinbase(const ExecutionPayload* msg);
+  static const ::types::H256& stateroot(const ExecutionPayload* msg);
+  static const ::types::H256& receiptroot(const ExecutionPayload* msg);
+  static const ::types::H2048& logsbloom(const ExecutionPayload* msg);
+  static const ::types::H256& prevrandao(const ExecutionPayload* msg);
+  static const ::types::H256& basefeepergas(const ExecutionPayload* msg);
+  static const ::types::H256& blockhash(const ExecutionPayload* msg);
+};
+
+const ::types::H256&
+ExecutionPayload::_Internal::parenthash(const ExecutionPayload* msg) {
+  return *msg->parenthash_;
+}
+const ::types::H160&
+ExecutionPayload::_Internal::coinbase(const ExecutionPayload* msg) {
+  return *msg->coinbase_;
+}
+const ::types::H256&
+ExecutionPayload::_Internal::stateroot(const ExecutionPayload* msg) {
+  return *msg->stateroot_;
+}
+const ::types::H256&
+ExecutionPayload::_Internal::receiptroot(const ExecutionPayload* msg) {
+  return *msg->receiptroot_;
+}
+const ::types::H2048&
+ExecutionPayload::_Internal::logsbloom(const ExecutionPayload* msg) {
+  return *msg->logsbloom_;
+}
+const ::types::H256&
+ExecutionPayload::_Internal::prevrandao(const ExecutionPayload* msg) {
+  return *msg->prevrandao_;
+}
+const ::types::H256&
+ExecutionPayload::_Internal::basefeepergas(const ExecutionPayload* msg) {
+  return *msg->basefeepergas_;
+}
+const ::types::H256&
+ExecutionPayload::_Internal::blockhash(const ExecutionPayload* msg) {
+  return *msg->blockhash_;
+}
+ExecutionPayload::ExecutionPayload(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  transactions_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:types.ExecutionPayload)
+}
+ExecutionPayload::ExecutionPayload(const ExecutionPayload& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      transactions_(from.transactions_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  extradata_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_extradata().empty()) {
+    extradata_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_extradata(), 
+      GetArena());
+  }
+  if (from._internal_has_parenthash()) {
+    parenthash_ = new ::types::H256(*from.parenthash_);
+  } else {
+    parenthash_ = nullptr;
+  }
+  if (from._internal_has_coinbase()) {
+    coinbase_ = new ::types::H160(*from.coinbase_);
+  } else {
+    coinbase_ = nullptr;
+  }
+  if (from._internal_has_stateroot()) {
+    stateroot_ = new ::types::H256(*from.stateroot_);
+  } else {
+    stateroot_ = nullptr;
+  }
+  if (from._internal_has_receiptroot()) {
+    receiptroot_ = new ::types::H256(*from.receiptroot_);
+  } else {
+    receiptroot_ = nullptr;
+  }
+  if (from._internal_has_logsbloom()) {
+    logsbloom_ = new ::types::H2048(*from.logsbloom_);
+  } else {
+    logsbloom_ = nullptr;
+  }
+  if (from._internal_has_prevrandao()) {
+    prevrandao_ = new ::types::H256(*from.prevrandao_);
+  } else {
+    prevrandao_ = nullptr;
+  }
+  if (from._internal_has_basefeepergas()) {
+    basefeepergas_ = new ::types::H256(*from.basefeepergas_);
+  } else {
+    basefeepergas_ = nullptr;
+  }
+  if (from._internal_has_blockhash()) {
+    blockhash_ = new ::types::H256(*from.blockhash_);
+  } else {
+    blockhash_ = nullptr;
+  }
+  ::memcpy(&blocknumber_, &from.blocknumber_,
+    static_cast<size_t>(reinterpret_cast<char*>(&timestamp_) -
+    reinterpret_cast<char*>(&blocknumber_)) + sizeof(timestamp_));
+  // @@protoc_insertion_point(copy_constructor:types.ExecutionPayload)
+}
+
+void ExecutionPayload::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_ExecutionPayload_types_2ftypes_2eproto.base);
+  extradata_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&parenthash_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&timestamp_) -
+      reinterpret_cast<char*>(&parenthash_)) + sizeof(timestamp_));
+}
+
+ExecutionPayload::~ExecutionPayload() {
+  // @@protoc_insertion_point(destructor:types.ExecutionPayload)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ExecutionPayload::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  extradata_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete parenthash_;
+  if (this != internal_default_instance()) delete coinbase_;
+  if (this != internal_default_instance()) delete stateroot_;
+  if (this != internal_default_instance()) delete receiptroot_;
+  if (this != internal_default_instance()) delete logsbloom_;
+  if (this != internal_default_instance()) delete prevrandao_;
+  if (this != internal_default_instance()) delete basefeepergas_;
+  if (this != internal_default_instance()) delete blockhash_;
+}
+
+void ExecutionPayload::ArenaDtor(void* object) {
+  ExecutionPayload* _this = reinterpret_cast< ExecutionPayload* >(object);
+  (void)_this;
+}
+void ExecutionPayload::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ExecutionPayload::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ExecutionPayload& ExecutionPayload::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_ExecutionPayload_types_2ftypes_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void ExecutionPayload::Clear() {
+// @@protoc_insertion_point(message_clear_start:types.ExecutionPayload)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  transactions_.Clear();
+  extradata_.ClearToEmpty();
+  if (GetArena() == nullptr && parenthash_ != nullptr) {
+    delete parenthash_;
+  }
+  parenthash_ = nullptr;
+  if (GetArena() == nullptr && coinbase_ != nullptr) {
+    delete coinbase_;
+  }
+  coinbase_ = nullptr;
+  if (GetArena() == nullptr && stateroot_ != nullptr) {
+    delete stateroot_;
+  }
+  stateroot_ = nullptr;
+  if (GetArena() == nullptr && receiptroot_ != nullptr) {
+    delete receiptroot_;
+  }
+  receiptroot_ = nullptr;
+  if (GetArena() == nullptr && logsbloom_ != nullptr) {
+    delete logsbloom_;
+  }
+  logsbloom_ = nullptr;
+  if (GetArena() == nullptr && prevrandao_ != nullptr) {
+    delete prevrandao_;
+  }
+  prevrandao_ = nullptr;
+  if (GetArena() == nullptr && basefeepergas_ != nullptr) {
+    delete basefeepergas_;
+  }
+  basefeepergas_ = nullptr;
+  if (GetArena() == nullptr && blockhash_ != nullptr) {
+    delete blockhash_;
+  }
+  blockhash_ = nullptr;
+  ::memset(&blocknumber_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&timestamp_) -
+      reinterpret_cast<char*>(&blocknumber_)) + sizeof(timestamp_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ExecutionPayload::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .types.H256 parentHash = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_parenthash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H160 coinbase = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_coinbase(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 stateRoot = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_stateroot(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 receiptRoot = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_receiptroot(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H2048 logsBloom = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 42)) {
+          ptr = ctx->ParseMessage(_internal_mutable_logsbloom(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 prevRandao = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 50)) {
+          ptr = ctx->ParseMessage(_internal_mutable_prevrandao(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 blockNumber = 7;
+      case 7:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 56)) {
+          blocknumber_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 gasLimit = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 64)) {
+          gaslimit_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 gasUsed = 9;
+      case 9:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 72)) {
+          gasused_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // uint64 timestamp = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 80)) {
+          timestamp_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bytes extraData = 11;
+      case 11:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 90)) {
+          auto str = _internal_mutable_extradata();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 baseFeePerGas = 12;
+      case 12:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 98)) {
+          ptr = ctx->ParseMessage(_internal_mutable_basefeepergas(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .types.H256 blockHash = 13;
+      case 13:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 106)) {
+          ptr = ctx->ParseMessage(_internal_mutable_blockhash(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated bytes transactions = 14;
+      case 14:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 114)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            auto str = _internal_add_transactions();
+            ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<114>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ExecutionPayload::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:types.ExecutionPayload)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H256 parentHash = 1;
+  if (this->has_parenthash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::parenthash(this), target, stream);
+  }
+
+  // .types.H160 coinbase = 2;
+  if (this->has_coinbase()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        2, _Internal::coinbase(this), target, stream);
+  }
+
+  // .types.H256 stateRoot = 3;
+  if (this->has_stateroot()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::stateroot(this), target, stream);
+  }
+
+  // .types.H256 receiptRoot = 4;
+  if (this->has_receiptroot()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::receiptroot(this), target, stream);
+  }
+
+  // .types.H2048 logsBloom = 5;
+  if (this->has_logsbloom()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        5, _Internal::logsbloom(this), target, stream);
+  }
+
+  // .types.H256 prevRandao = 6;
+  if (this->has_prevrandao()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        6, _Internal::prevrandao(this), target, stream);
+  }
+
+  // uint64 blockNumber = 7;
+  if (this->blocknumber() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(7, this->_internal_blocknumber(), target);
+  }
+
+  // uint64 gasLimit = 8;
+  if (this->gaslimit() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(8, this->_internal_gaslimit(), target);
+  }
+
+  // uint64 gasUsed = 9;
+  if (this->gasused() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(9, this->_internal_gasused(), target);
+  }
+
+  // uint64 timestamp = 10;
+  if (this->timestamp() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(10, this->_internal_timestamp(), target);
+  }
+
+  // bytes extraData = 11;
+  if (this->extradata().size() > 0) {
+    target = stream->WriteBytesMaybeAliased(
+        11, this->_internal_extradata(), target);
+  }
+
+  // .types.H256 baseFeePerGas = 12;
+  if (this->has_basefeepergas()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        12, _Internal::basefeepergas(this), target, stream);
+  }
+
+  // .types.H256 blockHash = 13;
+  if (this->has_blockhash()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        13, _Internal::blockhash(this), target, stream);
+  }
+
+  // repeated bytes transactions = 14;
+  for (int i = 0, n = this->_internal_transactions_size(); i < n; i++) {
+    const auto& s = this->_internal_transactions(i);
+    target = stream->WriteBytes(14, s, target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:types.ExecutionPayload)
+  return target;
+}
+
+size_t ExecutionPayload::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:types.ExecutionPayload)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated bytes transactions = 14;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(transactions_.size());
+  for (int i = 0, n = transactions_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+      transactions_.Get(i));
+  }
+
+  // bytes extraData = 11;
+  if (this->extradata().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_extradata());
+  }
+
+  // .types.H256 parentHash = 1;
+  if (this->has_parenthash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *parenthash_);
+  }
+
+  // .types.H160 coinbase = 2;
+  if (this->has_coinbase()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *coinbase_);
+  }
+
+  // .types.H256 stateRoot = 3;
+  if (this->has_stateroot()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *stateroot_);
+  }
+
+  // .types.H256 receiptRoot = 4;
+  if (this->has_receiptroot()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *receiptroot_);
+  }
+
+  // .types.H2048 logsBloom = 5;
+  if (this->has_logsbloom()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *logsbloom_);
+  }
+
+  // .types.H256 prevRandao = 6;
+  if (this->has_prevrandao()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *prevrandao_);
+  }
+
+  // .types.H256 baseFeePerGas = 12;
+  if (this->has_basefeepergas()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *basefeepergas_);
+  }
+
+  // .types.H256 blockHash = 13;
+  if (this->has_blockhash()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *blockhash_);
+  }
+
+  // uint64 blockNumber = 7;
+  if (this->blocknumber() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_blocknumber());
+  }
+
+  // uint64 gasLimit = 8;
+  if (this->gaslimit() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_gaslimit());
+  }
+
+  // uint64 gasUsed = 9;
+  if (this->gasused() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_gasused());
+  }
+
+  // uint64 timestamp = 10;
+  if (this->timestamp() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_timestamp());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ExecutionPayload::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:types.ExecutionPayload)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ExecutionPayload* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ExecutionPayload>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:types.ExecutionPayload)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:types.ExecutionPayload)
+    MergeFrom(*source);
+  }
+}
+
+void ExecutionPayload::MergeFrom(const ExecutionPayload& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:types.ExecutionPayload)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  transactions_.MergeFrom(from.transactions_);
+  if (from.extradata().size() > 0) {
+    _internal_set_extradata(from._internal_extradata());
+  }
+  if (from.has_parenthash()) {
+    _internal_mutable_parenthash()->::types::H256::MergeFrom(from._internal_parenthash());
+  }
+  if (from.has_coinbase()) {
+    _internal_mutable_coinbase()->::types::H160::MergeFrom(from._internal_coinbase());
+  }
+  if (from.has_stateroot()) {
+    _internal_mutable_stateroot()->::types::H256::MergeFrom(from._internal_stateroot());
+  }
+  if (from.has_receiptroot()) {
+    _internal_mutable_receiptroot()->::types::H256::MergeFrom(from._internal_receiptroot());
+  }
+  if (from.has_logsbloom()) {
+    _internal_mutable_logsbloom()->::types::H2048::MergeFrom(from._internal_logsbloom());
+  }
+  if (from.has_prevrandao()) {
+    _internal_mutable_prevrandao()->::types::H256::MergeFrom(from._internal_prevrandao());
+  }
+  if (from.has_basefeepergas()) {
+    _internal_mutable_basefeepergas()->::types::H256::MergeFrom(from._internal_basefeepergas());
+  }
+  if (from.has_blockhash()) {
+    _internal_mutable_blockhash()->::types::H256::MergeFrom(from._internal_blockhash());
+  }
+  if (from.blocknumber() != 0) {
+    _internal_set_blocknumber(from._internal_blocknumber());
+  }
+  if (from.gaslimit() != 0) {
+    _internal_set_gaslimit(from._internal_gaslimit());
+  }
+  if (from.gasused() != 0) {
+    _internal_set_gasused(from._internal_gasused());
+  }
+  if (from.timestamp() != 0) {
+    _internal_set_timestamp(from._internal_timestamp());
+  }
+}
+
+void ExecutionPayload::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:types.ExecutionPayload)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ExecutionPayload::CopyFrom(const ExecutionPayload& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:types.ExecutionPayload)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ExecutionPayload::IsInitialized() const {
+  return true;
+}
+
+void ExecutionPayload::InternalSwap(ExecutionPayload* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  transactions_.InternalSwap(&other->transactions_);
+  extradata_.Swap(&other->extradata_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ExecutionPayload, timestamp_)
+      + sizeof(ExecutionPayload::timestamp_)
+      - PROTOBUF_FIELD_OFFSET(ExecutionPayload, parenthash_)>(
+          reinterpret_cast<char*>(&parenthash_),
+          reinterpret_cast<char*>(&other->parenthash_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ExecutionPayload::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 class NodeInfoPorts::_Internal {
  public:
 };
@@ -2746,6 +3501,518 @@ void NodeInfoReply::InternalSwap(NodeInfoReply* other) {
   return GetMetadataStatic();
 }
 
+
+// ===================================================================
+
+class PeerInfo::_Internal {
+ public:
+};
+
+PeerInfo::PeerInfo(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  caps_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:types.PeerInfo)
+}
+PeerInfo::PeerInfo(const PeerInfo& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      caps_(from.caps_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  id_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_id().empty()) {
+    id_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_id(), 
+      GetArena());
+  }
+  name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_name().empty()) {
+    name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_name(), 
+      GetArena());
+  }
+  enode_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_enode().empty()) {
+    enode_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_enode(), 
+      GetArena());
+  }
+  enr_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_enr().empty()) {
+    enr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_enr(), 
+      GetArena());
+  }
+  connlocaladdr_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_connlocaladdr().empty()) {
+    connlocaladdr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_connlocaladdr(), 
+      GetArena());
+  }
+  connremoteaddr_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_connremoteaddr().empty()) {
+    connremoteaddr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_connremoteaddr(), 
+      GetArena());
+  }
+  ::memcpy(&connisinbound_, &from.connisinbound_,
+    static_cast<size_t>(reinterpret_cast<char*>(&connisstatic_) -
+    reinterpret_cast<char*>(&connisinbound_)) + sizeof(connisstatic_));
+  // @@protoc_insertion_point(copy_constructor:types.PeerInfo)
+}
+
+void PeerInfo::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_PeerInfo_types_2ftypes_2eproto.base);
+  id_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  enode_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  enr_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  connlocaladdr_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  connremoteaddr_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  ::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+      reinterpret_cast<char*>(&connisinbound_) - reinterpret_cast<char*>(this)),
+      0, static_cast<size_t>(reinterpret_cast<char*>(&connisstatic_) -
+      reinterpret_cast<char*>(&connisinbound_)) + sizeof(connisstatic_));
+}
+
+PeerInfo::~PeerInfo() {
+  // @@protoc_insertion_point(destructor:types.PeerInfo)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void PeerInfo::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  id_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  name_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  enode_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  enr_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  connlocaladdr_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  connremoteaddr_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void PeerInfo::ArenaDtor(void* object) {
+  PeerInfo* _this = reinterpret_cast< PeerInfo* >(object);
+  (void)_this;
+}
+void PeerInfo::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void PeerInfo::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const PeerInfo& PeerInfo::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_PeerInfo_types_2ftypes_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void PeerInfo::Clear() {
+// @@protoc_insertion_point(message_clear_start:types.PeerInfo)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  caps_.Clear();
+  id_.ClearToEmpty();
+  name_.ClearToEmpty();
+  enode_.ClearToEmpty();
+  enr_.ClearToEmpty();
+  connlocaladdr_.ClearToEmpty();
+  connremoteaddr_.ClearToEmpty();
+  ::memset(&connisinbound_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&connisstatic_) -
+      reinterpret_cast<char*>(&connisinbound_)) + sizeof(connisstatic_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PeerInfo::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string id = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_id();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.id"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string name = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_name();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.name"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string enode = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_enode();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.enode"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string enr = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          auto str = _internal_mutable_enr();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.enr"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated string caps = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 42)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            auto str = _internal_add_caps();
+            ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+            CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.caps"));
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<42>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // string connLocalAddr = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 50)) {
+          auto str = _internal_mutable_connlocaladdr();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.connLocalAddr"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string connRemoteAddr = 7;
+      case 7:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 58)) {
+          auto str = _internal_mutable_connremoteaddr();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "types.PeerInfo.connRemoteAddr"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool connIsInbound = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 64)) {
+          connisinbound_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool connIsTrusted = 9;
+      case 9:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 72)) {
+          connistrusted_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool connIsStatic = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 80)) {
+          connisstatic_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* PeerInfo::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:types.PeerInfo)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string id = 1;
+  if (this->id().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_id().data(), static_cast<int>(this->_internal_id().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.id");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_id(), target);
+  }
+
+  // string name = 2;
+  if (this->name().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_name().data(), static_cast<int>(this->_internal_name().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.name");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_name(), target);
+  }
+
+  // string enode = 3;
+  if (this->enode().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_enode().data(), static_cast<int>(this->_internal_enode().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.enode");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_enode(), target);
+  }
+
+  // string enr = 4;
+  if (this->enr().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_enr().data(), static_cast<int>(this->_internal_enr().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.enr");
+    target = stream->WriteStringMaybeAliased(
+        4, this->_internal_enr(), target);
+  }
+
+  // repeated string caps = 5;
+  for (int i = 0, n = this->_internal_caps_size(); i < n; i++) {
+    const auto& s = this->_internal_caps(i);
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      s.data(), static_cast<int>(s.length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.caps");
+    target = stream->WriteString(5, s, target);
+  }
+
+  // string connLocalAddr = 6;
+  if (this->connlocaladdr().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_connlocaladdr().data(), static_cast<int>(this->_internal_connlocaladdr().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.connLocalAddr");
+    target = stream->WriteStringMaybeAliased(
+        6, this->_internal_connlocaladdr(), target);
+  }
+
+  // string connRemoteAddr = 7;
+  if (this->connremoteaddr().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_connremoteaddr().data(), static_cast<int>(this->_internal_connremoteaddr().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "types.PeerInfo.connRemoteAddr");
+    target = stream->WriteStringMaybeAliased(
+        7, this->_internal_connremoteaddr(), target);
+  }
+
+  // bool connIsInbound = 8;
+  if (this->connisinbound() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(8, this->_internal_connisinbound(), target);
+  }
+
+  // bool connIsTrusted = 9;
+  if (this->connistrusted() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(9, this->_internal_connistrusted(), target);
+  }
+
+  // bool connIsStatic = 10;
+  if (this->connisstatic() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(10, this->_internal_connisstatic(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:types.PeerInfo)
+  return target;
+}
+
+size_t PeerInfo::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:types.PeerInfo)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated string caps = 5;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(caps_.size());
+  for (int i = 0, n = caps_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+      caps_.Get(i));
+  }
+
+  // string id = 1;
+  if (this->id().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_id());
+  }
+
+  // string name = 2;
+  if (this->name().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_name());
+  }
+
+  // string enode = 3;
+  if (this->enode().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_enode());
+  }
+
+  // string enr = 4;
+  if (this->enr().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_enr());
+  }
+
+  // string connLocalAddr = 6;
+  if (this->connlocaladdr().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_connlocaladdr());
+  }
+
+  // string connRemoteAddr = 7;
+  if (this->connremoteaddr().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_connremoteaddr());
+  }
+
+  // bool connIsInbound = 8;
+  if (this->connisinbound() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // bool connIsTrusted = 9;
+  if (this->connistrusted() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // bool connIsStatic = 10;
+  if (this->connisstatic() != 0) {
+    total_size += 1 + 1;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void PeerInfo::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:types.PeerInfo)
+  GOOGLE_DCHECK_NE(&from, this);
+  const PeerInfo* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<PeerInfo>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:types.PeerInfo)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:types.PeerInfo)
+    MergeFrom(*source);
+  }
+}
+
+void PeerInfo::MergeFrom(const PeerInfo& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:types.PeerInfo)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  caps_.MergeFrom(from.caps_);
+  if (from.id().size() > 0) {
+    _internal_set_id(from._internal_id());
+  }
+  if (from.name().size() > 0) {
+    _internal_set_name(from._internal_name());
+  }
+  if (from.enode().size() > 0) {
+    _internal_set_enode(from._internal_enode());
+  }
+  if (from.enr().size() > 0) {
+    _internal_set_enr(from._internal_enr());
+  }
+  if (from.connlocaladdr().size() > 0) {
+    _internal_set_connlocaladdr(from._internal_connlocaladdr());
+  }
+  if (from.connremoteaddr().size() > 0) {
+    _internal_set_connremoteaddr(from._internal_connremoteaddr());
+  }
+  if (from.connisinbound() != 0) {
+    _internal_set_connisinbound(from._internal_connisinbound());
+  }
+  if (from.connistrusted() != 0) {
+    _internal_set_connistrusted(from._internal_connistrusted());
+  }
+  if (from.connisstatic() != 0) {
+    _internal_set_connisstatic(from._internal_connisstatic());
+  }
+}
+
+void PeerInfo::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:types.PeerInfo)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void PeerInfo::CopyFrom(const PeerInfo& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:types.PeerInfo)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PeerInfo::IsInitialized() const {
+  return true;
+}
+
+void PeerInfo::InternalSwap(PeerInfo* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  caps_.InternalSwap(&other->caps_);
+  id_.Swap(&other->id_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  name_.Swap(&other->name_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  enode_.Swap(&other->enode_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  enr_.Swap(&other->enr_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  connlocaladdr_.Swap(&other->connlocaladdr_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  connremoteaddr_.Swap(&other->connremoteaddr_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(PeerInfo, connisstatic_)
+      + sizeof(PeerInfo::connisstatic_)
+      - PROTOBUF_FIELD_OFFSET(PeerInfo, connisinbound_)>(
+          reinterpret_cast<char*>(&connisinbound_),
+          reinterpret_cast<char*>(&other->connisinbound_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PeerInfo::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
 ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier< ::google::protobuf::FileOptions,
     ::PROTOBUF_NAMESPACE_ID::internal::PrimitiveTypeTraits< ::PROTOBUF_NAMESPACE_ID::uint32 >, 13, false >
   service_major_version(kServiceMajorVersionFieldNumber, 0u);
@@ -2780,11 +4047,17 @@ template<> PROTOBUF_NOINLINE ::types::H2048* Arena::CreateMaybeMessage< ::types:
 template<> PROTOBUF_NOINLINE ::types::VersionReply* Arena::CreateMaybeMessage< ::types::VersionReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::types::VersionReply >(arena);
 }
+template<> PROTOBUF_NOINLINE ::types::ExecutionPayload* Arena::CreateMaybeMessage< ::types::ExecutionPayload >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::types::ExecutionPayload >(arena);
+}
 template<> PROTOBUF_NOINLINE ::types::NodeInfoPorts* Arena::CreateMaybeMessage< ::types::NodeInfoPorts >(Arena* arena) {
   return Arena::CreateMessageInternal< ::types::NodeInfoPorts >(arena);
 }
 template<> PROTOBUF_NOINLINE ::types::NodeInfoReply* Arena::CreateMaybeMessage< ::types::NodeInfoReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::types::NodeInfoReply >(arena);
+}
+template<> PROTOBUF_NOINLINE ::types::PeerInfo* Arena::CreateMaybeMessage< ::types::PeerInfo >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::types::PeerInfo >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/interfaces/types/types.pb.h
+++ b/interfaces/types/types.pb.h
@@ -47,7 +47,7 @@ struct TableStruct_types_2ftypes_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[9]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[11]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -55,6 +55,9 @@ struct TableStruct_types_2ftypes_2eproto {
 };
 extern const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_types_2ftypes_2eproto;
 namespace types {
+class ExecutionPayload;
+class ExecutionPayloadDefaultTypeInternal;
+extern ExecutionPayloadDefaultTypeInternal _ExecutionPayload_default_instance_;
 class H1024;
 class H1024DefaultTypeInternal;
 extern H1024DefaultTypeInternal _H1024_default_instance_;
@@ -79,11 +82,15 @@ extern NodeInfoPortsDefaultTypeInternal _NodeInfoPorts_default_instance_;
 class NodeInfoReply;
 class NodeInfoReplyDefaultTypeInternal;
 extern NodeInfoReplyDefaultTypeInternal _NodeInfoReply_default_instance_;
+class PeerInfo;
+class PeerInfoDefaultTypeInternal;
+extern PeerInfoDefaultTypeInternal _PeerInfo_default_instance_;
 class VersionReply;
 class VersionReplyDefaultTypeInternal;
 extern VersionReplyDefaultTypeInternal _VersionReply_default_instance_;
 }  // namespace types
 PROTOBUF_NAMESPACE_OPEN
+template<> ::types::ExecutionPayload* Arena::CreateMaybeMessage<::types::ExecutionPayload>(Arena*);
 template<> ::types::H1024* Arena::CreateMaybeMessage<::types::H1024>(Arena*);
 template<> ::types::H128* Arena::CreateMaybeMessage<::types::H128>(Arena*);
 template<> ::types::H160* Arena::CreateMaybeMessage<::types::H160>(Arena*);
@@ -92,6 +99,7 @@ template<> ::types::H256* Arena::CreateMaybeMessage<::types::H256>(Arena*);
 template<> ::types::H512* Arena::CreateMaybeMessage<::types::H512>(Arena*);
 template<> ::types::NodeInfoPorts* Arena::CreateMaybeMessage<::types::NodeInfoPorts>(Arena*);
 template<> ::types::NodeInfoReply* Arena::CreateMaybeMessage<::types::NodeInfoReply>(Arena*);
+template<> ::types::PeerInfo* Arena::CreateMaybeMessage<::types::PeerInfo>(Arena*);
 template<> ::types::VersionReply* Arena::CreateMaybeMessage<::types::VersionReply>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace types {
@@ -1219,6 +1227,379 @@ class VersionReply PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class ExecutionPayload PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:types.ExecutionPayload) */ {
+ public:
+  inline ExecutionPayload() : ExecutionPayload(nullptr) {}
+  virtual ~ExecutionPayload();
+
+  ExecutionPayload(const ExecutionPayload& from);
+  ExecutionPayload(ExecutionPayload&& from) noexcept
+    : ExecutionPayload() {
+    *this = ::std::move(from);
+  }
+
+  inline ExecutionPayload& operator=(const ExecutionPayload& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ExecutionPayload& operator=(ExecutionPayload&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ExecutionPayload& default_instance();
+
+  static inline const ExecutionPayload* internal_default_instance() {
+    return reinterpret_cast<const ExecutionPayload*>(
+               &_ExecutionPayload_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    7;
+
+  friend void swap(ExecutionPayload& a, ExecutionPayload& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ExecutionPayload* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ExecutionPayload* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ExecutionPayload* New() const final {
+    return CreateMaybeMessage<ExecutionPayload>(nullptr);
+  }
+
+  ExecutionPayload* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ExecutionPayload>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ExecutionPayload& from);
+  void MergeFrom(const ExecutionPayload& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ExecutionPayload* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "types.ExecutionPayload";
+  }
+  protected:
+  explicit ExecutionPayload(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_types_2ftypes_2eproto);
+    return ::descriptor_table_types_2ftypes_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kTransactionsFieldNumber = 14,
+    kExtraDataFieldNumber = 11,
+    kParentHashFieldNumber = 1,
+    kCoinbaseFieldNumber = 2,
+    kStateRootFieldNumber = 3,
+    kReceiptRootFieldNumber = 4,
+    kLogsBloomFieldNumber = 5,
+    kPrevRandaoFieldNumber = 6,
+    kBaseFeePerGasFieldNumber = 12,
+    kBlockHashFieldNumber = 13,
+    kBlockNumberFieldNumber = 7,
+    kGasLimitFieldNumber = 8,
+    kGasUsedFieldNumber = 9,
+    kTimestampFieldNumber = 10,
+  };
+  // repeated bytes transactions = 14;
+  int transactions_size() const;
+  private:
+  int _internal_transactions_size() const;
+  public:
+  void clear_transactions();
+  const std::string& transactions(int index) const;
+  std::string* mutable_transactions(int index);
+  void set_transactions(int index, const std::string& value);
+  void set_transactions(int index, std::string&& value);
+  void set_transactions(int index, const char* value);
+  void set_transactions(int index, const void* value, size_t size);
+  std::string* add_transactions();
+  void add_transactions(const std::string& value);
+  void add_transactions(std::string&& value);
+  void add_transactions(const char* value);
+  void add_transactions(const void* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& transactions() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_transactions();
+  private:
+  const std::string& _internal_transactions(int index) const;
+  std::string* _internal_add_transactions();
+  public:
+
+  // bytes extraData = 11;
+  void clear_extradata();
+  const std::string& extradata() const;
+  void set_extradata(const std::string& value);
+  void set_extradata(std::string&& value);
+  void set_extradata(const char* value);
+  void set_extradata(const void* value, size_t size);
+  std::string* mutable_extradata();
+  std::string* release_extradata();
+  void set_allocated_extradata(std::string* extradata);
+  private:
+  const std::string& _internal_extradata() const;
+  void _internal_set_extradata(const std::string& value);
+  std::string* _internal_mutable_extradata();
+  public:
+
+  // .types.H256 parentHash = 1;
+  bool has_parenthash() const;
+  private:
+  bool _internal_has_parenthash() const;
+  public:
+  void clear_parenthash();
+  const ::types::H256& parenthash() const;
+  ::types::H256* release_parenthash();
+  ::types::H256* mutable_parenthash();
+  void set_allocated_parenthash(::types::H256* parenthash);
+  private:
+  const ::types::H256& _internal_parenthash() const;
+  ::types::H256* _internal_mutable_parenthash();
+  public:
+  void unsafe_arena_set_allocated_parenthash(
+      ::types::H256* parenthash);
+  ::types::H256* unsafe_arena_release_parenthash();
+
+  // .types.H160 coinbase = 2;
+  bool has_coinbase() const;
+  private:
+  bool _internal_has_coinbase() const;
+  public:
+  void clear_coinbase();
+  const ::types::H160& coinbase() const;
+  ::types::H160* release_coinbase();
+  ::types::H160* mutable_coinbase();
+  void set_allocated_coinbase(::types::H160* coinbase);
+  private:
+  const ::types::H160& _internal_coinbase() const;
+  ::types::H160* _internal_mutable_coinbase();
+  public:
+  void unsafe_arena_set_allocated_coinbase(
+      ::types::H160* coinbase);
+  ::types::H160* unsafe_arena_release_coinbase();
+
+  // .types.H256 stateRoot = 3;
+  bool has_stateroot() const;
+  private:
+  bool _internal_has_stateroot() const;
+  public:
+  void clear_stateroot();
+  const ::types::H256& stateroot() const;
+  ::types::H256* release_stateroot();
+  ::types::H256* mutable_stateroot();
+  void set_allocated_stateroot(::types::H256* stateroot);
+  private:
+  const ::types::H256& _internal_stateroot() const;
+  ::types::H256* _internal_mutable_stateroot();
+  public:
+  void unsafe_arena_set_allocated_stateroot(
+      ::types::H256* stateroot);
+  ::types::H256* unsafe_arena_release_stateroot();
+
+  // .types.H256 receiptRoot = 4;
+  bool has_receiptroot() const;
+  private:
+  bool _internal_has_receiptroot() const;
+  public:
+  void clear_receiptroot();
+  const ::types::H256& receiptroot() const;
+  ::types::H256* release_receiptroot();
+  ::types::H256* mutable_receiptroot();
+  void set_allocated_receiptroot(::types::H256* receiptroot);
+  private:
+  const ::types::H256& _internal_receiptroot() const;
+  ::types::H256* _internal_mutable_receiptroot();
+  public:
+  void unsafe_arena_set_allocated_receiptroot(
+      ::types::H256* receiptroot);
+  ::types::H256* unsafe_arena_release_receiptroot();
+
+  // .types.H2048 logsBloom = 5;
+  bool has_logsbloom() const;
+  private:
+  bool _internal_has_logsbloom() const;
+  public:
+  void clear_logsbloom();
+  const ::types::H2048& logsbloom() const;
+  ::types::H2048* release_logsbloom();
+  ::types::H2048* mutable_logsbloom();
+  void set_allocated_logsbloom(::types::H2048* logsbloom);
+  private:
+  const ::types::H2048& _internal_logsbloom() const;
+  ::types::H2048* _internal_mutable_logsbloom();
+  public:
+  void unsafe_arena_set_allocated_logsbloom(
+      ::types::H2048* logsbloom);
+  ::types::H2048* unsafe_arena_release_logsbloom();
+
+  // .types.H256 prevRandao = 6;
+  bool has_prevrandao() const;
+  private:
+  bool _internal_has_prevrandao() const;
+  public:
+  void clear_prevrandao();
+  const ::types::H256& prevrandao() const;
+  ::types::H256* release_prevrandao();
+  ::types::H256* mutable_prevrandao();
+  void set_allocated_prevrandao(::types::H256* prevrandao);
+  private:
+  const ::types::H256& _internal_prevrandao() const;
+  ::types::H256* _internal_mutable_prevrandao();
+  public:
+  void unsafe_arena_set_allocated_prevrandao(
+      ::types::H256* prevrandao);
+  ::types::H256* unsafe_arena_release_prevrandao();
+
+  // .types.H256 baseFeePerGas = 12;
+  bool has_basefeepergas() const;
+  private:
+  bool _internal_has_basefeepergas() const;
+  public:
+  void clear_basefeepergas();
+  const ::types::H256& basefeepergas() const;
+  ::types::H256* release_basefeepergas();
+  ::types::H256* mutable_basefeepergas();
+  void set_allocated_basefeepergas(::types::H256* basefeepergas);
+  private:
+  const ::types::H256& _internal_basefeepergas() const;
+  ::types::H256* _internal_mutable_basefeepergas();
+  public:
+  void unsafe_arena_set_allocated_basefeepergas(
+      ::types::H256* basefeepergas);
+  ::types::H256* unsafe_arena_release_basefeepergas();
+
+  // .types.H256 blockHash = 13;
+  bool has_blockhash() const;
+  private:
+  bool _internal_has_blockhash() const;
+  public:
+  void clear_blockhash();
+  const ::types::H256& blockhash() const;
+  ::types::H256* release_blockhash();
+  ::types::H256* mutable_blockhash();
+  void set_allocated_blockhash(::types::H256* blockhash);
+  private:
+  const ::types::H256& _internal_blockhash() const;
+  ::types::H256* _internal_mutable_blockhash();
+  public:
+  void unsafe_arena_set_allocated_blockhash(
+      ::types::H256* blockhash);
+  ::types::H256* unsafe_arena_release_blockhash();
+
+  // uint64 blockNumber = 7;
+  void clear_blocknumber();
+  ::PROTOBUF_NAMESPACE_ID::uint64 blocknumber() const;
+  void set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_blocknumber() const;
+  void _internal_set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // uint64 gasLimit = 8;
+  void clear_gaslimit();
+  ::PROTOBUF_NAMESPACE_ID::uint64 gaslimit() const;
+  void set_gaslimit(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_gaslimit() const;
+  void _internal_set_gaslimit(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // uint64 gasUsed = 9;
+  void clear_gasused();
+  ::PROTOBUF_NAMESPACE_ID::uint64 gasused() const;
+  void set_gasused(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_gasused() const;
+  void _internal_set_gasused(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // uint64 timestamp = 10;
+  void clear_timestamp();
+  ::PROTOBUF_NAMESPACE_ID::uint64 timestamp() const;
+  void set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_timestamp() const;
+  void _internal_set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:types.ExecutionPayload)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> transactions_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr extradata_;
+  ::types::H256* parenthash_;
+  ::types::H160* coinbase_;
+  ::types::H256* stateroot_;
+  ::types::H256* receiptroot_;
+  ::types::H2048* logsbloom_;
+  ::types::H256* prevrandao_;
+  ::types::H256* basefeepergas_;
+  ::types::H256* blockhash_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 blocknumber_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 gaslimit_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 gasused_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 timestamp_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_types_2ftypes_2eproto;
+};
+// -------------------------------------------------------------------
+
 class NodeInfoPorts PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:types.NodeInfoPorts) */ {
  public:
@@ -1260,7 +1641,7 @@ class NodeInfoPorts PROTOBUF_FINAL :
                &_NodeInfoPorts_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    8;
 
   friend void swap(NodeInfoPorts& a, NodeInfoPorts& b) {
     a.Swap(&b);
@@ -1407,7 +1788,7 @@ class NodeInfoReply PROTOBUF_FINAL :
                &_NodeInfoReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    9;
 
   friend void swap(NodeInfoReply& a, NodeInfoReply& b) {
     a.Swap(&b);
@@ -1614,6 +1995,298 @@ class NodeInfoReply PROTOBUF_FINAL :
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr listeneraddr_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr protocols_;
   ::types::NodeInfoPorts* ports_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_types_2ftypes_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PeerInfo PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:types.PeerInfo) */ {
+ public:
+  inline PeerInfo() : PeerInfo(nullptr) {}
+  virtual ~PeerInfo();
+
+  PeerInfo(const PeerInfo& from);
+  PeerInfo(PeerInfo&& from) noexcept
+    : PeerInfo() {
+    *this = ::std::move(from);
+  }
+
+  inline PeerInfo& operator=(const PeerInfo& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PeerInfo& operator=(PeerInfo&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const PeerInfo& default_instance();
+
+  static inline const PeerInfo* internal_default_instance() {
+    return reinterpret_cast<const PeerInfo*>(
+               &_PeerInfo_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  friend void swap(PeerInfo& a, PeerInfo& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PeerInfo* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PeerInfo* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline PeerInfo* New() const final {
+    return CreateMaybeMessage<PeerInfo>(nullptr);
+  }
+
+  PeerInfo* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<PeerInfo>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const PeerInfo& from);
+  void MergeFrom(const PeerInfo& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PeerInfo* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "types.PeerInfo";
+  }
+  protected:
+  explicit PeerInfo(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_types_2ftypes_2eproto);
+    return ::descriptor_table_types_2ftypes_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCapsFieldNumber = 5,
+    kIdFieldNumber = 1,
+    kNameFieldNumber = 2,
+    kEnodeFieldNumber = 3,
+    kEnrFieldNumber = 4,
+    kConnLocalAddrFieldNumber = 6,
+    kConnRemoteAddrFieldNumber = 7,
+    kConnIsInboundFieldNumber = 8,
+    kConnIsTrustedFieldNumber = 9,
+    kConnIsStaticFieldNumber = 10,
+  };
+  // repeated string caps = 5;
+  int caps_size() const;
+  private:
+  int _internal_caps_size() const;
+  public:
+  void clear_caps();
+  const std::string& caps(int index) const;
+  std::string* mutable_caps(int index);
+  void set_caps(int index, const std::string& value);
+  void set_caps(int index, std::string&& value);
+  void set_caps(int index, const char* value);
+  void set_caps(int index, const char* value, size_t size);
+  std::string* add_caps();
+  void add_caps(const std::string& value);
+  void add_caps(std::string&& value);
+  void add_caps(const char* value);
+  void add_caps(const char* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& caps() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_caps();
+  private:
+  const std::string& _internal_caps(int index) const;
+  std::string* _internal_add_caps();
+  public:
+
+  // string id = 1;
+  void clear_id();
+  const std::string& id() const;
+  void set_id(const std::string& value);
+  void set_id(std::string&& value);
+  void set_id(const char* value);
+  void set_id(const char* value, size_t size);
+  std::string* mutable_id();
+  std::string* release_id();
+  void set_allocated_id(std::string* id);
+  private:
+  const std::string& _internal_id() const;
+  void _internal_set_id(const std::string& value);
+  std::string* _internal_mutable_id();
+  public:
+
+  // string name = 2;
+  void clear_name();
+  const std::string& name() const;
+  void set_name(const std::string& value);
+  void set_name(std::string&& value);
+  void set_name(const char* value);
+  void set_name(const char* value, size_t size);
+  std::string* mutable_name();
+  std::string* release_name();
+  void set_allocated_name(std::string* name);
+  private:
+  const std::string& _internal_name() const;
+  void _internal_set_name(const std::string& value);
+  std::string* _internal_mutable_name();
+  public:
+
+  // string enode = 3;
+  void clear_enode();
+  const std::string& enode() const;
+  void set_enode(const std::string& value);
+  void set_enode(std::string&& value);
+  void set_enode(const char* value);
+  void set_enode(const char* value, size_t size);
+  std::string* mutable_enode();
+  std::string* release_enode();
+  void set_allocated_enode(std::string* enode);
+  private:
+  const std::string& _internal_enode() const;
+  void _internal_set_enode(const std::string& value);
+  std::string* _internal_mutable_enode();
+  public:
+
+  // string enr = 4;
+  void clear_enr();
+  const std::string& enr() const;
+  void set_enr(const std::string& value);
+  void set_enr(std::string&& value);
+  void set_enr(const char* value);
+  void set_enr(const char* value, size_t size);
+  std::string* mutable_enr();
+  std::string* release_enr();
+  void set_allocated_enr(std::string* enr);
+  private:
+  const std::string& _internal_enr() const;
+  void _internal_set_enr(const std::string& value);
+  std::string* _internal_mutable_enr();
+  public:
+
+  // string connLocalAddr = 6;
+  void clear_connlocaladdr();
+  const std::string& connlocaladdr() const;
+  void set_connlocaladdr(const std::string& value);
+  void set_connlocaladdr(std::string&& value);
+  void set_connlocaladdr(const char* value);
+  void set_connlocaladdr(const char* value, size_t size);
+  std::string* mutable_connlocaladdr();
+  std::string* release_connlocaladdr();
+  void set_allocated_connlocaladdr(std::string* connlocaladdr);
+  private:
+  const std::string& _internal_connlocaladdr() const;
+  void _internal_set_connlocaladdr(const std::string& value);
+  std::string* _internal_mutable_connlocaladdr();
+  public:
+
+  // string connRemoteAddr = 7;
+  void clear_connremoteaddr();
+  const std::string& connremoteaddr() const;
+  void set_connremoteaddr(const std::string& value);
+  void set_connremoteaddr(std::string&& value);
+  void set_connremoteaddr(const char* value);
+  void set_connremoteaddr(const char* value, size_t size);
+  std::string* mutable_connremoteaddr();
+  std::string* release_connremoteaddr();
+  void set_allocated_connremoteaddr(std::string* connremoteaddr);
+  private:
+  const std::string& _internal_connremoteaddr() const;
+  void _internal_set_connremoteaddr(const std::string& value);
+  std::string* _internal_mutable_connremoteaddr();
+  public:
+
+  // bool connIsInbound = 8;
+  void clear_connisinbound();
+  bool connisinbound() const;
+  void set_connisinbound(bool value);
+  private:
+  bool _internal_connisinbound() const;
+  void _internal_set_connisinbound(bool value);
+  public:
+
+  // bool connIsTrusted = 9;
+  void clear_connistrusted();
+  bool connistrusted() const;
+  void set_connistrusted(bool value);
+  private:
+  bool _internal_connistrusted() const;
+  void _internal_set_connistrusted(bool value);
+  public:
+
+  // bool connIsStatic = 10;
+  void clear_connisstatic();
+  bool connisstatic() const;
+  void set_connisstatic(bool value);
+  private:
+  bool _internal_connisstatic() const;
+  void _internal_set_connisstatic(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:types.PeerInfo)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> caps_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr id_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr name_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr enode_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr enr_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr connlocaladdr_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr connremoteaddr_;
+  bool connisinbound_;
+  bool connistrusted_;
+  bool connisstatic_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_types_2ftypes_2eproto;
 };
@@ -2533,6 +3206,889 @@ inline void VersionReply::set_patch(::PROTOBUF_NAMESPACE_ID::uint32 value) {
 
 // -------------------------------------------------------------------
 
+// ExecutionPayload
+
+// .types.H256 parentHash = 1;
+inline bool ExecutionPayload::_internal_has_parenthash() const {
+  return this != internal_default_instance() && parenthash_ != nullptr;
+}
+inline bool ExecutionPayload::has_parenthash() const {
+  return _internal_has_parenthash();
+}
+inline void ExecutionPayload::clear_parenthash() {
+  if (GetArena() == nullptr && parenthash_ != nullptr) {
+    delete parenthash_;
+  }
+  parenthash_ = nullptr;
+}
+inline const ::types::H256& ExecutionPayload::_internal_parenthash() const {
+  const ::types::H256* p = parenthash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& ExecutionPayload::parenthash() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.parentHash)
+  return _internal_parenthash();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_parenthash(
+    ::types::H256* parenthash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(parenthash_);
+  }
+  parenthash_ = parenthash;
+  if (parenthash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.parentHash)
+}
+inline ::types::H256* ExecutionPayload::release_parenthash() {
+  
+  ::types::H256* temp = parenthash_;
+  parenthash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::unsafe_arena_release_parenthash() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.parentHash)
+  
+  ::types::H256* temp = parenthash_;
+  parenthash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::_internal_mutable_parenthash() {
+  
+  if (parenthash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    parenthash_ = p;
+  }
+  return parenthash_;
+}
+inline ::types::H256* ExecutionPayload::mutable_parenthash() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.parentHash)
+  return _internal_mutable_parenthash();
+}
+inline void ExecutionPayload::set_allocated_parenthash(::types::H256* parenthash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete parenthash_;
+  }
+  if (parenthash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(parenthash);
+    if (message_arena != submessage_arena) {
+      parenthash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, parenthash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  parenthash_ = parenthash;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.parentHash)
+}
+
+// .types.H160 coinbase = 2;
+inline bool ExecutionPayload::_internal_has_coinbase() const {
+  return this != internal_default_instance() && coinbase_ != nullptr;
+}
+inline bool ExecutionPayload::has_coinbase() const {
+  return _internal_has_coinbase();
+}
+inline void ExecutionPayload::clear_coinbase() {
+  if (GetArena() == nullptr && coinbase_ != nullptr) {
+    delete coinbase_;
+  }
+  coinbase_ = nullptr;
+}
+inline const ::types::H160& ExecutionPayload::_internal_coinbase() const {
+  const ::types::H160* p = coinbase_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H160&>(
+      ::types::_H160_default_instance_);
+}
+inline const ::types::H160& ExecutionPayload::coinbase() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.coinbase)
+  return _internal_coinbase();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_coinbase(
+    ::types::H160* coinbase) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(coinbase_);
+  }
+  coinbase_ = coinbase;
+  if (coinbase) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.coinbase)
+}
+inline ::types::H160* ExecutionPayload::release_coinbase() {
+  
+  ::types::H160* temp = coinbase_;
+  coinbase_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H160* ExecutionPayload::unsafe_arena_release_coinbase() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.coinbase)
+  
+  ::types::H160* temp = coinbase_;
+  coinbase_ = nullptr;
+  return temp;
+}
+inline ::types::H160* ExecutionPayload::_internal_mutable_coinbase() {
+  
+  if (coinbase_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H160>(GetArena());
+    coinbase_ = p;
+  }
+  return coinbase_;
+}
+inline ::types::H160* ExecutionPayload::mutable_coinbase() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.coinbase)
+  return _internal_mutable_coinbase();
+}
+inline void ExecutionPayload::set_allocated_coinbase(::types::H160* coinbase) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete coinbase_;
+  }
+  if (coinbase) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(coinbase);
+    if (message_arena != submessage_arena) {
+      coinbase = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, coinbase, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  coinbase_ = coinbase;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.coinbase)
+}
+
+// .types.H256 stateRoot = 3;
+inline bool ExecutionPayload::_internal_has_stateroot() const {
+  return this != internal_default_instance() && stateroot_ != nullptr;
+}
+inline bool ExecutionPayload::has_stateroot() const {
+  return _internal_has_stateroot();
+}
+inline void ExecutionPayload::clear_stateroot() {
+  if (GetArena() == nullptr && stateroot_ != nullptr) {
+    delete stateroot_;
+  }
+  stateroot_ = nullptr;
+}
+inline const ::types::H256& ExecutionPayload::_internal_stateroot() const {
+  const ::types::H256* p = stateroot_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& ExecutionPayload::stateroot() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.stateRoot)
+  return _internal_stateroot();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_stateroot(
+    ::types::H256* stateroot) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(stateroot_);
+  }
+  stateroot_ = stateroot;
+  if (stateroot) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.stateRoot)
+}
+inline ::types::H256* ExecutionPayload::release_stateroot() {
+  
+  ::types::H256* temp = stateroot_;
+  stateroot_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::unsafe_arena_release_stateroot() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.stateRoot)
+  
+  ::types::H256* temp = stateroot_;
+  stateroot_ = nullptr;
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::_internal_mutable_stateroot() {
+  
+  if (stateroot_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    stateroot_ = p;
+  }
+  return stateroot_;
+}
+inline ::types::H256* ExecutionPayload::mutable_stateroot() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.stateRoot)
+  return _internal_mutable_stateroot();
+}
+inline void ExecutionPayload::set_allocated_stateroot(::types::H256* stateroot) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete stateroot_;
+  }
+  if (stateroot) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(stateroot);
+    if (message_arena != submessage_arena) {
+      stateroot = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, stateroot, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  stateroot_ = stateroot;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.stateRoot)
+}
+
+// .types.H256 receiptRoot = 4;
+inline bool ExecutionPayload::_internal_has_receiptroot() const {
+  return this != internal_default_instance() && receiptroot_ != nullptr;
+}
+inline bool ExecutionPayload::has_receiptroot() const {
+  return _internal_has_receiptroot();
+}
+inline void ExecutionPayload::clear_receiptroot() {
+  if (GetArena() == nullptr && receiptroot_ != nullptr) {
+    delete receiptroot_;
+  }
+  receiptroot_ = nullptr;
+}
+inline const ::types::H256& ExecutionPayload::_internal_receiptroot() const {
+  const ::types::H256* p = receiptroot_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& ExecutionPayload::receiptroot() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.receiptRoot)
+  return _internal_receiptroot();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_receiptroot(
+    ::types::H256* receiptroot) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(receiptroot_);
+  }
+  receiptroot_ = receiptroot;
+  if (receiptroot) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.receiptRoot)
+}
+inline ::types::H256* ExecutionPayload::release_receiptroot() {
+  
+  ::types::H256* temp = receiptroot_;
+  receiptroot_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::unsafe_arena_release_receiptroot() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.receiptRoot)
+  
+  ::types::H256* temp = receiptroot_;
+  receiptroot_ = nullptr;
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::_internal_mutable_receiptroot() {
+  
+  if (receiptroot_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    receiptroot_ = p;
+  }
+  return receiptroot_;
+}
+inline ::types::H256* ExecutionPayload::mutable_receiptroot() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.receiptRoot)
+  return _internal_mutable_receiptroot();
+}
+inline void ExecutionPayload::set_allocated_receiptroot(::types::H256* receiptroot) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete receiptroot_;
+  }
+  if (receiptroot) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(receiptroot);
+    if (message_arena != submessage_arena) {
+      receiptroot = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, receiptroot, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  receiptroot_ = receiptroot;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.receiptRoot)
+}
+
+// .types.H2048 logsBloom = 5;
+inline bool ExecutionPayload::_internal_has_logsbloom() const {
+  return this != internal_default_instance() && logsbloom_ != nullptr;
+}
+inline bool ExecutionPayload::has_logsbloom() const {
+  return _internal_has_logsbloom();
+}
+inline void ExecutionPayload::clear_logsbloom() {
+  if (GetArena() == nullptr && logsbloom_ != nullptr) {
+    delete logsbloom_;
+  }
+  logsbloom_ = nullptr;
+}
+inline const ::types::H2048& ExecutionPayload::_internal_logsbloom() const {
+  const ::types::H2048* p = logsbloom_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H2048&>(
+      ::types::_H2048_default_instance_);
+}
+inline const ::types::H2048& ExecutionPayload::logsbloom() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.logsBloom)
+  return _internal_logsbloom();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_logsbloom(
+    ::types::H2048* logsbloom) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(logsbloom_);
+  }
+  logsbloom_ = logsbloom;
+  if (logsbloom) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.logsBloom)
+}
+inline ::types::H2048* ExecutionPayload::release_logsbloom() {
+  
+  ::types::H2048* temp = logsbloom_;
+  logsbloom_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H2048* ExecutionPayload::unsafe_arena_release_logsbloom() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.logsBloom)
+  
+  ::types::H2048* temp = logsbloom_;
+  logsbloom_ = nullptr;
+  return temp;
+}
+inline ::types::H2048* ExecutionPayload::_internal_mutable_logsbloom() {
+  
+  if (logsbloom_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H2048>(GetArena());
+    logsbloom_ = p;
+  }
+  return logsbloom_;
+}
+inline ::types::H2048* ExecutionPayload::mutable_logsbloom() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.logsBloom)
+  return _internal_mutable_logsbloom();
+}
+inline void ExecutionPayload::set_allocated_logsbloom(::types::H2048* logsbloom) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete logsbloom_;
+  }
+  if (logsbloom) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(logsbloom);
+    if (message_arena != submessage_arena) {
+      logsbloom = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, logsbloom, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  logsbloom_ = logsbloom;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.logsBloom)
+}
+
+// .types.H256 prevRandao = 6;
+inline bool ExecutionPayload::_internal_has_prevrandao() const {
+  return this != internal_default_instance() && prevrandao_ != nullptr;
+}
+inline bool ExecutionPayload::has_prevrandao() const {
+  return _internal_has_prevrandao();
+}
+inline void ExecutionPayload::clear_prevrandao() {
+  if (GetArena() == nullptr && prevrandao_ != nullptr) {
+    delete prevrandao_;
+  }
+  prevrandao_ = nullptr;
+}
+inline const ::types::H256& ExecutionPayload::_internal_prevrandao() const {
+  const ::types::H256* p = prevrandao_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& ExecutionPayload::prevrandao() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.prevRandao)
+  return _internal_prevrandao();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_prevrandao(
+    ::types::H256* prevrandao) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(prevrandao_);
+  }
+  prevrandao_ = prevrandao;
+  if (prevrandao) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.prevRandao)
+}
+inline ::types::H256* ExecutionPayload::release_prevrandao() {
+  
+  ::types::H256* temp = prevrandao_;
+  prevrandao_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::unsafe_arena_release_prevrandao() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.prevRandao)
+  
+  ::types::H256* temp = prevrandao_;
+  prevrandao_ = nullptr;
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::_internal_mutable_prevrandao() {
+  
+  if (prevrandao_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    prevrandao_ = p;
+  }
+  return prevrandao_;
+}
+inline ::types::H256* ExecutionPayload::mutable_prevrandao() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.prevRandao)
+  return _internal_mutable_prevrandao();
+}
+inline void ExecutionPayload::set_allocated_prevrandao(::types::H256* prevrandao) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete prevrandao_;
+  }
+  if (prevrandao) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(prevrandao);
+    if (message_arena != submessage_arena) {
+      prevrandao = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, prevrandao, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  prevrandao_ = prevrandao;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.prevRandao)
+}
+
+// uint64 blockNumber = 7;
+inline void ExecutionPayload::clear_blocknumber() {
+  blocknumber_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::_internal_blocknumber() const {
+  return blocknumber_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::blocknumber() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.blockNumber)
+  return _internal_blocknumber();
+}
+inline void ExecutionPayload::_internal_set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  blocknumber_ = value;
+}
+inline void ExecutionPayload::set_blocknumber(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_blocknumber(value);
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.blockNumber)
+}
+
+// uint64 gasLimit = 8;
+inline void ExecutionPayload::clear_gaslimit() {
+  gaslimit_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::_internal_gaslimit() const {
+  return gaslimit_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::gaslimit() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.gasLimit)
+  return _internal_gaslimit();
+}
+inline void ExecutionPayload::_internal_set_gaslimit(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  gaslimit_ = value;
+}
+inline void ExecutionPayload::set_gaslimit(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_gaslimit(value);
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.gasLimit)
+}
+
+// uint64 gasUsed = 9;
+inline void ExecutionPayload::clear_gasused() {
+  gasused_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::_internal_gasused() const {
+  return gasused_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::gasused() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.gasUsed)
+  return _internal_gasused();
+}
+inline void ExecutionPayload::_internal_set_gasused(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  gasused_ = value;
+}
+inline void ExecutionPayload::set_gasused(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_gasused(value);
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.gasUsed)
+}
+
+// uint64 timestamp = 10;
+inline void ExecutionPayload::clear_timestamp() {
+  timestamp_ = PROTOBUF_ULONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::_internal_timestamp() const {
+  return timestamp_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 ExecutionPayload::timestamp() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.timestamp)
+  return _internal_timestamp();
+}
+inline void ExecutionPayload::_internal_set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  
+  timestamp_ = value;
+}
+inline void ExecutionPayload::set_timestamp(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_timestamp(value);
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.timestamp)
+}
+
+// bytes extraData = 11;
+inline void ExecutionPayload::clear_extradata() {
+  extradata_.ClearToEmpty();
+}
+inline const std::string& ExecutionPayload::extradata() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.extraData)
+  return _internal_extradata();
+}
+inline void ExecutionPayload::set_extradata(const std::string& value) {
+  _internal_set_extradata(value);
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.extraData)
+}
+inline std::string* ExecutionPayload::mutable_extradata() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.extraData)
+  return _internal_mutable_extradata();
+}
+inline const std::string& ExecutionPayload::_internal_extradata() const {
+  return extradata_.Get();
+}
+inline void ExecutionPayload::_internal_set_extradata(const std::string& value) {
+  
+  extradata_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ExecutionPayload::set_extradata(std::string&& value) {
+  
+  extradata_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.ExecutionPayload.extraData)
+}
+inline void ExecutionPayload::set_extradata(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  extradata_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.ExecutionPayload.extraData)
+}
+inline void ExecutionPayload::set_extradata(const void* value,
+    size_t size) {
+  
+  extradata_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.ExecutionPayload.extraData)
+}
+inline std::string* ExecutionPayload::_internal_mutable_extradata() {
+  
+  return extradata_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ExecutionPayload::release_extradata() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.extraData)
+  return extradata_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ExecutionPayload::set_allocated_extradata(std::string* extradata) {
+  if (extradata != nullptr) {
+    
+  } else {
+    
+  }
+  extradata_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), extradata,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.extraData)
+}
+
+// .types.H256 baseFeePerGas = 12;
+inline bool ExecutionPayload::_internal_has_basefeepergas() const {
+  return this != internal_default_instance() && basefeepergas_ != nullptr;
+}
+inline bool ExecutionPayload::has_basefeepergas() const {
+  return _internal_has_basefeepergas();
+}
+inline void ExecutionPayload::clear_basefeepergas() {
+  if (GetArena() == nullptr && basefeepergas_ != nullptr) {
+    delete basefeepergas_;
+  }
+  basefeepergas_ = nullptr;
+}
+inline const ::types::H256& ExecutionPayload::_internal_basefeepergas() const {
+  const ::types::H256* p = basefeepergas_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& ExecutionPayload::basefeepergas() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.baseFeePerGas)
+  return _internal_basefeepergas();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_basefeepergas(
+    ::types::H256* basefeepergas) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(basefeepergas_);
+  }
+  basefeepergas_ = basefeepergas;
+  if (basefeepergas) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.baseFeePerGas)
+}
+inline ::types::H256* ExecutionPayload::release_basefeepergas() {
+  
+  ::types::H256* temp = basefeepergas_;
+  basefeepergas_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::unsafe_arena_release_basefeepergas() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.baseFeePerGas)
+  
+  ::types::H256* temp = basefeepergas_;
+  basefeepergas_ = nullptr;
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::_internal_mutable_basefeepergas() {
+  
+  if (basefeepergas_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    basefeepergas_ = p;
+  }
+  return basefeepergas_;
+}
+inline ::types::H256* ExecutionPayload::mutable_basefeepergas() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.baseFeePerGas)
+  return _internal_mutable_basefeepergas();
+}
+inline void ExecutionPayload::set_allocated_basefeepergas(::types::H256* basefeepergas) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete basefeepergas_;
+  }
+  if (basefeepergas) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(basefeepergas);
+    if (message_arena != submessage_arena) {
+      basefeepergas = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, basefeepergas, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  basefeepergas_ = basefeepergas;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.baseFeePerGas)
+}
+
+// .types.H256 blockHash = 13;
+inline bool ExecutionPayload::_internal_has_blockhash() const {
+  return this != internal_default_instance() && blockhash_ != nullptr;
+}
+inline bool ExecutionPayload::has_blockhash() const {
+  return _internal_has_blockhash();
+}
+inline void ExecutionPayload::clear_blockhash() {
+  if (GetArena() == nullptr && blockhash_ != nullptr) {
+    delete blockhash_;
+  }
+  blockhash_ = nullptr;
+}
+inline const ::types::H256& ExecutionPayload::_internal_blockhash() const {
+  const ::types::H256* p = blockhash_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& ExecutionPayload::blockhash() const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.blockHash)
+  return _internal_blockhash();
+}
+inline void ExecutionPayload::unsafe_arena_set_allocated_blockhash(
+    ::types::H256* blockhash) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(blockhash_);
+  }
+  blockhash_ = blockhash;
+  if (blockhash) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ExecutionPayload.blockHash)
+}
+inline ::types::H256* ExecutionPayload::release_blockhash() {
+  
+  ::types::H256* temp = blockhash_;
+  blockhash_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::unsafe_arena_release_blockhash() {
+  // @@protoc_insertion_point(field_release:types.ExecutionPayload.blockHash)
+  
+  ::types::H256* temp = blockhash_;
+  blockhash_ = nullptr;
+  return temp;
+}
+inline ::types::H256* ExecutionPayload::_internal_mutable_blockhash() {
+  
+  if (blockhash_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArena());
+    blockhash_ = p;
+  }
+  return blockhash_;
+}
+inline ::types::H256* ExecutionPayload::mutable_blockhash() {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.blockHash)
+  return _internal_mutable_blockhash();
+}
+inline void ExecutionPayload::set_allocated_blockhash(::types::H256* blockhash) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete blockhash_;
+  }
+  if (blockhash) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(blockhash);
+    if (message_arena != submessage_arena) {
+      blockhash = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, blockhash, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  blockhash_ = blockhash;
+  // @@protoc_insertion_point(field_set_allocated:types.ExecutionPayload.blockHash)
+}
+
+// repeated bytes transactions = 14;
+inline int ExecutionPayload::_internal_transactions_size() const {
+  return transactions_.size();
+}
+inline int ExecutionPayload::transactions_size() const {
+  return _internal_transactions_size();
+}
+inline void ExecutionPayload::clear_transactions() {
+  transactions_.Clear();
+}
+inline std::string* ExecutionPayload::add_transactions() {
+  // @@protoc_insertion_point(field_add_mutable:types.ExecutionPayload.transactions)
+  return _internal_add_transactions();
+}
+inline const std::string& ExecutionPayload::_internal_transactions(int index) const {
+  return transactions_.Get(index);
+}
+inline const std::string& ExecutionPayload::transactions(int index) const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.transactions)
+  return _internal_transactions(index);
+}
+inline std::string* ExecutionPayload::mutable_transactions(int index) {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.transactions)
+  return transactions_.Mutable(index);
+}
+inline void ExecutionPayload::set_transactions(int index, const std::string& value) {
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.transactions)
+  transactions_.Mutable(index)->assign(value);
+}
+inline void ExecutionPayload::set_transactions(int index, std::string&& value) {
+  // @@protoc_insertion_point(field_set:types.ExecutionPayload.transactions)
+  transactions_.Mutable(index)->assign(std::move(value));
+}
+inline void ExecutionPayload::set_transactions(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  transactions_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:types.ExecutionPayload.transactions)
+}
+inline void ExecutionPayload::set_transactions(int index, const void* value, size_t size) {
+  transactions_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:types.ExecutionPayload.transactions)
+}
+inline std::string* ExecutionPayload::_internal_add_transactions() {
+  return transactions_.Add();
+}
+inline void ExecutionPayload::add_transactions(const std::string& value) {
+  transactions_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:types.ExecutionPayload.transactions)
+}
+inline void ExecutionPayload::add_transactions(std::string&& value) {
+  transactions_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:types.ExecutionPayload.transactions)
+}
+inline void ExecutionPayload::add_transactions(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  transactions_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:types.ExecutionPayload.transactions)
+}
+inline void ExecutionPayload::add_transactions(const void* value, size_t size) {
+  transactions_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:types.ExecutionPayload.transactions)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+ExecutionPayload::transactions() const {
+  // @@protoc_insertion_point(field_list:types.ExecutionPayload.transactions)
+  return transactions_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+ExecutionPayload::mutable_transactions() {
+  // @@protoc_insertion_point(field_mutable_list:types.ExecutionPayload.transactions)
+  return &transactions_;
+}
+
+// -------------------------------------------------------------------
+
 // NodeInfoPorts
 
 // uint32 discovery = 1;
@@ -3028,9 +4584,517 @@ inline void NodeInfoReply::set_allocated_protocols(std::string* protocols) {
   // @@protoc_insertion_point(field_set_allocated:types.NodeInfoReply.protocols)
 }
 
+// -------------------------------------------------------------------
+
+// PeerInfo
+
+// string id = 1;
+inline void PeerInfo::clear_id() {
+  id_.ClearToEmpty();
+}
+inline const std::string& PeerInfo::id() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.id)
+  return _internal_id();
+}
+inline void PeerInfo::set_id(const std::string& value) {
+  _internal_set_id(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.id)
+}
+inline std::string* PeerInfo::mutable_id() {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.id)
+  return _internal_mutable_id();
+}
+inline const std::string& PeerInfo::_internal_id() const {
+  return id_.Get();
+}
+inline void PeerInfo::_internal_set_id(const std::string& value) {
+  
+  id_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void PeerInfo::set_id(std::string&& value) {
+  
+  id_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.PeerInfo.id)
+}
+inline void PeerInfo::set_id(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  id_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.id)
+}
+inline void PeerInfo::set_id(const char* value,
+    size_t size) {
+  
+  id_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.id)
+}
+inline std::string* PeerInfo::_internal_mutable_id() {
+  
+  return id_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* PeerInfo::release_id() {
+  // @@protoc_insertion_point(field_release:types.PeerInfo.id)
+  return id_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void PeerInfo::set_allocated_id(std::string* id) {
+  if (id != nullptr) {
+    
+  } else {
+    
+  }
+  id_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), id,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.PeerInfo.id)
+}
+
+// string name = 2;
+inline void PeerInfo::clear_name() {
+  name_.ClearToEmpty();
+}
+inline const std::string& PeerInfo::name() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.name)
+  return _internal_name();
+}
+inline void PeerInfo::set_name(const std::string& value) {
+  _internal_set_name(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.name)
+}
+inline std::string* PeerInfo::mutable_name() {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.name)
+  return _internal_mutable_name();
+}
+inline const std::string& PeerInfo::_internal_name() const {
+  return name_.Get();
+}
+inline void PeerInfo::_internal_set_name(const std::string& value) {
+  
+  name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void PeerInfo::set_name(std::string&& value) {
+  
+  name_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.PeerInfo.name)
+}
+inline void PeerInfo::set_name(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.name)
+}
+inline void PeerInfo::set_name(const char* value,
+    size_t size) {
+  
+  name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.name)
+}
+inline std::string* PeerInfo::_internal_mutable_name() {
+  
+  return name_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* PeerInfo::release_name() {
+  // @@protoc_insertion_point(field_release:types.PeerInfo.name)
+  return name_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void PeerInfo::set_allocated_name(std::string* name) {
+  if (name != nullptr) {
+    
+  } else {
+    
+  }
+  name_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), name,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.PeerInfo.name)
+}
+
+// string enode = 3;
+inline void PeerInfo::clear_enode() {
+  enode_.ClearToEmpty();
+}
+inline const std::string& PeerInfo::enode() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.enode)
+  return _internal_enode();
+}
+inline void PeerInfo::set_enode(const std::string& value) {
+  _internal_set_enode(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.enode)
+}
+inline std::string* PeerInfo::mutable_enode() {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.enode)
+  return _internal_mutable_enode();
+}
+inline const std::string& PeerInfo::_internal_enode() const {
+  return enode_.Get();
+}
+inline void PeerInfo::_internal_set_enode(const std::string& value) {
+  
+  enode_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void PeerInfo::set_enode(std::string&& value) {
+  
+  enode_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.PeerInfo.enode)
+}
+inline void PeerInfo::set_enode(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  enode_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.enode)
+}
+inline void PeerInfo::set_enode(const char* value,
+    size_t size) {
+  
+  enode_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.enode)
+}
+inline std::string* PeerInfo::_internal_mutable_enode() {
+  
+  return enode_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* PeerInfo::release_enode() {
+  // @@protoc_insertion_point(field_release:types.PeerInfo.enode)
+  return enode_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void PeerInfo::set_allocated_enode(std::string* enode) {
+  if (enode != nullptr) {
+    
+  } else {
+    
+  }
+  enode_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), enode,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.PeerInfo.enode)
+}
+
+// string enr = 4;
+inline void PeerInfo::clear_enr() {
+  enr_.ClearToEmpty();
+}
+inline const std::string& PeerInfo::enr() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.enr)
+  return _internal_enr();
+}
+inline void PeerInfo::set_enr(const std::string& value) {
+  _internal_set_enr(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.enr)
+}
+inline std::string* PeerInfo::mutable_enr() {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.enr)
+  return _internal_mutable_enr();
+}
+inline const std::string& PeerInfo::_internal_enr() const {
+  return enr_.Get();
+}
+inline void PeerInfo::_internal_set_enr(const std::string& value) {
+  
+  enr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void PeerInfo::set_enr(std::string&& value) {
+  
+  enr_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.PeerInfo.enr)
+}
+inline void PeerInfo::set_enr(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  enr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.enr)
+}
+inline void PeerInfo::set_enr(const char* value,
+    size_t size) {
+  
+  enr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.enr)
+}
+inline std::string* PeerInfo::_internal_mutable_enr() {
+  
+  return enr_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* PeerInfo::release_enr() {
+  // @@protoc_insertion_point(field_release:types.PeerInfo.enr)
+  return enr_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void PeerInfo::set_allocated_enr(std::string* enr) {
+  if (enr != nullptr) {
+    
+  } else {
+    
+  }
+  enr_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), enr,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.PeerInfo.enr)
+}
+
+// repeated string caps = 5;
+inline int PeerInfo::_internal_caps_size() const {
+  return caps_.size();
+}
+inline int PeerInfo::caps_size() const {
+  return _internal_caps_size();
+}
+inline void PeerInfo::clear_caps() {
+  caps_.Clear();
+}
+inline std::string* PeerInfo::add_caps() {
+  // @@protoc_insertion_point(field_add_mutable:types.PeerInfo.caps)
+  return _internal_add_caps();
+}
+inline const std::string& PeerInfo::_internal_caps(int index) const {
+  return caps_.Get(index);
+}
+inline const std::string& PeerInfo::caps(int index) const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.caps)
+  return _internal_caps(index);
+}
+inline std::string* PeerInfo::mutable_caps(int index) {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.caps)
+  return caps_.Mutable(index);
+}
+inline void PeerInfo::set_caps(int index, const std::string& value) {
+  // @@protoc_insertion_point(field_set:types.PeerInfo.caps)
+  caps_.Mutable(index)->assign(value);
+}
+inline void PeerInfo::set_caps(int index, std::string&& value) {
+  // @@protoc_insertion_point(field_set:types.PeerInfo.caps)
+  caps_.Mutable(index)->assign(std::move(value));
+}
+inline void PeerInfo::set_caps(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  caps_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.caps)
+}
+inline void PeerInfo::set_caps(int index, const char* value, size_t size) {
+  caps_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.caps)
+}
+inline std::string* PeerInfo::_internal_add_caps() {
+  return caps_.Add();
+}
+inline void PeerInfo::add_caps(const std::string& value) {
+  caps_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:types.PeerInfo.caps)
+}
+inline void PeerInfo::add_caps(std::string&& value) {
+  caps_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:types.PeerInfo.caps)
+}
+inline void PeerInfo::add_caps(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  caps_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:types.PeerInfo.caps)
+}
+inline void PeerInfo::add_caps(const char* value, size_t size) {
+  caps_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:types.PeerInfo.caps)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+PeerInfo::caps() const {
+  // @@protoc_insertion_point(field_list:types.PeerInfo.caps)
+  return caps_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+PeerInfo::mutable_caps() {
+  // @@protoc_insertion_point(field_mutable_list:types.PeerInfo.caps)
+  return &caps_;
+}
+
+// string connLocalAddr = 6;
+inline void PeerInfo::clear_connlocaladdr() {
+  connlocaladdr_.ClearToEmpty();
+}
+inline const std::string& PeerInfo::connlocaladdr() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.connLocalAddr)
+  return _internal_connlocaladdr();
+}
+inline void PeerInfo::set_connlocaladdr(const std::string& value) {
+  _internal_set_connlocaladdr(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.connLocalAddr)
+}
+inline std::string* PeerInfo::mutable_connlocaladdr() {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.connLocalAddr)
+  return _internal_mutable_connlocaladdr();
+}
+inline const std::string& PeerInfo::_internal_connlocaladdr() const {
+  return connlocaladdr_.Get();
+}
+inline void PeerInfo::_internal_set_connlocaladdr(const std::string& value) {
+  
+  connlocaladdr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void PeerInfo::set_connlocaladdr(std::string&& value) {
+  
+  connlocaladdr_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.PeerInfo.connLocalAddr)
+}
+inline void PeerInfo::set_connlocaladdr(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  connlocaladdr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.connLocalAddr)
+}
+inline void PeerInfo::set_connlocaladdr(const char* value,
+    size_t size) {
+  
+  connlocaladdr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.connLocalAddr)
+}
+inline std::string* PeerInfo::_internal_mutable_connlocaladdr() {
+  
+  return connlocaladdr_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* PeerInfo::release_connlocaladdr() {
+  // @@protoc_insertion_point(field_release:types.PeerInfo.connLocalAddr)
+  return connlocaladdr_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void PeerInfo::set_allocated_connlocaladdr(std::string* connlocaladdr) {
+  if (connlocaladdr != nullptr) {
+    
+  } else {
+    
+  }
+  connlocaladdr_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), connlocaladdr,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.PeerInfo.connLocalAddr)
+}
+
+// string connRemoteAddr = 7;
+inline void PeerInfo::clear_connremoteaddr() {
+  connremoteaddr_.ClearToEmpty();
+}
+inline const std::string& PeerInfo::connremoteaddr() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.connRemoteAddr)
+  return _internal_connremoteaddr();
+}
+inline void PeerInfo::set_connremoteaddr(const std::string& value) {
+  _internal_set_connremoteaddr(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.connRemoteAddr)
+}
+inline std::string* PeerInfo::mutable_connremoteaddr() {
+  // @@protoc_insertion_point(field_mutable:types.PeerInfo.connRemoteAddr)
+  return _internal_mutable_connremoteaddr();
+}
+inline const std::string& PeerInfo::_internal_connremoteaddr() const {
+  return connremoteaddr_.Get();
+}
+inline void PeerInfo::_internal_set_connremoteaddr(const std::string& value) {
+  
+  connremoteaddr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void PeerInfo::set_connremoteaddr(std::string&& value) {
+  
+  connremoteaddr_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:types.PeerInfo.connRemoteAddr)
+}
+inline void PeerInfo::set_connremoteaddr(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  connremoteaddr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:types.PeerInfo.connRemoteAddr)
+}
+inline void PeerInfo::set_connremoteaddr(const char* value,
+    size_t size) {
+  
+  connremoteaddr_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:types.PeerInfo.connRemoteAddr)
+}
+inline std::string* PeerInfo::_internal_mutable_connremoteaddr() {
+  
+  return connremoteaddr_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* PeerInfo::release_connremoteaddr() {
+  // @@protoc_insertion_point(field_release:types.PeerInfo.connRemoteAddr)
+  return connremoteaddr_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void PeerInfo::set_allocated_connremoteaddr(std::string* connremoteaddr) {
+  if (connremoteaddr != nullptr) {
+    
+  } else {
+    
+  }
+  connremoteaddr_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), connremoteaddr,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:types.PeerInfo.connRemoteAddr)
+}
+
+// bool connIsInbound = 8;
+inline void PeerInfo::clear_connisinbound() {
+  connisinbound_ = false;
+}
+inline bool PeerInfo::_internal_connisinbound() const {
+  return connisinbound_;
+}
+inline bool PeerInfo::connisinbound() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.connIsInbound)
+  return _internal_connisinbound();
+}
+inline void PeerInfo::_internal_set_connisinbound(bool value) {
+  
+  connisinbound_ = value;
+}
+inline void PeerInfo::set_connisinbound(bool value) {
+  _internal_set_connisinbound(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.connIsInbound)
+}
+
+// bool connIsTrusted = 9;
+inline void PeerInfo::clear_connistrusted() {
+  connistrusted_ = false;
+}
+inline bool PeerInfo::_internal_connistrusted() const {
+  return connistrusted_;
+}
+inline bool PeerInfo::connistrusted() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.connIsTrusted)
+  return _internal_connistrusted();
+}
+inline void PeerInfo::_internal_set_connistrusted(bool value) {
+  
+  connistrusted_ = value;
+}
+inline void PeerInfo::set_connistrusted(bool value) {
+  _internal_set_connistrusted(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.connIsTrusted)
+}
+
+// bool connIsStatic = 10;
+inline void PeerInfo::clear_connisstatic() {
+  connisstatic_ = false;
+}
+inline bool PeerInfo::_internal_connisstatic() const {
+  return connisstatic_;
+}
+inline bool PeerInfo::connisstatic() const {
+  // @@protoc_insertion_point(field_get:types.PeerInfo.connIsStatic)
+  return _internal_connisstatic();
+}
+inline void PeerInfo::_internal_set_connisstatic(bool value) {
+  
+  connisstatic_ = value;
+}
+inline void PeerInfo::set_connisstatic(bool value) {
+  _internal_set_connisstatic(value);
+  // @@protoc_insertion_point(field_set:types.PeerInfo.connIsStatic)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/node/silkworm/downloader/rpc/receive_peer_stats.cpp
+++ b/node/silkworm/downloader/rpc/receive_peer_stats.cpp
@@ -19,7 +19,7 @@
 namespace silkworm::rpc {
 
 ReceivePeerStats::ReceivePeerStats()
-        : OutStreamingCall("ReceivePeerStats", &sentry::Sentry::Stub::Peers, {}) {
+        : OutStreamingCall("ReceivePeerStats", &sentry::Sentry::Stub::PeerEvents, {}) {
 }
 
 }

--- a/node/silkworm/downloader/rpc/receive_peer_stats.hpp
+++ b/node/silkworm/downloader/rpc/receive_peer_stats.hpp
@@ -21,7 +21,7 @@
 
 namespace silkworm::rpc {
 
-class ReceivePeerStats : public rpc::OutStreamingCall<sentry::Sentry, sentry::PeersRequest, sentry::PeersReply> {
+class ReceivePeerStats : public rpc::OutStreamingCall<sentry::Sentry, sentry::PeerEventsRequest, sentry::PeerEvent> {
   public:
     ReceivePeerStats();
 };

--- a/node/silkworm/downloader/sentry_client.cpp
+++ b/node/silkworm/downloader/sentry_client.cpp
@@ -111,11 +111,11 @@ void SentryClient::stats_receiving_loop() {
 
     // receive stats
     while (!is_stopping() && receive_peer_stats.receive_one_reply()) {
-        const sentry::PeersReply& stat = receive_peer_stats.reply();
+        const sentry::PeerEvent& stat = receive_peer_stats.reply();
 
         auto peerId = string_from_H512(stat.peer_id());
         const char* event = "";
-        if (stat.event() == sentry::PeersReply::Connect) {
+        if (stat.event_id() == sentry::PeerEvent::Connect) {
             event = "connected";
             active_peers_++;
         } else {


### PR DESCRIPTION
silkworm was referencing a "stable" interfaces branch.
I believe it should reference master as the purpose of "stable" is to cater the erigon stable (aka erigon1) needs.
It doesn't mean that we should always be on master, but while in development we should try to be as close as possible.

If silkworm is released to production for long-term support, it could have its own notion of stable interfaces (separate from erigon1, perhaps a custom branch).

Note: I need this for sentry to get the latest sentry.proto. Unfortunately I can't update only sentry.proto in isolation.
