### PR TITLE
consteval operator""

### DIFF
--- a/core/silkworm/common/base.hpp
+++ b/core/silkworm/common/base.hpp
@@ -81,10 +81,10 @@ inline constexpr uint64_t kTebi{1024 * kGibi};
 inline constexpr uint64_t kGiga{1'000'000'000};   // = 10^9
 inline constexpr uint64_t kEther{kGiga * kGiga};  // = 10^18
 
-constexpr uint64_t operator"" _Kibi(unsigned long long x) { return x * kKibi; }
-constexpr uint64_t operator"" _Mebi(unsigned long long x) { return x * kMebi; }
-constexpr uint64_t operator"" _Gibi(unsigned long long x) { return x * kGibi; }
-constexpr uint64_t operator"" _Tebi(unsigned long long x) { return x * kTebi; }
+consteval uint64_t operator"" _Kibi(unsigned long long x) { return x * kKibi; }
+consteval uint64_t operator"" _Mebi(unsigned long long x) { return x * kMebi; }
+consteval uint64_t operator"" _Gibi(unsigned long long x) { return x * kGibi; }
+consteval uint64_t operator"" _Tebi(unsigned long long x) { return x * kTebi; }
 
 }  // namespace silkworm
 


### PR DESCRIPTION
[consteval](https://en.cppreference.com/w/cpp/language/consteval) is more restrictive than `constexpr`: it enforces compile-time execution. That's more accurate for user-defined literals since we don't want them to be executed at runtime.