### PR TITLE
Fix GCC 12 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,16 +63,16 @@ commands:
           name: "Ethereum consensus tests"
           working_directory: ~/build
           no_output_timeout: 20m
-          command: cmd/test/consensus --threads 4 # out of memory with 8 threads under linux-gcc-11-thread-sanitizer 
+          command: cmd/test/consensus --threads 4 # out of memory with 8 threads under thread sanitizer 
 
 jobs:
-  linux-gcc-11-thread-sanitizer:
+  linux-gcc-12-thread-sanitizer:
     environment:
       BUILD_TYPE: Debug
       CLANG_COVERAGE: OFF
       SANITIZE: thread
     docker:
-      - image: ethereum/cpp-build-env:17-gcc-11
+      - image: ethereum/cpp-build-env:18-gcc-12
     resource_class: xlarge
     steps:
       - checkout_with_submodules
@@ -202,7 +202,7 @@ workflows:
   version: 2
   silkworm:
     jobs:
-      - linux-gcc-11-thread-sanitizer
+      - linux-gcc-12-thread-sanitizer
       - linux-gcc-11
       - linux-clang-13-coverage
       - linux-clang-12-address-sanitizer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,26 +66,39 @@ commands:
           command: cmd/test/consensus --threads 4 # out of memory with 8 threads under thread sanitizer 
 
 jobs:
-  linux-gcc-12-thread-sanitizer:
+  linux-gcc-11-thread-sanitizer:
     environment:
       BUILD_TYPE: Debug
       CLANG_COVERAGE: OFF
       SANITIZE: thread
     docker:
-      - image: ethereum/cpp-build-env:18-gcc-12
+      - image: ethereum/cpp-build-env:17-gcc-11
     resource_class: xlarge
     steps:
       - checkout_with_submodules
       - build
       - test
 
-  linux-gcc-11:
+  linux-gcc-10-debug:
     environment:
       BUILD_TYPE: Debug
       CLANG_COVERAGE: OFF
       SANITIZE: OFF
     docker:
-      - image: ethereum/cpp-build-env:17-gcc-11
+      - image: ethereum/cpp-build-env:17-gcc-10
+    resource_class: xlarge
+    steps:
+      - checkout_with_submodules
+      - build
+      - test
+
+  linux-gcc-12-release:
+    environment:
+      BUILD_TYPE: Release
+      CLANG_COVERAGE: OFF
+      SANITIZE: OFF
+    docker:
+      - image: ethereum/cpp-build-env:18-gcc-12
     resource_class: xlarge
     steps:
       - checkout_with_submodules
@@ -202,8 +215,9 @@ workflows:
   version: 2
   silkworm:
     jobs:
-      - linux-gcc-12-thread-sanitizer
-      - linux-gcc-11
+      - linux-gcc-10-debug
+      - linux-gcc-12-release
+      - linux-gcc-11-thread-sanitizer
       - linux-clang-13-coverage
       - linux-clang-12-address-sanitizer
       - linux-wasm-build

--- a/core/silkworm/chain/genesis.cpp
+++ b/core/silkworm/chain/genesis.cpp
@@ -31,25 +31,19 @@ extern size_t sizeof_genesis_rinkeby_data();
 namespace silkworm {
 
 std::string read_genesis_data(uint64_t chain_id) {
-    std::string ret{};
     switch (chain_id) {
         case 1:
             assert(sizeof_genesis_mainnet_data() != 0);
-            ret.assign(genesis_mainnet_data(), sizeof_genesis_mainnet_data());
-            break;
+            return std::string(genesis_mainnet_data(), sizeof_genesis_mainnet_data());
         case 4:
             assert(sizeof_genesis_rinkeby_data() != 0);
-            ret.assign(genesis_rinkeby_data(), sizeof_genesis_rinkeby_data());
-            break;
+            return std::string(genesis_rinkeby_data(), sizeof_genesis_rinkeby_data());
         case 5:
             assert(sizeof_genesis_goerli_data() != 0);
-            ret.assign(genesis_goerli_data(), sizeof_genesis_goerli_data());
-            break;
+            return std::string(genesis_goerli_data(), sizeof_genesis_goerli_data());
         default:
-            ret = "{";  // <- Won't be lately parsed as valid json value
+            return "{";  // <- Won't be lately parsed as valid json value
     }
-
-    return ret;
 }
 
 }  // namespace silkworm

--- a/core/silkworm/common/util.cpp
+++ b/core/silkworm/common/util.cpp
@@ -242,22 +242,4 @@ size_t prefix_length(ByteView a, ByteView b) {
     return len;
 }
 
