### PR TITLE
Safer human_size

### DIFF
--- a/core/silkworm/common/base.hpp
+++ b/core/silkworm/common/base.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-// The most common and basic concepts, types, and constants.
+// The most common and basic macros, concepts, types, and constants.
 
 #include <concepts>
 #include <cstddef>
@@ -26,6 +26,12 @@
 
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
+
+#if defined(__wasm__)
+#define SILKWORM_THREAD_LOCAL static
+#else
+#define SILKWORM_THREAD_LOCAL thread_local
+#endif
 
 namespace silkworm {
 

--- a/core/silkworm/common/endian.cpp
+++ b/core/silkworm/common/endian.cpp
@@ -18,12 +18,6 @@
 
 #include <silkworm/common/util.hpp>
 
-#if defined(__wasm__)
-#define SILKWORM_THREAD_LOCAL static
-#else
-#define SILKWORM_THREAD_LOCAL thread_local
-#endif
-
 namespace silkworm::endian {
 
 ByteView to_big_compact(const uint64_t value) {

--- a/core/silkworm/common/util.cpp
+++ b/core/silkworm/common/util.cpp
@@ -228,7 +228,7 @@ std::string human_size(uint64_t bytes) {
         }
     }
     static constexpr size_t kBufferSize{64};
-    static char output[kBufferSize];
+    SILKWORM_THREAD_LOCAL char output[kBufferSize];
     std::snprintf(output, kBufferSize, "%.02lf %s", value, suffix[index]);
     return output;
 }

--- a/core/silkworm/common/util.cpp
+++ b/core/silkworm/common/util.cpp
@@ -16,7 +16,7 @@
 
 #include "util.hpp"
 
-#include <cassert>
+#include <cstdio>
 #include <regex>
 
 #include <silkworm/common/as_range.hpp>
@@ -227,8 +227,9 @@ std::string human_size(uint64_t bytes) {
             break;
         }
     }
-    static char output[64];
-    sprintf(output, "%.02lf %s", value, suffix[index]);
+    static constexpr size_t kBufferSize{64};
+    static char output[kBufferSize];
+    std::snprintf(output, kBufferSize, "%.02lf %s", value, suffix[index]);
     return output;
 }
 


### PR DESCRIPTION
`human_size()` was not thread-safe because of the `static` buffer.

Also, Xcode 14 treats [sprintf](https://en.cppreference.com/w/cpp/io/c/fprintf) as deprecated.