### PR TITLE
Downloader printable peer-id

### DIFF
--- a/core/silkworm/common/util.hpp
+++ b/core/silkworm/common/util.hpp
@@ -82,19 +82,4 @@ size_t prefix_length(ByteView a, ByteView b);
 
 inline ethash::hash256 keccak256(ByteView view) { return ethash::keccak256(view.data(), view.size()); }
 
-inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& bytes) {
-    out << silkworm::to_hex(bytes);
-    return out;
-}
-
-inline std::ostream& operator<<(std::ostream& out, const evmc::address& addr) {
-    out << silkworm::to_hex(addr);
-    return out;
-}
-
-inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
-    out << silkworm::to_hex(b32);
-    return out;
-}
-
 }  // namespace silkworm

--- a/core/silkworm/common/util.hpp
+++ b/core/silkworm/common/util.hpp
@@ -82,4 +82,19 @@ size_t prefix_length(ByteView a, ByteView b);
 
 inline ethash::hash256 keccak256(ByteView view) { return ethash::keccak256(view.data(), view.size()); }
 
+inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& bytes) {
+    out << silkworm::to_hex(bytes);
+    return out;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const evmc::address& addr) {
+    out << silkworm::to_hex(addr);
+    return out;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
+    out << silkworm::to_hex(b32);
+    return out;
+}
+
 }  // namespace silkworm