-std::vector<std::string> split(std::string_view source, std::string_view delimiter) {
-    std::vector<std::string> res{};
-    if (delimiter.length() >= source.length() || !delimiter.length()) {
-        res.emplace_back(source);
-        return res;
-    }
-    size_t pos{0};
-    while ((pos = source.find(delimiter)) != std::string::npos) {
-        res.emplace_back(source.substr(0, pos));
-        source.remove_prefix(pos + delimiter.length());
-    }
-    // Any residual part of input where delimiter is not found
-    if (source.length()) {
-        res.emplace_back(source);
-    }
-    return res;
-}
-
 }  // namespace silkworm

--- a/core/silkworm/common/util.hpp
+++ b/core/silkworm/common/util.hpp
@@ -79,9 +79,6 @@ size_t prefix_length(ByteView a, ByteView b);
 
 inline ethash::hash256 keccak256(ByteView view) { return ethash::keccak256(view.data(), view.size()); }
 
-// Splits a string by delimiter and returns a vector of tokens
-std::vector<std::string> split(std::string_view source, std::string_view delimiter);
-
 }  // namespace silkworm
 
 #endif  // SILKWORM_COMMON_UTIL_HPP_

--- a/core/silkworm/common/util_test.cpp
+++ b/core/silkworm/common/util_test.cpp
@@ -20,30 +20,6 @@
 
 namespace silkworm {
 
-TEST_CASE("Split") {
-    std::string source{};
-    std::string delim{};
-    auto output{split(source, delim)};
-    CHECK((output.size() == 1 && output.at(0) == source));
-
-    source = "aabbcc";
-    output = split(source, delim);
-    CHECK((output.size() == 1 && output.at(0) == source));
-
-    delim = "b";
-    output = split(source, delim);
-    CHECK((output.size() == 3 && output.at(0) == "aa" && output.at(1).empty() == true && output.at(2) == "cc"));
-
-    delim = "bb";
-    output = split(source, delim);
-    CHECK((output.size() == 2 && output.at(0) == "aa" && output.at(1) == "cc"));
-
-    source = "aaaaa";
-    delim = "a";
-    output = split(source, delim);
-    CHECK(output.size() == 5);
-}
-
 TEST_CASE("Hex") {
     CHECK(decode_hex_digit('g').has_value() == false);
 

--- a/node/silkworm/common/directories.cpp
+++ b/node/silkworm/common/directories.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "directories.hpp"
 
 #include <random>
+
+#include <absl/strings/str_split.h>
 
 #include <silkworm/common/util.hpp>
 
@@ -124,7 +126,7 @@ DataDirectory DataDirectory::from_chaindata(const std::filesystem::path& chainda
     }
 
     std::string delimiter{std::filesystem::path::preferred_separator};
-    auto tokens{silkworm::split(chaindata_path.string(), delimiter)};
+    std::vector<std::string> tokens{absl::StrSplit(chaindata_path.string(), delimiter)};
     if (tokens.empty() || !iequals(tokens.back(), "chaindata")) {
         throw std::invalid_argument("Not a valid Silkworm chaindata path");
     }
@@ -185,9 +187,7 @@ void DataDirectory::deploy() {
     nodes_.create();
 }
 
-std::filesystem::path TemporaryDirectory::get_os_temporary_path() {
-    return std::filesystem::temp_directory_path();
-}
+std::filesystem::path TemporaryDirectory::get_os_temporary_path() { return std::filesystem::temp_directory_path(); }
 
 std::filesystem::path TemporaryDirectory::get_unique_temporary_path(const std::filesystem::path& base_path) {
     if (base_path.empty()) {

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -27,6 +27,7 @@ see its package dbutils.
 #include <string>
 
 #include <absl/container/btree_map.h>
+#include <absl/strings/str_cat.h>
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/db/mdbx.hpp>
@@ -42,12 +43,7 @@ struct VersionBase {
     uint32_t Minor{0};
     uint32_t Patch{0};
 
-    [[nodiscard]] std::string to_string() const {
-        std::string ret{std::to_string(Major)};
-        ret.append("." + std::to_string(Minor));
-        ret.append("." + std::to_string(Patch));
-        return ret;
-    }
+    [[nodiscard]] std::string to_string() const { return absl::StrCat(Major, ".", Minor, ".", Patch); }
 
     friend auto operator<=>(const VersionBase&, const VersionBase&) = default;
 };


### PR DESCRIPTION
Previously Silkworm build was [failing](https://app.circleci.com/pipelines/github/ethereum/evmone/2892/workflows/a7918891-4993-4817-b426-5eaabfc4d255/jobs/24408) with GCC 12, as reported by @chfast. 