### PR TITLE
Update evmone to v0.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ add_library(evmone third_party/evmone/lib/evmone/advanced_analysis.cpp
                    third_party/evmone/lib/evmone/tracing.hpp
                    third_party/evmone/lib/evmone/vm.cpp
                    third_party/evmone/lib/evmone/vm.hpp)
-set_source_files_properties(third_party/evmone/lib/evmone/vm.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="0.9.0-dev")
+set_source_files_properties(third_party/evmone/lib/evmone/vm.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="0.9.0")
 target_include_directories(evmone PUBLIC third_party/evmone/include third_party/evmone/lib)
 target_link_libraries(evmone PUBLIC evmc intx::intx PRIVATE evmc::instructions)
 


### PR DESCRIPTION
Update evmone to the final [v0.9.0](https://github.com/ethereum/evmone/releases/tag/v0.9.0).