### PR TITLE
sentry: --nat and --port options

### DIFF
--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -38,7 +38,10 @@ int sentry_main(int argc, char* argv[]) {
     cli.add_option("--sentry.api.addr", options.api_address, "GRPC API endpoint")
         ->capture_default_str()
         ->check(IPEndPointValidator(/*allow_empty=*/true));
-    cli.add_option("--port", options.port, "Network listening port")
+
+    cli.add_option("--port", options.port)
+        ->description("Network listening port for incoming peers TCP connections and discovery UDP requests")
+        ->check(CLI::Range(1024, 65535))
         ->capture_default_str();
 
     auto nat_option = cli.add_option("--nat", [&options](CLI::results_t results) {

--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -38,6 +38,17 @@ int sentry_main(int argc, char* argv[]) {
     cli.add_option("--sentry.api.addr", options.api_address, "GRPC API endpoint")
         ->capture_default_str()
         ->check(IPEndPointValidator(/*allow_empty=*/true));
+    cli.add_option("--port", options.port, "Network listening port")
+        ->capture_default_str();
+
+    auto nat_option = cli.add_option("--nat", [&options](CLI::results_t results) {
+       return lexical_cast(results[0], options.nat);
+    });
+    nat_option->description("NAT port mapping mechanism (none|extip:<IP>)\n"
+            "- none              no NAT, use a local IP as public\n"
+            "- extip:1.2.3.4     use the given public IP");
+    nat_option->default_str("none");
+
     add_option_num_contexts(cli, options.num_contexts);
     add_option_wait_mode(cli, options.wait_mode);
 

--- a/sentry/sentry/nat_option.cpp
+++ b/sentry/sentry/nat_option.cpp
@@ -25,7 +25,7 @@ bool lexical_cast(const std::string& input, NatOption& value) {
         return true;
     }
     if (boost::algorithm::istarts_with(input, "extip:")) {
-        auto ip_str = input.c_str() + 6;
+        const auto ip_str{&input[6]};
         boost::system::error_code err;
         auto ip = boost::asio::ip::address::from_string(ip_str, err);
         value = {NatMode::kExternalIP, {ip}};

--- a/sentry/sentry/nat_option.cpp
+++ b/sentry/sentry/nat_option.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "nat_option.hpp"
+#include <boost/algorithm/string/predicate.hpp>
 
 namespace silkworm::sentry {
 
@@ -23,7 +24,7 @@ bool lexical_cast(const std::string& input, NatOption& value) {
         value = {};
         return true;
     }
-    if (input.starts_with("extip:")) {
+    if (boost::algorithm::istarts_with(input, "extip:")) {
         std::string ip_str = input.substr(6);
         boost::system::error_code err;
         auto ip = boost::asio::ip::address::from_string(ip_str, err);

--- a/sentry/sentry/nat_option.cpp
+++ b/sentry/sentry/nat_option.cpp
@@ -14,32 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#pragma once
-
-#include <string>
-#include <vector>
-#include <silkworm/rpc/server/wait_strategy.hpp>
-#include "enode_url.hpp"
 #include "nat_option.hpp"
 
 namespace silkworm::sentry {
 
-struct Options {
-    std::string api_address{"127.0.0.1:9091"};
-
-    // RLPx TCP port
-    uint16_t port{30303};
-
-    NatOption nat;
-
-    // initialized in the constructor based on hardware_concurrency
-    uint32_t num_contexts{0};
-
-    silkworm::rpc::WaitMode wait_mode{silkworm::rpc::WaitMode::blocking};
-
-    std::vector<EnodeUrl> static_peers;
-
-    Options();
-};
+bool lexical_cast(const std::string& input, NatOption& value) {
+    if (input == "none") {
+        value = {};
+        return true;
+    }
+    if (input.starts_with("extip:")) {
+        std::string ip_str = input.substr(6);
+        boost::system::error_code err;
+        auto ip = boost::asio::ip::address::from_string(ip_str, err);
+        value = {NatMode::kExternalIP, {ip}};
+        return !err;
+    }
+    return false;
+}
 
 }  // namespace silkworm::sentry

--- a/sentry/sentry/nat_option.cpp
+++ b/sentry/sentry/nat_option.cpp
@@ -25,7 +25,7 @@ bool lexical_cast(const std::string& input, NatOption& value) {
         return true;
     }
     if (boost::algorithm::istarts_with(input, "extip:")) {
-        const auto ip_str{&input[6]};
+        auto ip_str = input.c_str() + 6;
         boost::system::error_code err;
         auto ip = boost::asio::ip::address::from_string(ip_str, err);
         value = {NatMode::kExternalIP, {ip}};

--- a/sentry/sentry/nat_option.cpp
+++ b/sentry/sentry/nat_option.cpp
@@ -25,7 +25,7 @@ bool lexical_cast(const std::string& input, NatOption& value) {
         return true;
     }
     if (boost::algorithm::istarts_with(input, "extip:")) {
-        std::string ip_str = input.substr(6);
+        auto ip_str = input.c_str() + 6;
         boost::system::error_code err;
         auto ip = boost::asio::ip::address::from_string(ip_str, err);
         value = {NatMode::kExternalIP, {ip}};

--- a/sentry/sentry/nat_option.hpp
+++ b/sentry/sentry/nat_option.hpp
@@ -17,29 +17,21 @@ limitations under the License.
 #pragma once
 
 #include <string>
-#include <vector>
-#include <silkworm/rpc/server/wait_strategy.hpp>
-#include "enode_url.hpp"
-#include "nat_option.hpp"
+#include <optional>
+#include <boost/asio/ip/address.hpp>
 
 namespace silkworm::sentry {
 
-struct Options {
-    std::string api_address{"127.0.0.1:9091"};
-
-    // RLPx TCP port
-    uint16_t port{30303};
-
-    NatOption nat;
-
-    // initialized in the constructor based on hardware_concurrency
-    uint32_t num_contexts{0};
-
-    silkworm::rpc::WaitMode wait_mode{silkworm::rpc::WaitMode::blocking};
-
-    std::vector<EnodeUrl> static_peers;
-
-    Options();
+enum class NatMode {
+    kNone,
+    kExternalIP,
 };
 
-}  // namespace silkworm::sentry
+struct NatOption {
+    NatMode mode{NatMode::kNone};
+    std::optional<boost::asio::ip::address> value;
+};
+
+bool lexical_cast(const std::string& input, NatOption& value);
+
+}  // silkworm::sentry


### PR DESCRIPTION
Note: I've tried to use [this example](https://github.com/CLIUtils/CLI11/blob/main/examples/custom_parse.cpp) to parse my custom type. It says:

> the lexical cast operator should be in the same namespace as the type

but this didn't work (it tried using a builtin CLI::detail::lexical_cast instead, and didn't find mine).

So instead I had to manually call this function as [described here](https://github.com/CLIUtils/CLI11/blob/main/book/chapters/advanced-topics.md#custom-option-callbacks).

I wonder if this is because we are not using the latest CLI11 version? (How to find out which version is used?)