### PR TITLE
UnsignedIntegral concept

### DIFF
--- a/core/silkworm/common/base.hpp
+++ b/core/silkworm/common/base.hpp
@@ -17,18 +17,24 @@
 #ifndef SILKWORM_COMMON_BASE_HPP_
 #define SILKWORM_COMMON_BASE_HPP_
 
-// The most common and basic types and constants.
+// The most common and basic concepts, types, and constants.
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <string_view>
 
 #include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
 
 namespace silkworm {
 
 using namespace evmc::literals;
+
+template <class T>
+concept UnsignedIntegral = std::unsigned_integral<T> || std::same_as<T, intx::uint128> ||
+    std::same_as<T, intx::uint256> || std::same_as<T, intx::uint512>;
 
 using Bytes = std::basic_string<uint8_t>;
 

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -78,15 +78,15 @@ ByteView to_big_compact(uint64_t value);
 ByteView to_big_compact(const intx::uint256& value);
 
 //! \brief Parses unsigned integer from a compacted big endian byte form.
-//! \param [in] data : byte view of compacted value. Length must be <= sizeof(UnsignedInteger);
-//! otherwise kOverflow is returned.
+//! \param [in] data : byte view of a compacted value.
+//! Its length must not be greater than the sizeof the UnsignedIntegral type; otherwise kOverflow is returned.
 //! \param [out] out: the corresponding integer with native endianness.
 //! \return kOk or kOverflow or kLeadingZero.
 //! \remarks A "compact" big endian form strips leftmost bytes valued to zero;
 //! if the input is not compact kLeadingZero is returned.
-template <typename UnsignedInteger>
-static DecodingResult from_big_compact(ByteView data, UnsignedInteger& out) {
-    if (data.length() > sizeof(UnsignedInteger)) {
+template <UnsignedIntegral T>
+static DecodingResult from_big_compact(ByteView data, T& out) {
+    if (data.length() > sizeof(T)) {
         return DecodingResult::kOverflow;
     }
 
@@ -100,7 +100,7 @@ static DecodingResult from_big_compact(ByteView data, UnsignedInteger& out) {
     }
 
     auto* ptr{reinterpret_cast<uint8_t*>(&out)};
-    std::memcpy(ptr + (sizeof(UnsignedInteger) - data.length()), &data[0], data.length());
+    std::memcpy(ptr + (sizeof(T) - data.length()), &data[0], data.length());
 
     out = intx::to_big_endian(out);
     return DecodingResult::kOk;

--- a/core/silkworm/common/endian.hpp
+++ b/core/silkworm/common/endian.hpp
@@ -79,7 +79,7 @@ ByteView to_big_compact(const intx::uint256& value);
 
 //! \brief Parses unsigned integer from a compacted big endian byte form.
 //! \param [in] data : byte view of a compacted value.
-//! Its length must not be greater than the sizeof the UnsignedIntegral type; otherwise kOverflow is returned.
+//! Its length must not be greater than the sizeof the UnsignedIntegral type; otherwise, kOverflow is returned.
 //! \param [out] out: the corresponding integer with native endianness.
 //! \return kOk or kOverflow or kLeadingZero.
 //! \remarks A "compact" big endian form strips leftmost bytes valued to zero;

--- a/core/silkworm/rlp/decode.cpp
+++ b/core/silkworm/rlp/decode.cpp
@@ -121,30 +121,4 @@ DecodingResult decode(ByteView& from, bool& to) noexcept {
     return DecodingResult::kOk;
 }
 
-template <typename UnsignedInteger>
-static DecodingResult decode_integer(ByteView& from, UnsignedInteger& to) noexcept {
-    auto [h, err]{decode_header(from)};
-    if (err != DecodingResult::kOk) {
-        return err;
-    }
-    if (h.list) {
-        return DecodingResult::kUnexpectedList;
-    }
-    err = endian::from_big_compact(from.substr(0, h.payload_length), to);
-    if (err != DecodingResult::kOk) {
-        return err;
-    }
-    from.remove_prefix(h.payload_length);
-    return DecodingResult::kOk;
-}
-
-template <>
-DecodingResult decode(ByteView& from, uint64_t& to) noexcept {
-    return decode_integer<uint64_t>(from, to);
-}
-
-template <>
-DecodingResult decode(ByteView& from, intx::uint256& to) noexcept {
-    return decode_integer<intx::uint256>(from, to);
-}
 }  // namespace silkworm::rlp

--- a/core/silkworm/rlp/decode.hpp
+++ b/core/silkworm/rlp/decode.hpp
@@ -47,14 +47,25 @@ DecodingResult decode(ByteView& from, evmc::bytes32& to) noexcept;
 template <>
 DecodingResult decode(ByteView& from, Bytes& to) noexcept;
 
+template <UnsignedIntegral T>
+DecodingResult decode(ByteView& from, T& to) noexcept {
+    auto [h, err]{decode_header(from)};
+    if (err != DecodingResult::kOk) {
+        return err;
+    }
+    if (h.list) {
+        return DecodingResult::kUnexpectedList;
+    }
+    err = endian::from_big_compact(from.substr(0, h.payload_length), to);
+    if (err != DecodingResult::kOk) {
+        return err;
+    }
+    from.remove_prefix(h.payload_length);
+    return DecodingResult::kOk;
+}
+
 template <>
 DecodingResult decode(ByteView& from, bool& to) noexcept;
-
-template <>
-DecodingResult decode(ByteView& from, uint64_t& to) noexcept;
-
-template <>
-DecodingResult decode(ByteView& from, intx::uint256& to) noexcept;
 
 template <size_t N>
 DecodingResult decode(ByteView& from, std::span<uint8_t, N> to) noexcept {

--- a/core/silkworm/rlp/encode.cpp
+++ b/core/silkworm/rlp/encode.cpp
@@ -38,6 +38,11 @@ size_t length_of_length(uint64_t payload_length) noexcept {
     }
 }
 
+template <>
+void encode(Bytes& to, const bool& x) {
+    to.push_back(x ? uint8_t{1} : kEmptyStringCode);
+}
+
 void encode(Bytes& to, ByteView s) {
     if (s.length() != 1 || s[0] >= kEmptyStringCode) {
         encode_header(to, {false, s.length()});

--- a/core/silkworm/rlp/encode.cpp
+++ b/core/silkworm/rlp/encode.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 #include "encode.hpp"
 
-#include <silkworm/common/endian.hpp>
-
 namespace silkworm::rlp {
 
 void encode_header(Bytes& to, Header header) {
@@ -32,11 +30,11 @@ void encode_header(Bytes& to, Header header) {
     }
 }
 
-size_t length_of_length(uint64_t payload_length) {
+size_t length_of_length(uint64_t payload_length) noexcept {
     if (payload_length < 56) {
         return 1;
     } else {
-        return 1 + 8 - intx::clz(payload_length) / 8;
+        return 1 + intx::count_significant_bytes(payload_length);
     }
 }
 
@@ -47,52 +45,12 @@ void encode(Bytes& to, ByteView s) {
     to.append(s);
 }
 
-size_t length(ByteView s) {
+size_t length(ByteView s) noexcept {
     size_t len{s.length()};
     if (s.length() != 1 || s[0] >= kEmptyStringCode) {
         len += length_of_length(s.length());
     }
     return len;
-}
-
-void encode(Bytes& to, uint64_t n) {
-    if (n == 0) {
-        to.push_back(kEmptyStringCode);
-    } else if (n < kEmptyStringCode) {
-        to.push_back(static_cast<uint8_t>(n));
-    } else {
-        auto be{endian::to_big_compact(n)};
-        to.push_back(static_cast<uint8_t>(kEmptyStringCode + be.length()));
-        to.append(be);
-    }
-}
-
-size_t length(uint64_t n) noexcept {
-    if (n < kEmptyStringCode) {
-        return 1;
-    } else {
-        return 1 + 8 - intx::clz(n) / 8;
-    }
-}
-
-void encode(Bytes& to, const intx::uint256& n) {
-    if (n == 0) {
-        to.push_back(kEmptyStringCode);
-    } else if (n < kEmptyStringCode) {
-        to.push_back(static_cast<uint8_t>(n));
-    } else {
-        auto be{endian::to_big_compact(n)};
-        to.push_back(static_cast<uint8_t>(kEmptyStringCode + be.length()));
-        to.append(be);
-    }
-}
-
-size_t length(const intx::uint256& n) {
-    if (n < kEmptyStringCode) {
-        return 1;
-    } else {
-        return 1 + 32 - intx::clz(n) / 8;
-    }
 }
 
 }  // namespace silkworm::rlp

--- a/core/silkworm/rlp/encode.hpp
+++ b/core/silkworm/rlp/encode.hpp
@@ -55,6 +55,9 @@ void encode(Bytes& to, const T& n) {
     }
 }
 
+template <>
+void encode(Bytes& to, const bool&);
+
 size_t length_of_length(uint64_t payload_length) noexcept;
 
 size_t length(ByteView) noexcept;

--- a/core/silkworm/types/transaction.cpp
+++ b/core/silkworm/types/transaction.cpp
@@ -159,8 +159,8 @@ namespace rlp {
             encode(to, txn.s);
         } else if (txn.chain_id) {
             encode(to, *txn.chain_id);
-            encode(to, 0);
-            encode(to, 0);
+            encode(to, 0u);
+            encode(to, 0u);
         }
     }
 


### PR DESCRIPTION
Introduce `UnsignedIntegral` concept equal to [std::unsigned_integral](https://en.cppreference.com/w/cpp/concepts/unsigned_integral) + [intx::uint](https://github.com/chfast/intx) types.