### PR TITLE
yacc is occasionally missing from CI machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           name: "Install dependencies"
           command: |
             sudo apt-get update
-            sudo apt-get install -y m4 texinfo
+            sudo apt-get install -y m4 texinfo bison
       - restore_cache:
           name: "Restore Hunter cache"
           key: &hunter-cache-key hunter-{{ .Environment.CIRCLE_JOB }}-{{checksum "cmake/Hunter/config.cmake"}}-{{checksum "cmake/toolchain/base.cmake"}}-{{checksum "cmake/toolchain/cxx20.cmake"}}-{{checksum "cmake/toolchain/clang_libcxx.cmake"}}-{{checksum "cmake/toolchain/wasi.cmake"}}


### PR DESCRIPTION
To fix spurious CI build failures after PR #756 (e.g. https://app.circleci.com/pipelines/github/torquem-ch/silkworm/5153/workflows/8617cf27-37ea-4ae0-b3b1-fd9cad37ed71/jobs/18345).