### PR TITLE
Re-enable Windows buildability

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -2,7 +2,7 @@
   "configurations": [
     {
       "name": "x64-Debug",
-      "generator": "Visual Studio 16 2019 Win64",
+      "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\silkworm\\build\\${name}",
@@ -14,7 +14,7 @@
     },
     {
       "name": "x64-Release",
-      "generator": "Visual Studio 16 2019 Win64",
+      "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Release",
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\silkworm\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\silkworm\\install\\${name}",

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -15,14 +15,6 @@
 ]]
 
 hunter_config(
-  abseil
-  VERSION 20220623.0
-  URL https://github.com/abseil/abseil-cpp/archive/20220623.0.tar.gz
-  SHA1 144c2108e1532c642cdb6ca532ee26e91146cf28
-  CMAKE_ARGS ABSL_PROPAGATE_CXX_STD=ON
-)
-
-hunter_config(
   Microsoft.GSL
   VERSION 4.0.0
   URL https://github.com/microsoft/GSL/archive/v4.0.0.tar.gz

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -14,6 +14,16 @@
    limitations under the License.
 ]]
 
+include(hunter_cmake_args)
+
+hunter_cmake_args(
+  abseil
+  CMAKE_ARGS
+        ABSL_PROPAGATE_CXX_STD=ON
+        ABSL_ENABLE_INSTALL=OFF
+        ABSL_RUN_TESTS=OFF
+)
+
 hunter_config(
   Microsoft.GSL
   VERSION 4.0.0

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -30,8 +30,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   add_compile_definitions(_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
   add_compile_definitions(_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING)
 
-  add_compile_options(/MP)     # Enable parallel compilation
-  add_compile_options(/EHa)    # Enable standard C++ unwinding
+  add_compile_options(/MP)            # Enable parallel compilation
+  add_compile_options(/EHa)           # Enable standard C++ unwinding
+  add_compile_options(/await:strict)  # Enable coroutine support in std namespace
 
   #[[
   There is an issue on CLion IDE when toolchain is MSVC. Basically it wrongly parses file(line,column) which

--- a/core/silkworm/common/base.hpp
+++ b/core/silkworm/common/base.hpp
@@ -39,7 +39,7 @@ using namespace evmc::literals;
 
 template <class T>
 concept UnsignedIntegral = std::unsigned_integral<T> || std::same_as<T, intx::uint128> ||
-    std::same_as<T, intx::uint256> || std::same_as<T, intx::uint512>;
+                           std::same_as<T, intx::uint256> || std::same_as<T, intx::uint512>;
 
 using Bytes = std::basic_string<uint8_t>;
 

--- a/node/silkworm/concurrency/coroutine.hpp
+++ b/node/silkworm/concurrency/coroutine.hpp
@@ -1,17 +1,17 @@
 /*
-Copyright 2020-2022 The Silkworm Authors
+   Copyright 2022 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #pragma once

--- a/sentry/silkworm/sentry/common/random.cpp
+++ b/sentry/silkworm/sentry/common/random.cpp
@@ -15,17 +15,19 @@ limitations under the License.
 */
 
 #include "random.hpp"
+
 #include <random>
 
 namespace silkworm::sentry::common {
 
 Bytes random_bytes(Bytes::size_type size) {
     std::default_random_engine random_engine{std::random_device{}()};
-    std::uniform_int_distribution<uint8_t> random_distribution;
+    std::uniform_int_distribution<uint16_t> random_distribution{0, UINT8_MAX};
 
     Bytes data(size, 0);
-    for (auto& d : data)
+    for (auto& d : data) {
         d = random_distribution(random_engine);
+    }
     return data;
 }
 

--- a/sentry/silkworm/sentry/common/random.cpp
+++ b/sentry/silkworm/sentry/common/random.cpp
@@ -1,18 +1,19 @@
 /*
-Copyright 2020-2022 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
+
 
 #include "random.hpp"
 

--- a/sentry/silkworm/sentry/common/random.hpp
+++ b/sentry/silkworm/sentry/common/random.hpp
@@ -1,17 +1,17 @@
 /*
-Copyright 2020-2022 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #pragma once

--- a/sentry/silkworm/sentry/rlpx/server.cpp
+++ b/sentry/silkworm/sentry/rlpx/server.cpp
@@ -16,9 +16,6 @@
 
 #include "server.hpp"
 
-#include <memory>
-#include <utility>
-
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/use_awaitable.hpp>
 

--- a/sentry/silkworm/sentry/rlpx/server.cpp
+++ b/sentry/silkworm/sentry/rlpx/server.cpp
@@ -17,13 +17,10 @@
 #include "server.hpp"
 
 #include <memory>
-#include <string>
 #include <utility>
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/use_awaitable.hpp>
-
-#include <silkworm/common/log.hpp>
 
 namespace silkworm::sentry::rlpx {
 

--- a/sentry/silkworm/sentry/rlpx/server.cpp
+++ b/sentry/silkworm/sentry/rlpx/server.cpp
@@ -1,21 +1,22 @@
 /*
-Copyright 2020-2022 The Silkworm Authors
+   Copyright 2020-2022 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #include "server.hpp"
 
+#include <coroutine>
 #include <memory>
 #include <string>
 #include <utility>
@@ -29,8 +30,7 @@ namespace silkworm::sentry::rlpx {
 
 using namespace boost::asio;
 
-Server::Server(std::string host, uint16_t port) : host_(std::move(host)), port_(port) {
-}
+Server::Server(std::string host, uint16_t port) : host_(std::move(host)), port_(port) {}
 
 awaitable<void> Server::start(io_context& io_context) {
     ip::tcp::resolver resolver{io_context};

--- a/sentry/silkworm/sentry/rlpx/server.cpp
+++ b/sentry/silkworm/sentry/rlpx/server.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020-2022 The Silkworm Authors
+   Copyright 2022 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 #include "server.hpp"
 
-#include <coroutine>
 #include <memory>
 #include <string>
 #include <utility>

--- a/sentry/silkworm/sentry/rlpx/server.cpp
+++ b/sentry/silkworm/sentry/rlpx/server.cpp
@@ -38,7 +38,15 @@ awaitable<void> Server::start(io_context& io_context) {
 
     ip::tcp::acceptor acceptor{io_context, endpoint.protocol()};
     acceptor.set_option(ip::tcp::acceptor::reuse_address(true));
+
+#if defined(_WIN32)
+    // Windows does not have SO_REUSEPORT
+    // see portability notes https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ
+    acceptor.set_option(detail::socket_option::boolean<SOL_SOCKET, SO_EXCLUSIVEADDRUSE>(true));
+#else
     acceptor.set_option(detail::socket_option::boolean<SOL_SOCKET, SO_REUSEPORT>(true));
+#endif
+
     acceptor.bind(endpoint);
     acceptor.listen();
 

--- a/sentry/silkworm/sentry/rlpx/server.hpp
+++ b/sentry/silkworm/sentry/rlpx/server.hpp
@@ -1,17 +1,17 @@
 /*
-Copyright 2020-2022 The Silkworm Authors
+   Copyright 2022 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #pragma once


### PR DESCRIPTION
Small set of changes needed to restore Windows buildability.

Note for Clion users: as of latest Clion release up to 2022.08.05 [there are issues with Intellisense decting `awaitable` class template from Boost](https://youtrack.jetbrains.com/issue/CPP-28338). Nevertheless CLion can build using MSVC toolchain and tests ok.

Visual Studio 2019 have other issues : IDE properly detects `awaitable` class template but other intellisense errors appear
```
Severity	Code	Description	Project	File	Line	Suppression State
Error (active)	E0135	namespace "std" has no member "coroutine_handle"	silkworm_sentry.lib (sentry\Release\silkworm_sentry.lib) - x64-Release	C:\.hunter\_Base\10738b5\8e1c0b3\c8087bd\Install\include\boost\asio\awaitable.hpp	37	
Error (active)	E0135	namespace "std" has no member "suspend_always"	silkworm_sentry.lib (sentry\Release\silkworm_sentry.lib) - x64-Release	C:\.hunter\_Base\10738b5\8e1c0b3\c8087bd\Install\include\boost\asio\awaitable.hpp	38	
Error (active)	E0840	a template argument list is not allowed in a declaration of a primary template	silkworm_sentry.lib (sentry\Release\silkworm_sentry.lib) - x64-Release	C:\.hunter\_Base\10738b5\8e1c0b3\c8087bd\Install\include\boost\asio\impl\awaitable.hpp	738	
Error (active)	E2674	class template "std::coroutine_traits" not found	silkworm_sentry.lib (sentry\Release\silkworm_sentry.lib) - x64-Release	D:\GitHub\silkworm\sentry\silkworm\sentry\rlpx\server.cpp	28	
Error (active)	E0135	class "boost::asio::awaitable<std::remove_reference_t<boost::asio::ip::basic_resolver_results<boost::asio::ip::tcp>>, boost::asio::any_io_executor>" has no member "cbegin"	silkworm_sentry.lib (sentry\Release\silkworm_sentry.lib) - x64-Release	D:\GitHub\silkworm\sentry\silkworm\sentry\rlpx\server.cpp	31	
```

However, once again, build with VS2019 gets completed correctly and tests ok

Marking this PR as draft as I'm upgrading to VS2022 to see if IDE errors do persist

UPDATE : Even VS 2022 has same problem. Nevertheless is only an issue with IDE visualization and does not prevent correct build. Good news of the upgrade is it [solved this CLion issue](https://youtrack.jetbrains.com/issue/CPP-29533/MSVC-toolchain-cant-build-huntered-OpenSSL-as-dep-of-gRPC-whilest-Visual-Studio-can) @mriccobene 

Ready for review