### PR TITLE
Fix Xcode 14 build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,9 @@
 # This is the official list of Silkworm authors for copyright purposes.
 
 Andrey Ashikhmin
+Tullio Canepa
 Greg Colvin
 Andrea Lanfranchi
+Daniel Lazarenko
 Giulio Rebuffo
 Michelangelo Riccobene

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -525,7 +525,7 @@ evmc::result EvmHost::call(const evmc_message& message) noexcept {
 
 evmc_tx_context EvmHost::get_tx_context() const noexcept {
     const BlockHeader& header{evm_.block_.header};
-    evmc_tx_context context;
+    evmc_tx_context context{};
     const intx::uint256 base_fee_per_gas{header.base_fee_per_gas.value_or(0)};
     const intx::uint256 effective_gas_price{evm_.txn_->effective_gas_price(base_fee_per_gas)};
     intx::be::store(context.tx_gas_price.bytes, effective_gas_price);

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[[
-   Copyright 2020-2021 The SilkRpc Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -72,10 +72,12 @@ add_custom_command(
     DEPENDS "${SENTRY_PROTO}"
 )
 
+add_custom_target(generate_types_proto DEPENDS "${TYPES_PROTO_SOURCES}" "${TYPES_PROTO_HEADERS}")
+
 add_custom_target(
     generate_sentry_grpc
     DEPENDS "${SENTRY_PROTO_SOURCES}" "${SENTRY_PROTO_HEADERS}" "${SENTRY_GRPC_SOURCES}" "${SENTRY_GRPC_HEADERS}"
-            "${TYPES_PROTO_SOURCES}" "${TYPES_PROTO_HEADERS}"
+            generate_types_proto
 )
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -101,7 +103,7 @@ add_custom_command(
 add_custom_target(
     generate_kv_grpc
     DEPENDS "${KV_PROTO_SOURCES}" "${KV_PROTO_HEADERS}" "${KV_GRPC_SOURCES}" "${KV_GRPC_HEADERS}"
-            "${TYPES_PROTO_SOURCES}" "${TYPES_PROTO_HEADERS}"
+            generate_types_proto
 )
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -127,5 +129,5 @@ add_custom_command(
 add_custom_target(
     generate_ethbackend_grpc
     DEPENDS "${ETHBACKEND_PROTO_SOURCES}" "${ETHBACKEND_PROTO_HEADERS}" "${ETHBACKEND_GRPC_SOURCES}" "${ETHBACKEND_GRPC_HEADERS}"
-            "${TYPES_PROTO_SOURCES}" "${TYPES_PROTO_HEADERS}"
+            generate_types_proto
 )

--- a/node/silkworm/etl/collector_test.cpp
+++ b/node/silkworm/etl/collector_test.cpp
@@ -57,7 +57,7 @@ void run_collector_test(LoadFunc load_func, bool do_copy = true) {
     test::Context context;
 
     // Initialize random seed
-    std::srand(std::time(nullptr));
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
 
     // Generate Test Entries
     auto set{generate_entry_set(1000)};  // 1000 entries in total

--- a/node/silkworm/etl/file_provider.cpp
+++ b/node/silkworm/etl/file_provider.cpp
@@ -49,8 +49,8 @@ void FileProvider::flush(Buffer& buffer) {
     }
 
     for (const auto& entry : entries) {
-        head.lengths[0] = entry.key.size();
-        head.lengths[1] = entry.value.size();
+        head.lengths[0] = static_cast<uint32_t>(entry.key.size());
+        head.lengths[1] = static_cast<uint32_t>(entry.value.size());
         if (!file_.write(byte_ptr_cast(head.bytes), 8) ||
             !file_.write(byte_ptr_cast(entry.key.data()), static_cast<std::streamsize>(entry.key.size())) ||
             !file_.write(byte_ptr_cast(entry.value.data()), static_cast<std::streamsize>(entry.value.size()))) {

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -49,7 +49,7 @@ static void loader_function(const etl::Entry& entry, mdbx::cursor& target_table,
         // make chunk index
         Bytes chunk_index(entry.key.size() + 4, '\0');
         std::memcpy(&chunk_index[0], &entry.key[0], entry.key.size());
-        uint64_t suffix{bm.cardinality() == 0 ? UINT32_MAX : current_chunk.maximum()};
+        const uint32_t suffix{bm.cardinality() == 0 ? UINT32_MAX : current_chunk.maximum()};
         endian::store_big_u32(&chunk_index[entry.key.size()], suffix);
         Bytes current_chunk_bytes(current_chunk.getSizeInBytes(), '\0');
         current_chunk.write(byte_ptr_cast(&current_chunk_bytes[0]));
@@ -97,7 +97,7 @@ StageResult stage_log_index(db::RWTxn& txn, const std::filesystem::path& etl_pat
         // Decode CBOR and distribute it to the 2 bitmaps
         block_number = endian::load_big_u64(static_cast<uint8_t*>(log_data.key.data()));
         current_listener.set_block_number(block_number);
-        cbor::input input(log_data.value.data(), log_data.value.length());
+        cbor::input input(log_data.value.data(), static_cast<int>(log_data.value.length()));
         cbor::decoder decoder(input, current_listener);
         decoder.run();
         // Flushes

--- a/node/silkworm/stagedsync/stage_logindex/listener_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_logindex/listener_log_index.cpp
@@ -1,0 +1,40 @@
+/*
+   Copyright 2021-2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "listener_log_index.hpp"
+
+#include <silkworm/common/cast.hpp>
+
+namespace silkworm::stagedsync {
+
+void listener_log_index::on_bytes(unsigned char* data, int size) {
+    std::string key(byte_ptr_cast(data), static_cast<size_t>(size));
+    if (size == kHashLength) {
+        if (topics_map_->find(key) == topics_map_->end()) {
+            topics_map_->emplace(key, roaring::Roaring());
+        }
+        topics_map_->at(key).add(static_cast<uint32_t>(block_number_));
+        *allocated_topics_ += kHashLength;
+    } else if (size == kAddressLength) {
+        if (addrs_map_->find(key) == addrs_map_->end()) {
+            addrs_map_->emplace(key, roaring::Roaring());
+        }
+        addrs_map_->at(key).add(static_cast<uint32_t>(block_number_));
+        *allocated_addrs_ += kAddressLength;
+    }
+}
+
+}  // namespace silkworm::stagedsync

--- a/node/silkworm/stagedsync/stage_logindex/listener_log_index.hpp
+++ b/node/silkworm/stagedsync/stage_logindex/listener_log_index.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkworm Authors
+   Copyright 2021-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -45,13 +45,13 @@ class listener_log_index : public cbor::listener {
             if (topics_map_->find(key) == topics_map_->end()) {
                 topics_map_->emplace(key, roaring::Roaring());
             }
-            topics_map_->at(key).add(block_number_);
+            topics_map_->at(key).add(static_cast<uint32_t>(block_number_));
             *allocated_topics_ += kHashLength;
         } else if (size == kAddressLength) {
             if (addrs_map_->find(key) == addrs_map_->end()) {
                 addrs_map_->emplace(key, roaring::Roaring());
             }
-            addrs_map_->at(key).add(block_number_);
+            addrs_map_->at(key).add(static_cast<uint32_t>(block_number_));
             *allocated_addrs_ += kAddressLength;
         }
     }

--- a/node/silkworm/stagedsync/stage_logindex/listener_log_index.hpp
+++ b/node/silkworm/stagedsync/stage_logindex/listener_log_index.hpp
@@ -39,22 +39,7 @@ class listener_log_index : public cbor::listener {
 
     void on_integer(int) override {}
 
-    void on_bytes(unsigned char* data, int size) override {
-        std::string key(byte_ptr_cast(data), static_cast<size_t>(size));
-        if (size == kHashLength) {
-            if (topics_map_->find(key) == topics_map_->end()) {
-                topics_map_->emplace(key, roaring::Roaring());
-            }
-            topics_map_->at(key).add(static_cast<uint32_t>(block_number_));
-            *allocated_topics_ += kHashLength;
-        } else if (size == kAddressLength) {
-            if (addrs_map_->find(key) == addrs_map_->end()) {
-                addrs_map_->emplace(key, roaring::Roaring());
-            }
-            addrs_map_->at(key).add(static_cast<uint32_t>(block_number_));
-            *allocated_addrs_ += kAddressLength;
-        }
-    }
+    void on_bytes(unsigned char* data, int size) override;
 
     void on_string(std::string&) override {}
 

--- a/node/silkworm/stagedsync/stage_senders/recovery_farm.cpp
+++ b/node/silkworm/stagedsync/stage_senders/recovery_farm.cpp
@@ -410,7 +410,7 @@ bool RecoveryFarm::initialize_new_worker() {
     log::Trace("Spawning new Recovery worker", {"id", std::to_string(workers_.size())});
     using namespace std::placeholders;
     try {
-        workers_.emplace_back(new RecoveryWorker(workers_.size()));
+        workers_.emplace_back(new RecoveryWorker(static_cast<uint32_t>(workers_.size())));
         workers_connections_.emplace_back(
             workers_.back()->signal_task_completed.connect(std::bind(&RecoveryFarm::task_completed_handler, this, _1)));
         workers_connections_.emplace_back(workers_.back()->signal_worker_stopped.connect(

--- a/node/silkworm/stagedsync/stage_senders/recovery_farm.hpp
+++ b/node/silkworm/stagedsync/stage_senders/recovery_farm.hpp
@@ -119,8 +119,8 @@ class RecoveryFarm : public Stoppable {
 
     /* Canonical blocks + headers */
     struct HeaderInfo {
-        HeaderInfo(uint32_t count, const evmc::bytes32& hash) : txn_count(count), block_hash{hash} {};
-        uint32_t txn_count;
+        HeaderInfo(uint64_t count, const evmc::bytes32& hash) : txn_count(count), block_hash{hash} {};
+        uint64_t txn_count;
         evmc::bytes32 block_hash;
     };
     std::vector<HeaderInfo> headers_{};               // Collected canonical headers

--- a/node/silkworm/types/log_cbor.cpp
+++ b/node/silkworm/types/log_cbor.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2021 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ Bytes cbor_encode(const std::vector<Log>& v) {
         for (const evmc::bytes32& t : l.topics) {
             encoder.write_bytes(t.bytes, kHashLength);
         }
-        encoder.write_bytes(l.data.data(), l.data.size());
+        encoder.write_bytes(l.data.data(), static_cast<unsigned>(l.data.size()));
     }
 
     return Bytes{output.data(), output.size()};


### PR DESCRIPTION
Prior to this change `cmake -G Xcode ..` was failing with
```
CMake Error in interfaces/CMakeLists.txt:
  The custom command generating

    /Users/andrew/silkworm/interfaces/types/types.pb.cc

  is attached to multiple targets:

    generate_sentry_grpc
    generate_kv_grpc
    generate_ethbackend_grpc

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```

When that was fixed, Xcode 14 complained about some conversions.