### PR TITLE
Revert "consteval operator"""

### DIFF
--- a/core/silkworm/common/base.hpp
+++ b/core/silkworm/common/base.hpp
@@ -87,10 +87,10 @@ inline constexpr uint64_t kTebi{1024 * kGibi};
 inline constexpr uint64_t kGiga{1'000'000'000};   // = 10^9
 inline constexpr uint64_t kEther{kGiga * kGiga};  // = 10^18
 
-consteval uint64_t operator"" _Kibi(unsigned long long x) { return x * kKibi; }
-consteval uint64_t operator"" _Mebi(unsigned long long x) { return x * kMebi; }
-consteval uint64_t operator"" _Gibi(unsigned long long x) { return x * kGibi; }
-consteval uint64_t operator"" _Tebi(unsigned long long x) { return x * kTebi; }
+constexpr uint64_t operator"" _Kibi(unsigned long long x) { return x * kKibi; }
+constexpr uint64_t operator"" _Mebi(unsigned long long x) { return x * kMebi; }
+constexpr uint64_t operator"" _Gibi(unsigned long long x) { return x * kGibi; }
+constexpr uint64_t operator"" _Tebi(unsigned long long x) { return x * kTebi; }
 
 }  // namespace silkworm
 


### PR DESCRIPTION
Reverts torquem-ch/silkworm#704

After this PR MSVC does not build anymore due to :

```
error C7595: 'silkworm::operator ""_Tebi': call to immediate function is not a constant expression (compiling source file
```

Reverting