--- a/node/silkworm/downloader/block_exchange.cpp
+++ b/node/silkworm/downloader/block_exchange.cpp
@@ -57,8 +57,8 @@ void BlockExchange::receive_message(const sentry::InboundMessage& raw_message) {
 
         messages_.push(message);
     } catch (rlp::DecodingError& error) {
-        PeerId peer_id = string_from_H512(raw_message.peer_id());
-        log::Warning() << "BlockExchange received and ignored a malformed message, peer= " << peer_id
+        PeerId peer_id = bytes_from_H512(raw_message.peer_id());
+        log::Warning() << "BlockExchange received and ignored a malformed message, peer= " << human_readable_id(peer_id)
                        << ", msg-id= " << raw_message.id() << "/" << sentry::MessageId_Name(raw_message.id())
                        << " - " << error.what();
         send_penalization(peer_id, BadBlockPenalty);

--- a/node/silkworm/downloader/internals/body_sequence_test.cpp
+++ b/node/silkworm/downloader/internals/body_sequence_test.cpp
@@ -21,8 +21,8 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/chain/genesis.hpp>
-#include <silkworm/common/test_context.hpp>
 #include <silkworm/common/cast.hpp>
+#include <silkworm/common/test_context.hpp>
 #include <silkworm/db/genesis.hpp>
 
 namespace silkworm {

--- a/node/silkworm/downloader/internals/body_sequence_test.cpp
+++ b/node/silkworm/downloader/internals/body_sequence_test.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/chain/genesis.hpp>
 #include <silkworm/common/test_context.hpp>
+#include <silkworm/common/cast.hpp>
 #include <silkworm/db/genesis.hpp>
 
 namespace silkworm {
@@ -139,7 +140,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
         REQUIRE(bs.lowest_block_in_memory() == 1);
 
         // accepting
-        PeerId peer_id{"1"};
+        PeerId peer_id{byte_ptr_cast("1")};
         BlockBodiesPacket66 response_packet;
         response_packet.requestId = packet.requestId;
         response_packet.request.push_back(block1);
@@ -212,7 +213,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
         block1tampered.transactions[0].gas_limit = 90'000;
         block1tampered.transactions[0].to = 0xe5ef458d37212a06e3f59d40c454e76150ae7c32_address;
 
-        PeerId peer_id{"1"};
+        PeerId peer_id{byte_ptr_cast("1")};
         BlockBodiesPacket66 response_packet;
         response_packet.requestId = packet.requestId;       // correct request-id
         response_packet.request.push_back(block1tampered);  // wrong body
@@ -245,7 +246,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
         REQUIRE(request_status.block_height == 1);
 
         // accepting
-        PeerId peer_id{"1"};
+        PeerId peer_id{byte_ptr_cast("1")};
         BlockBodiesPacket66 response_packet;
         response_packet.requestId = packet.requestId;
         response_packet.request.push_back(block1);
@@ -283,7 +284,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
         // in real life the request can become stale and can be renewed
         // but if the peer is slow we will get a response to the old request
 
-        PeerId peer_id{"1"};
+        PeerId peer_id{byte_ptr_cast("1")};
         BlockBodiesPacket66 response_packet;
         response_packet.requestId = packet.requestId - 1;  // simulate response to prev request
         response_packet.request.push_back(block1);
@@ -436,7 +437,7 @@ TEST_CASE("body downloading", "[silkworm][downloader][BodySequence]") {
         REQUIRE(bs.announced_blocks_.size() == 0);
 
         // accepting announcement
-        PeerId peer_id{"1"};
+        PeerId peer_id{byte_ptr_cast("1")};
         bs.accept_new_block(block1, peer_id);
         REQUIRE(bs.announced_blocks_.size() == 1);
 

--- a/node/silkworm/downloader/internals/chain_elements_test.cpp
+++ b/node/silkworm/downloader/internals/chain_elements_test.cpp
@@ -18,12 +18,14 @@
 
 #include <algorithm>
 
+#include <silkworm/common/cast.hpp>
+
 #include <catch2/catch.hpp>
 
 namespace silkworm {
 
 TEST_CASE("links") {
-    PeerId peer_id{"dummy"};
+    PeerId peer_id{byte_ptr_cast("dummy")};
     bool persisted = false;
 
     std::array<BlockHeader, 5> headers;
@@ -82,7 +84,7 @@ TEST_CASE("links") {
 }
 
 TEST_CASE("anchors") {
-    PeerId peer_id{"dummy"};
+    PeerId peer_id{byte_ptr_cast("dummy")};
     bool persisted = false;
 
     std::array<BlockHeader, 5> headers;

--- a/node/silkworm/downloader/internals/chain_elements_test.cpp
+++ b/node/silkworm/downloader/internals/chain_elements_test.cpp
@@ -18,9 +18,9 @@
 
 #include <algorithm>
 
-#include <silkworm/common/cast.hpp>
-
 #include <catch2/catch.hpp>
+
+#include <silkworm/common/cast.hpp>
 
 namespace silkworm {
 

--- a/node/silkworm/downloader/internals/chain_integration_test.cpp
+++ b/node/silkworm/downloader/internals/chain_integration_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers = {header1, header2, header1b};
-        PeerId peer_id = "1";
+        PeerId peer_id{byte_ptr_cast("1")};
         wc.accept_headers(headers, request_id, peer_id);
 
         // saving headers ready to persist as the header downloader does in the forward() method
@@ -188,7 +188,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers = {header1, header2};
-        PeerId peer_id = "1";
+        PeerId peer_id{byte_ptr_cast("1")};
         wc.accept_headers(headers, request_id, peer_id);
 
         // creating the persisted chain as the header downloader does at the beginning of the forward() method
@@ -227,7 +227,7 @@ TEST_CASE("working/persistent-chain integration test") {
         auto header1b_hash = header1b.hash();
 
         std::vector<BlockHeader> headers_bis = {header1b};
-        peer_id = "2";
+        peer_id = byte_ptr_cast("2");
         wc.accept_headers(headers_bis, request_id, peer_id);
 
         // saving headers ready to persist as the header downloader does in the forward() method
@@ -301,7 +301,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers = {header1, header2};
-        PeerId peer_id = "1";
+        PeerId peer_id{byte_ptr_cast("1")};
         wc.accept_headers(headers, request_id, peer_id);
 
         // creating the persisted chain as the header downloader does at the beginning of the forward() method
@@ -340,7 +340,7 @@ TEST_CASE("working/persistent-chain integration test") {
         auto header1b_hash = header1b.hash();
 
         std::vector<BlockHeader> headers_bis = {header1b};
-        peer_id = "2";
+        peer_id = byte_ptr_cast("2");
         wc.accept_headers(headers_bis, request_id, peer_id);
 
         // saving headers ready to persist as the header downloader does in the forward() method
@@ -411,7 +411,7 @@ TEST_CASE("working/persistent-chain integration test") {
         auto header1b_hash = header1b.hash();
 
         std::vector<BlockHeader> headers = {header1b};
-        PeerId peer_id = "1";
+        PeerId peer_id{byte_ptr_cast("1")};
         wc.accept_headers(headers, request_id, peer_id);
 
         // creating the persisted chain as the header downloader does at the beginning of the forward() method
@@ -453,7 +453,7 @@ TEST_CASE("working/persistent-chain integration test") {
 
         // processing the headers
         std::vector<BlockHeader> headers_bis = {header1, header2};
-        peer_id = "2";
+        peer_id = byte_ptr_cast("2");
         wc.accept_headers(headers_bis, request_id, peer_id);
 
         // saving headers ready to persist as the header downloader does in the forward() method

--- a/node/silkworm/downloader/internals/header_chain_test.cpp
+++ b/node/silkworm/downloader/internals/header_chain_test.cpp
@@ -341,7 +341,7 @@ TEST_CASE("HeaderChain - process_segment - (1) simple chain") {
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 
@@ -566,7 +566,7 @@ TEST_CASE("HeaderChain - process_segment - (2) extending down with 2 siblings") 
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 
@@ -622,7 +622,7 @@ TEST_CASE("HeaderChain - process_segment - (3) chain with branches") {
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id {byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 
@@ -835,7 +835,7 @@ TEST_CASE("HeaderChain - process_segment - (4) pre-verified hashes on canonical 
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 
@@ -923,7 +923,7 @@ TEST_CASE("HeaderChain - process_segment - (5) pre-verified hashes") {
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 7> headers;
 
@@ -998,7 +998,7 @@ TEST_CASE("HeaderChain - process_segment - (5') pre-verified hashes with canonic
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 6> a_headers;
 
@@ -1055,7 +1055,7 @@ TEST_CASE("HeaderChain - process_segment - (6) (malicious) siblings") {
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 
@@ -1190,7 +1190,7 @@ TEST_CASE("HeaderChain - process_segment - (7) invalidating anchor") {
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 
@@ -1279,7 +1279,7 @@ TEST_CASE("HeaderChain - process_segment - (8) sibling with anchor invalidation 
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id = "1";
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 

--- a/node/silkworm/downloader/internals/header_chain_test.cpp
+++ b/node/silkworm/downloader/internals/header_chain_test.cpp
@@ -622,7 +622,7 @@ TEST_CASE("HeaderChain - process_segment - (3) chain with branches") {
     HeaderChain_ForTest chain;
     chain.top_seen_block_height(1'000'000);
     auto request_id = chain.generate_request_id();
-    PeerId peer_id {byte_ptr_cast("1")};
+    PeerId peer_id{byte_ptr_cast("1")};
 
     std::array<BlockHeader, 10> headers;
 

--- a/node/silkworm/downloader/internals/priority_queue_test.cpp
+++ b/node/silkworm/downloader/internals/priority_queue_test.cpp
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 
+#include <silkworm/common/cast.hpp>
+
 #include <catch2/catch.hpp>
 
 #include "header_chain.hpp"
@@ -47,26 +49,27 @@ TEST_CASE("Oldest_First_Anchor_Queue") {
     using namespace std::literals::chrono_literals;
     BlockHeader dummy_header;
     time_point_t now = std::chrono::system_clock::now();
+    PeerId dummy_peer_id{byte_ptr_cast("dummy-peer-id")};
 
     OldestFirstAnchorQueue queue;
 
-    auto anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
+    auto anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
     anchor->blockHeight = 1;
     anchor->timestamp = now;
     queue.push(anchor);
 
-    anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
+    anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
     anchor->blockHeight = 3;
     anchor->timestamp = now;
     queue.push(anchor);
 
-    anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
+    anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
     anchor->blockHeight = 2;
     anchor->timestamp = now + 2s;
     queue.push(anchor);
     auto anchor2 = anchor;
 
-    anchor = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
+    anchor = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
     anchor->blockHeight = 4;
     anchor->timestamp = now + 4s;
     queue.push(anchor);
@@ -127,14 +130,15 @@ TEST_CASE("Oldest_First_Anchor_Queue") {
 TEST_CASE("Oldest_First_Anchor_Queue - siblings handling") {
     using namespace std::literals::chrono_literals;
     time_point_t now = std::chrono::system_clock::now();
+    PeerId dummy_peer_id{byte_ptr_cast("dummy-peer-id")};
 
     BlockHeader dummy_header;
 
-    auto anchor1 = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
+    auto anchor1 = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
     anchor1->blockHeight = 1;
     anchor1->timestamp = now;
 
-    auto anchor2 = std::make_shared<Anchor>(dummy_header, "dummy-peer-id");
+    auto anchor2 = std::make_shared<Anchor>(dummy_header, dummy_peer_id);
     anchor2->blockHeight = 1;  // same block number, it is a sibling
     anchor2->timestamp = now;
 

--- a/node/silkworm/downloader/internals/priority_queue_test.cpp
+++ b/node/silkworm/downloader/internals/priority_queue_test.cpp
@@ -16,9 +16,9 @@
 
 #include <algorithm>
 
-#include <silkworm/common/cast.hpp>
-
 #include <catch2/catch.hpp>
+
+#include <silkworm/common/cast.hpp>
 
 #include "header_chain.hpp"
 

--- a/node/silkworm/downloader/internals/sentry_type_casts.cpp
+++ b/node/silkworm/downloader/internals/sentry_type_casts.cpp
@@ -111,7 +111,7 @@ Hash hash_from_H256(const types::H256& orig) {
     return dest;
 }
 
-std::unique_ptr<types::H512> to_H512(const std::string& orig) {
+std::unique_ptr<types::H512> to_H512(const Bytes& orig) {
     using types::H128, types::H256, types::H512, evmc::load64be;
 
     Bytes bytes(64, 0);
@@ -146,7 +146,7 @@ std::unique_ptr<types::H512> to_H512(const std::string& orig) {
     return dest;  // transfer ownership
 }
 
-std::string string_from_H512(const types::H512& orig) {
+Bytes bytes_from_H512(const types::H512& orig) {
     uint64_t hi_hi_hi = orig.hi().hi().hi();
     uint64_t hi_hi_lo = orig.hi().hi().lo();
     uint64_t hi_lo_hi = orig.hi().lo().hi();
@@ -156,8 +156,8 @@ std::string string_from_H512(const types::H512& orig) {
     uint64_t lo_lo_hi = orig.lo().lo().hi();
     uint64_t lo_lo_lo = orig.lo().lo().lo();
 
-    std::string dest(64, 0);
-    auto data = reinterpret_cast<uint8_t*>(dest.data());
+    Bytes dest(64, 0);
+    auto data = dest.data();
     endian::store_big_u64(data + 0, hi_hi_hi);
     endian::store_big_u64(data + 8, hi_hi_lo);
     endian::store_big_u64(data + 16, hi_lo_hi);

--- a/node/silkworm/downloader/internals/sentry_type_casts.hpp
+++ b/node/silkworm/downloader/internals/sentry_type_casts.hpp
@@ -26,10 +26,10 @@ namespace silkworm {
 
 std::unique_ptr<types::H256> to_H256(const intx::uint256& orig);
 std::unique_ptr<types::H256> to_H256(const Hash& orig);
-std::unique_ptr<types::H512> to_H512(const std::string& orig);
+std::unique_ptr<types::H512> to_H512(const Bytes& orig);
 
 intx::uint256 uint256_from_H256(const types::H256& orig);
 Hash hash_from_H256(const types::H256& orig);
-std::string string_from_H512(const types::H512& orig);
+Bytes bytes_from_H512(const types::H512& orig);
 
 }  // namespace silkworm

--- a/node/silkworm/downloader/internals/sentry_type_casts_test.cpp
+++ b/node/silkworm/downloader/internals/sentry_type_casts_test.cpp
@@ -39,10 +39,10 @@ TEST_CASE("H256/512 to/from conversions") {
 
     for (size_t len : {64u, 64u, 64u, 64u, 64u, 60u, 70u}) {
         SECTION("H512 to/from string, len=" + to_string(len)) {
-            string orig_string(len, 0);
+            Bytes orig_string(len, 0);
             generate_n(orig_string.begin(), len, [] { return static_cast<char>(rand() % 255); });
 
-            string transf_string = string_from_H512(*to_H512(orig_string));
+            Bytes transf_string = bytes_from_H512(*to_H512(orig_string));
 
             orig_string.resize(64, 0);  // transf_string is always of 64 bytes with trailing zeros if needed
             REQUIRE(orig_string == transf_string);

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -76,7 +76,12 @@ inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
     return out;
 }
 
-using PeerId = std::string;
+using PeerId = Bytes;
+
+// Bytes already has operator<<, so PeerId but PeerId is too long
+inline ByteView human_readable_id(const PeerId& peer_id) {
+    return {peer_id.data(), std::min<size_t>(peer_id.length(), 20)};
+}
 
 enum Penalty : int {
     NoPenalty = 0,

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -61,25 +61,9 @@ using duration_t = std::chrono::system_clock::duration;
 using seconds_t = std::chrono::seconds;
 using milliseconds_t = std::chrono::milliseconds;
 
-inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& bytes) {
-    out << silkworm::to_hex(bytes);
-    return out;
-}
-
-inline std::ostream& operator<<(std::ostream& out, const evmc::address& addr) {
-    out << silkworm::to_hex(addr);
-    return out;
-}
-
-inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
-    out << silkworm::to_hex(b32);
-    return out;
-}
-
 using PeerId = Bytes;
 
-// Bytes already has operator<<, so PeerId but PeerId is too long
-inline ByteView human_readable_id(const PeerId& peer_id) {
+inline Bytes human_readable_id(const PeerId& peer_id) {
     return {peer_id.data(), std::min<size_t>(peer_id.length(), 20)};
 }
 

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -61,9 +61,25 @@ using duration_t = std::chrono::system_clock::duration;
 using seconds_t = std::chrono::seconds;
 using milliseconds_t = std::chrono::milliseconds;
 
+inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& bytes) {
+    out << silkworm::to_hex(bytes);
+    return out;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const evmc::address& addr) {
+    out << silkworm::to_hex(addr);
+    return out;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
+    out << silkworm::to_hex(b32);
+    return out;
+}
+
 using PeerId = Bytes;
 
-inline Bytes human_readable_id(const PeerId& peer_id) {
+// Bytes already has operator<<, so PeerId but PeerId is too long
+inline ByteView human_readable_id(const PeerId& peer_id) {
     return {peer_id.data(), std::min<size_t>(peer_id.length(), 20)};
 }
 

--- a/node/silkworm/downloader/messages/inbound_block_bodies.cpp
+++ b/node/silkworm/downloader/messages/inbound_block_bodies.cpp
@@ -26,7 +26,7 @@ InboundBlockBodies::InboundBlockBodies(const sentry::InboundMessage& msg) {
     if (msg.id() != sentry::MessageId::BLOCK_BODIES_66)
         throw std::logic_error("InboundBlockBodies received wrong InboundMessage");
 
-    peerId_ = string_from_H512(msg.peer_id());
+    peerId_ = bytes_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/inbound_block_headers.cpp
+++ b/node/silkworm/downloader/messages/inbound_block_headers.cpp
@@ -28,7 +28,7 @@ InboundBlockHeaders::InboundBlockHeaders(const sentry::InboundMessage& msg) {
     if (msg.id() != sentry::MessageId::BLOCK_HEADERS_66)
         throw std::logic_error("InboundBlockHeaders received wrong InboundMessage");
 
-    peerId_ = string_from_H512(msg.peer_id());
+    peerId_ = bytes_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/inbound_get_block_bodies.cpp
+++ b/node/silkworm/downloader/messages/inbound_get_block_bodies.cpp
@@ -29,7 +29,7 @@ InboundGetBlockBodies::InboundGetBlockBodies(const sentry::InboundMessage& msg) 
         throw std::logic_error("InboundGetBlockBodies received wrong InboundMessage");
     }
 
-    peerId_ = string_from_H512(msg.peer_id());
+    peerId_ = bytes_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/inbound_get_block_bodies.hpp
+++ b/node/silkworm/downloader/messages/inbound_get_block_bodies.hpp
@@ -33,7 +33,7 @@ class InboundGetBlockBodies : public InboundMessage {
     void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
-    std::string peerId_;
+    PeerId peerId_;
     GetBlockBodiesPacket66 packet_;
 };
 

--- a/node/silkworm/downloader/messages/inbound_get_block_headers.cpp
+++ b/node/silkworm/downloader/messages/inbound_get_block_headers.cpp
@@ -29,7 +29,7 @@ InboundGetBlockHeaders::InboundGetBlockHeaders(const sentry::InboundMessage& msg
         throw std::logic_error("InboundGetBlockHeaders received wrong InboundMessage");
     }
 
-    peerId_ = string_from_H512(msg.peer_id());
+    peerId_ = bytes_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/inbound_get_block_headers.hpp
+++ b/node/silkworm/downloader/messages/inbound_get_block_headers.hpp
@@ -33,7 +33,7 @@ class InboundGetBlockHeaders : public InboundMessage {
     void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
-    std::string peerId_;
+    PeerId peerId_;
     GetBlockHeadersPacket66 packet_;
 };
 

--- a/node/silkworm/downloader/messages/inbound_new_block.cpp
+++ b/node/silkworm/downloader/messages/inbound_new_block.cpp
@@ -31,7 +31,7 @@ InboundNewBlock::InboundNewBlock(const sentry::InboundMessage& msg) {
 
     reqId_ = RANDOM_NUMBER.generate_one();  // for trace purposes
 
-    peerId_ = string_from_H512(msg.peer_id());
+    peerId_ = bytes_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/inbound_new_block.hpp
+++ b/node/silkworm/downloader/messages/inbound_new_block.hpp
@@ -33,7 +33,7 @@ class InboundNewBlock : public InboundMessage {
     void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
-    std::string peerId_;
+    PeerId peerId_;
     NewBlockPacket packet_;
     uint64_t reqId_;
 };

--- a/node/silkworm/downloader/messages/inbound_new_block_hashes.cpp
+++ b/node/silkworm/downloader/messages/inbound_new_block_hashes.cpp
@@ -32,7 +32,7 @@ InboundNewBlockHashes::InboundNewBlockHashes(const sentry::InboundMessage& msg) 
 
     reqId_ = RANDOM_NUMBER.generate_one();  // for trace purposes
 
-    peerId_ = string_from_H512(msg.peer_id());
+    peerId_ = bytes_from_H512(msg.peer_id());
 
     ByteView data = string_view_to_byte_view(msg.data());  // copy for consumption
     rlp::success_or_throw(rlp::decode(data, packet_));

--- a/node/silkworm/downloader/messages/inbound_new_block_hashes.hpp
+++ b/node/silkworm/downloader/messages/inbound_new_block_hashes.hpp
@@ -33,7 +33,7 @@ class InboundNewBlockHashes : public InboundMessage {
     void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
-    std::string peerId_;
+    PeerId peerId_;
     NewBlockHashesPacket packet_;
     uint64_t reqId_;
 };

--- a/node/silkworm/downloader/rpc/peer_min_block.cpp
+++ b/node/silkworm/downloader/rpc/peer_min_block.cpp
@@ -18,7 +18,7 @@
 
 namespace silkworm::rpc {
 
-PeerMinBlock::PeerMinBlock(const std::string& peerId, BlockNum minBlock)
+PeerMinBlock::PeerMinBlock(const PeerId& peerId, BlockNum minBlock)
     : UnaryCall("PeerMinBlock", &sentry::Sentry::Stub::PeerMinBlock, {}) {
     request_.set_allocated_peer_id(to_H512(peerId).release());
     request_.set_min_block(minBlock);  // take ownership

--- a/node/silkworm/downloader/rpc/peer_min_block.hpp
+++ b/node/silkworm/downloader/rpc/peer_min_block.hpp
@@ -22,7 +22,7 @@ namespace silkworm::rpc {
 
 class PeerMinBlock : public rpc::UnaryCall<sentry::Sentry, sentry::PeerMinBlockRequest, google::protobuf::Empty> {
   public:
-    PeerMinBlock(const std::string& peerId, BlockNum minBlock);
+    PeerMinBlock(const PeerId&, BlockNum minBlock);
 };
 
 }  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/penalize_peer.cpp
+++ b/node/silkworm/downloader/rpc/penalize_peer.cpp
@@ -18,11 +18,11 @@
 
 namespace silkworm::rpc {
 
-PenalizePeer::PenalizePeer(const std::string& peerId, Penalty penalty)
+PenalizePeer::PenalizePeer(const PeerId& peerId, Penalty penalty)
     : UnaryCall("PenalizePeer", &sentry::Sentry::Stub::PenalizePeer, {}) {
     request_.set_allocated_peer_id(to_H512(peerId).release());
 
-    sentry::PenaltyKind raw_penalty = static_cast<sentry::PenaltyKind>(penalty);
+    auto raw_penalty = static_cast<sentry::PenaltyKind>(penalty);
     request_.set_penalty(raw_penalty);
 }
 

--- a/node/silkworm/downloader/rpc/penalize_peer.hpp
+++ b/node/silkworm/downloader/rpc/penalize_peer.hpp
@@ -22,7 +22,7 @@ namespace silkworm::rpc {
 
 class PenalizePeer : public rpc::UnaryCall<sentry::Sentry, sentry::PenalizePeerRequest, google::protobuf::Empty> {
   public:
-    PenalizePeer(const std::string& peerId, Penalty penalty);
+    PenalizePeer(const PeerId&, Penalty);
 };
 
 }  // namespace silkworm::rpc

--- a/node/silkworm/downloader/rpc/send_message_by_id.cpp
+++ b/node/silkworm/downloader/rpc/send_message_by_id.cpp
@@ -18,7 +18,7 @@
 
 namespace silkworm::rpc {
 
-SendMessageById::SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
+SendMessageById::SendMessageById(const PeerId& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
     : UnaryCall("SendMessageById", &sentry::Sentry::Stub::SendMessageById, {}) {
     request_.set_allocated_peer_id(to_H512(peerId).release());
     request_.set_allocated_data(message.release());  // take ownership

--- a/node/silkworm/downloader/rpc/send_message_by_id.hpp
+++ b/node/silkworm/downloader/rpc/send_message_by_id.hpp
@@ -22,7 +22,7 @@ namespace silkworm::rpc {
 
 class SendMessageById : public rpc::UnaryCall<sentry::Sentry, sentry::SendMessageByIdRequest, sentry::SentPeers> {
   public:
-    SendMessageById(const std::string& peerId, std::unique_ptr<sentry::OutboundMessageData> message);
+    SendMessageById(const PeerId&, std::unique_ptr<sentry::OutboundMessageData> message);
 };
 
 }  // namespace silkworm::rpc

--- a/node/silkworm/downloader/sentry_client.cpp
+++ b/node/silkworm/downloader/sentry_client.cpp
@@ -120,7 +120,7 @@ void SentryClient::stats_receiving_loop() {
     while (!is_stopping() && receive_peer_stats.receive_one_reply()) {
         const sentry::PeerEvent& stat = receive_peer_stats.reply();
 
-        auto peerId = string_from_H512(stat.peer_id());
+        auto peerId = bytes_from_H512(stat.peer_id());
         const char* event = "";
         if (stat.event_id() == sentry::PeerEvent::Connect) {
             event = "connected";
@@ -130,7 +130,7 @@ void SentryClient::stats_receiving_loop() {
             if (active_peers_ > 0) active_peers_--;  // workaround, to fix this we need to improve the interface
         }                                            // or issue a count_active_peers()
 
-        log::Info() << "Peer " << peerId << " " << event << ", active " << active_peers_;
+        log::Info() << "Peer " << human_readable_id(peerId) << " " << event << ", active " << active_peers_;
     }
 
     stop();


### PR DESCRIPTION
Erigon Sentry now uses pubkey as peer-id but pubkey has not printable characters.
This PR use Bytes in place of string to represent peer-id and use hex encoding to print peer-id.