### PR TITLE
Downloader - Give different names to two different states

### DIFF
--- a/node/silkworm/downloader/internals/chain_integration_test.cpp
+++ b/node/silkworm/downloader/internals/chain_integration_test.cpp
@@ -143,7 +143,7 @@ TEST_CASE("working/persistent-chain integration test") {
         REQUIRE(header1b_in_db.has_value());
         REQUIRE(header1b_in_db == header1b);
 
-        pc.close();  // here pc update the canonical chain on the db
+        pc.finish();  // here pc update the canonical chain on the db
 
         REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
         REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);
@@ -256,7 +256,7 @@ TEST_CASE("working/persistent-chain integration test") {
         REQUIRE(header2_in_db == header2);
 
         // updating the canonical chain on the db
-        pc.close();
+        pc.finish();
 
         REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
         REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);
@@ -372,7 +372,7 @@ TEST_CASE("working/persistent-chain integration test") {
         REQUIRE(header2_in_db == header2);
 
         // updating the canonical chain on the db
-        pc.close();
+        pc.finish();
 
         REQUIRE(db::read_canonical_hash(tx, 1) == header1b_hash);
         REQUIRE(db::read_canonical_hash(tx, 2).has_value() == false);
@@ -484,7 +484,7 @@ TEST_CASE("working/persistent-chain integration test") {
         REQUIRE(header1b_in_db == header1b);
 
         // updating the canonical chain on the db
-        pc.close();
+        pc.finish();
 
         REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
         REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);

--- a/node/silkworm/downloader/internals/db_utils.cpp
+++ b/node/silkworm/downloader/internals/db_utils.cpp
@@ -74,7 +74,7 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(mdbx::txn& txn, const std::set
             max_block_num = endian::load_big_u64(block_num.data());
         }
 
-        return true;  // = continue loop
+        return true;  // = continue loop - todo: check if we really need to parse all the table
     };
 
     db::cursor_for_each(td_cursor, find_max, db::CursorMoveDirection::Reverse);

--- a/node/silkworm/downloader/internals/header_persistence.cpp
+++ b/node/silkworm/downloader/internals/header_persistence.cpp
@@ -31,8 +31,8 @@ HeaderPersistence::HeaderPersistence(db::RWTxn& tx) : tx_(tx), canonical_cache_(
     if (!headers_head_hash) {
         update_canonical_chain(headers_height, *db::read_head_header_hash(tx));
         repaired_ = true;
-        return;
-    }
+        return; // todo: remove this return so that the instance will be fully initialised
+    }           // so that we are not forced to check this state in every method, and we can use it even when repaired
 
     std::optional<BigInt> headers_head_td = db::read_total_difficulty(tx, headers_height, *headers_head_hash);
     if (!headers_head_td)

--- a/node/silkworm/downloader/internals/header_persistence.cpp
+++ b/node/silkworm/downloader/internals/header_persistence.cpp
@@ -97,8 +97,8 @@ void HeaderPersistence::persist(const BlockHeader& header) {  // try to modulari
     }
     auto parent = db::read_header(tx_, height - 1, header.parent_hash);
     if (!parent) {
-        std::string error_message = "HeaderPersistence: could not find parent with hash " + to_hex(header.parent_hash)
-                                    + " and height " + std::to_string(height - 1) + " for header " + hash.to_hex();
+        std::string error_message = "HeaderPersistence: could not find parent with hash " + to_hex(header.parent_hash) +
+                                    " and height " + std::to_string(height - 1) + " for header " + hash.to_hex();
         log::Error() << error_message;
         throw std::logic_error(error_message);
     }

--- a/node/silkworm/downloader/internals/header_persistence.cpp
+++ b/node/silkworm/downloader/internals/header_persistence.cpp
@@ -27,14 +27,13 @@ namespace silkworm {
 
 HeaderPersistence::HeaderPersistence(db::RWTxn& tx) : tx_(tx), canonical_cache_(kCanonicalCacheSize) {
     BlockNum headers_height = db::stages::read_stage_progress(tx, db::stages::kHeadersKey);
-    auto headers_head_hash = db::read_canonical_hash(tx, headers_height);
-    if (!headers_head_hash) {
+    auto head_header_hash = db::read_canonical_hash(tx, headers_height);
+    if (!head_header_hash) {
         update_canonical_chain(headers_height, *db::read_head_header_hash(tx));
         repaired_ = true;
-        return; // todo: remove this return so that the instance will be fully initialised
-    }           // so that we are not forced to check this state in every method, and we can use it even when repaired
+    }
 
-    std::optional<BigInt> headers_head_td = db::read_total_difficulty(tx, headers_height, *headers_head_hash);
+    std::optional<BigInt> headers_head_td = db::read_total_difficulty(tx, headers_height, *head_header_hash);
     if (!headers_head_td)
         throw std::logic_error("total difficulty of canonical hash at height " + std::to_string(headers_height) +
                                " not found in db");
@@ -49,7 +48,7 @@ bool HeaderPersistence::best_header_changed() const { return new_canonical_; }
 
 bool HeaderPersistence::unwind_needed() const { return unwind_needed_; }
 
-bool HeaderPersistence::repaired() const { return repaired_; }
+bool HeaderPersistence::canonical_repaired() const { return repaired_; }
 
 BlockNum HeaderPersistence::initial_height() const { return initial_in_db_; }
 
@@ -79,7 +78,13 @@ void HeaderPersistence::persist(const Headers& headers) {
                  << " (duration=" << measure_curr_scope.format(end_time - start_time) << ")";  // only for test
 }
 
-void HeaderPersistence::persist(const BlockHeader& header) {  // todo: try to modularize
+void HeaderPersistence::persist(const BlockHeader& header) {  // try to modularize this method
+    if (finished_) {
+        std::string error_message = "HeaderPersistence: persist method called on instance in 'finished' state";
+        log::Error() << error_message;
+        throw std::logic_error(error_message);
+    }
+
     // Admittance conditions
     auto height = header.number;
     Hash hash = header.hash();
@@ -92,8 +97,8 @@ void HeaderPersistence::persist(const BlockHeader& header) {  // todo: try to mo
     }
     auto parent = db::read_header(tx_, height - 1, header.parent_hash);
     if (!parent) {
-        std::string error_message = "HeaderPersistence: could not find parent with hash " + to_hex(header.parent_hash) + " and height " +
-                                    std::to_string(height - 1) + " for header " + hash.to_hex();
+        std::string error_message = "HeaderPersistence: could not find parent with hash " + to_hex(header.parent_hash)
+                                    + " and height " + std::to_string(height - 1) + " for header " + hash.to_hex();
         log::Error() << error_message;
         throw std::logic_error(error_message);
     }
@@ -215,8 +220,8 @@ void HeaderPersistence::update_canonical_chain(BlockNum height, Hash hash) {  //
     }
 }
 
-void HeaderPersistence::close() {
-    if (closed_) return;
+void HeaderPersistence::finish() {
+    if (finished_) return;
 
     if (unwind_needed()) return;
 
@@ -224,7 +229,7 @@ void HeaderPersistence::close() {
         update_canonical_chain(highest_height(), highest_hash());
     }
 
-    closed_ = true;
+    finished_ = true;
 }
 
 std::set<Hash> HeaderPersistence::remove_headers(BlockNum unwind_point, std::optional<Hash> bad_block,

--- a/node/silkworm/downloader/internals/header_persistence.cpp
+++ b/node/silkworm/downloader/internals/header_persistence.cpp
@@ -30,7 +30,7 @@ HeaderPersistence::HeaderPersistence(db::RWTxn& tx) : tx_(tx), canonical_cache_(
     auto headers_head_hash = db::read_canonical_hash(tx, headers_height);
     if (!headers_head_hash) {
         update_canonical_chain(headers_height, *db::read_head_header_hash(tx));
-        unwind_needed_ = true;
+        repaired_ = true;
         return;
     }
 
@@ -48,6 +48,8 @@ HeaderPersistence::HeaderPersistence(db::RWTxn& tx) : tx_(tx), canonical_cache_(
 bool HeaderPersistence::best_header_changed() const { return new_canonical_; }
 
 bool HeaderPersistence::unwind_needed() const { return unwind_needed_; }
+
+bool HeaderPersistence::repaired() const { return repaired_; }
 
 BlockNum HeaderPersistence::initial_height() const { return initial_in_db_; }
 

--- a/node/silkworm/downloader/internals/header_persistence.hpp
+++ b/node/silkworm/downloader/internals/header_persistence.hpp
@@ -53,6 +53,7 @@ class HeaderPersistence {
 
     bool best_header_changed() const;
     bool unwind_needed() const;
+    bool repaired() const;
 
     BlockNum unwind_point() const;
     BlockNum initial_height() const;
@@ -76,6 +77,7 @@ class HeaderPersistence {
     BlockNum unwind_point_{};
     bool unwind_needed_{false};
     bool new_canonical_{false};
+    bool repaired_{false};
     lru_cache<BlockNum, Hash> canonical_cache_;
     bool closed_{false};
 };

--- a/node/silkworm/downloader/internals/header_persistence.hpp
+++ b/node/silkworm/downloader/internals/header_persistence.hpp
@@ -46,14 +46,14 @@ class HeaderPersistence {
 
     void persist(const Headers&);
     void persist(const BlockHeader&);
-    void close();
+    void finish();
 
     static std::set<Hash> remove_headers(BlockNum new_height, std::optional<Hash> bad_block,
                                          std::optional<BlockNum>& new_max_block_num, db::RWTxn& tx);
 
     bool best_header_changed() const;
     bool unwind_needed() const;
-    bool repaired() const;
+    bool canonical_repaired() const;
 
     BlockNum unwind_point() const;
     BlockNum initial_height() const;
@@ -79,7 +79,7 @@ class HeaderPersistence {
     bool new_canonical_{false};
     bool repaired_{false};
     lru_cache<BlockNum, Hash> canonical_cache_;
-    bool closed_{false};
+    bool finished_{false};
 };
 
 }  // namespace silkworm

--- a/node/silkworm/downloader/internals/header_persistence_test.cpp
+++ b/node/silkworm/downloader/internals/header_persistence_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE("header persistence", "[silkworm][downloader][HeaderPersistence]") {
         REQUIRE(header1_in_db.has_value());
         REQUIRE(header1_in_db == header1);
 
-        pc.close();  // here pc update the canonical chain on the db
+        pc.finish();  // here pc update the canonical chain on the db
 
         REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
     }
@@ -150,7 +150,7 @@ TEST_CASE("header persistence", "[silkworm][downloader][HeaderPersistence]") {
         REQUIRE(header1b_in_db.has_value());
         REQUIRE(header1b_in_db == header1b);
 
-        pc.close();  // here pc update the canonical chain on the db
+        pc.finish();  // here pc update the canonical chain on the db
 
         REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
         REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);

--- a/node/silkworm/downloader/stage_headers.cpp
+++ b/node/silkworm/downloader/stage_headers.cpp
@@ -50,7 +50,7 @@ auto HeadersStage::forward(db::RWTxn& tx) -> Stage::Result {
     try {
         HeaderPersistence header_persistence(tx);
 
-        if (header_persistence.repaired()) {
+        if (header_persistence.canonical_repaired()) {
             tx.commit();
             log::Info() << "[1/16 Headers] End (forward skipped due to the need of to complete the previous run, canonical chain updated), "
                         << "duration=" << timing.format(timing.lap_duration());
@@ -135,7 +135,7 @@ auto HeadersStage::forward(db::RWTxn& tx) -> Stage::Result {
                     << " duration=" << StopWatch::format(timing.lap_duration());
 
         log::Info() << "[1/16 Headers] Updating canonical chain";
-        header_persistence.close();
+        header_persistence.finish();
 
         tx.commit();  // this will commit or not depending on the creator of txn
 

--- a/node/silkworm/downloader/stage_headers.cpp
+++ b/node/silkworm/downloader/stage_headers.cpp
@@ -50,9 +50,9 @@ auto HeadersStage::forward(db::RWTxn& tx) -> Stage::Result {
     try {
         HeaderPersistence header_persistence(tx);
 
-        if (header_persistence.unwind_needed()) {
+        if (header_persistence.repaired()) {
             tx.commit();
-            log::Info() << "[1/16 Headers] End (forward skipped due to unwind_needed detection, canonical chain updated), "
+            log::Info() << "[1/16 Headers] End (forward skipped due to the need of to complete the previous run, canonical chain updated), "
                         << "duration=" << timing.format(timing.lap_duration());
             return Stage::Result::Done;
         }


### PR DESCRIPTION
Now HeaderPersistence class gives different names to two different conditions.

The state "repaired" occurs when the previous "forward" run inserted new headers in the database but was unable to update the canonical chain due to an unwind condition detection. A subsequent "unwind" method execution reverted the canonical chain to the forking point. But the inserted headers are still there so the canonical chain has to be updated. HeaderPersistence detects this condition in the following forward execution and updates the canonical chain. 

