### PR TITLE
Completed syncloop

### DIFF
--- a/node/silkworm/db/access_layer_test.cpp
+++ b/node/silkworm/db/access_layer_test.cpp
@@ -518,7 +518,8 @@ namespace db {
         db::stages::write_stage_progress(txn, db::stages::kExecutionKey, 3);
 
         db::RWTxn tm{txn};
-        stagedsync::HistoryIndex stage_history_index(&context.node_settings());
+        stagedsync::SyncContext sync_context{};
+        stagedsync::HistoryIndex stage_history_index(&context.node_settings(), &sync_context);
         REQUIRE(stage_history_index.forward(tm) == stagedsync::StageResult::kSuccess);
 
         std::optional<Account> current_account{read_account(txn, miner_a)};

--- a/node/silkworm/db/stages.hpp
+++ b/node/silkworm/db/stages.hpp
@@ -101,11 +101,11 @@ inline constexpr const char* kAllStages[]{
     kUnwindKey,
 };
 
-//! \brief Stages won't log begin if segment is beyond this threshold
-inline constexpr size_t kSmallSegmentWidth{16};
+//! \brief Stages won't log their "start" if segment is below this threshold
+inline constexpr size_t kSmallBlockSegmentWidth{16};
 
 //! \brief Some stages will use this threshold to determine if worth regen vs incremental
-inline constexpr size_t kLargeSegmentWorthRegen{100'000};
+inline constexpr size_t kLargeBlockSegmentWorthRegen{100'000};
 
 //! \brief Reads from db the progress (block height) of the provided stage name
 //! \param [in] txn : a reference to a ro/rw db transaction

--- a/node/silkworm/db/stages.hpp
+++ b/node/silkworm/db/stages.hpp
@@ -24,58 +24,61 @@
 
 namespace silkworm::db::stages {
 
-// Headers are downloaded, their Proof-Of-Work validity and chaining is verified
+//! \brief Headers are downloaded, their Proof-Of-Work validity and chaining is verified
 inline constexpr const char* kHeadersKey{"Headers"};
 
-// Headers Number are written, fills blockHash => number bucket
+//! \brief Headers Number are written, fills blockHash => number bucket
 inline constexpr const char* kBlockHashesKey{"BlockHashes"};
 
-// Block bodies are downloaded, TxHash and UncleHash are getting verified
+//! \brief Block bodies are downloaded, TxHash and UncleHash are getting verified
 inline constexpr const char* kBlockBodiesKey{"Bodies"};
 
-// "From" recovered from signatures
+//! \brief "From" recovered from signatures
 inline constexpr const char* kSendersKey{"Senders"};
 
-// Executing each block w/o building a trie
+//! \brief Executing each block w/o building a trie
 inline constexpr const char* kExecutionKey{"Execution"};
 
-// Generate intermediate hashes, calculate the state root hash
+//! \brief Generate intermediate hashes, calculate the state root hash
 inline constexpr const char* kIntermediateHashesKey{"IntermediateHashes"};
 
-// Apply Keccak256 to all the keys in the state
+//! \brief Apply Keccak256 to all the keys in the state
 inline constexpr const char* kHashStateKey{"HashState"};
 
-// Generating history index for accounts
+//! \brief Generating history index for accounts
 inline constexpr const char* kHistoryIndexKey{"HistoryIndex"};
 
-// Generating history index for accounts
+//! \brief Generating history index for accounts
 inline constexpr const char* kAccountHistoryIndexKey{"AccountHistoryIndex"};
 
-// Generating history index for storage
+//! \brief Generating history index for storage
 inline constexpr const char* kStorageHistoryIndexKey{"StorageHistoryIndex"};
 
-// Generating logs index (from receipts)
+//! \brief Generating logs index (from receipts)
 inline constexpr const char* kLogIndexKey{"LogIndex"};
 
-// Generating call traces index
+//! \brief Generating call traces index
 inline constexpr const char* kCallTracesKey{"CallTraces"};
 
-// Generating transactions lookup index
+//! \brief Generating transactions lookup index
 inline constexpr const char* kTxLookupKey{"TxLookup"};
 
-// Starts Backend
+//! \brief Starts Backend
 inline constexpr const char* kTxPoolKey{"TxPool"};
 
-// Nominal stage after all other stages
+//! \brief Nominal stage after all other stages
 inline constexpr const char* kFinishKey{"Finish"};
 
-// Create block for mining
+//! \brief Not an actual stage rather placeholder for global unwind point
+inline constexpr const char* kUnwindKey{"Unwind"};
+
+//! \brief Create block for mining
 inline constexpr const char* kMiningCreateBlockKey{"MiningCreateBlock"};
 
-//  Execute mining
+//! \brief  Execute mining
 inline constexpr const char* kMiningExecutionKey{"MiningExecution"};
 
-// Mining completed
+//! \brief Mining completed
 inline constexpr const char* kMiningFinishKey{"MiningFinish"};
 
 //! \brief List of all known stages
@@ -95,6 +98,7 @@ inline constexpr const char* kAllStages[]{
     kTxLookupKey,
     kTxPoolKey,
     kFinishKey,
+    kUnwindKey,
 };
 
 //! \brief Stages won't log begin if segment is beyond this threshold

--- a/node/silkworm/db/stages.hpp
+++ b/node/silkworm/db/stages.hpp
@@ -97,6 +97,12 @@ inline constexpr const char* kAllStages[]{
     kFinishKey,
 };
 
+//! \brief Stages won't log begin if segment is beyond this threshold
+inline constexpr size_t kSmallSegmentWidth{16};
+
+//! \brief Some stages will use this threshold to determine if worth regen vs incremental
+inline constexpr size_t kLargeSegmentWorthRegen{100'000};
+
 //! \brief Reads from db the progress (block height) of the provided stage name
 //! \param [in] txn : a reference to a ro/rw db transaction
 //! \param [in] stage_name : the name of the requested stage (must be known see kAllStages[])

--- a/node/silkworm/db/tables.hpp
+++ b/node/silkworm/db/tables.hpp
@@ -59,6 +59,12 @@ inline constexpr db::MapConfig kAccountChangeSet{"AccountChangeSet", mdbx::key_m
 //! same content limits wrt pruning
 inline constexpr db::MapConfig kAccountHistory{"AccountHistory"};
 
+//! \details Holds blockbody data
+//! \struct
+//! \verbatim
+//!   key   : block number (BE 8 bytes) + block header hash (32 bytes)
+//!   value : block body data RLP encoded
+//! \endverbatim
 inline constexpr db::MapConfig kBlockBodies{"BlockBody"};
 
 //! \details Stores the binding of *canonical* block number with header hash

--- a/node/silkworm/stagedsync/_test.cpp
+++ b/node/silkworm/stagedsync/_test.cpp
@@ -168,6 +168,9 @@ TEST_CASE("Sync Stages") {
         REQUIRE_NOTHROW(db::write_canonical_header_hash(*txn, block_hashes[1].bytes, 2));
         REQUIRE_NOTHROW(db::write_canonical_header_hash(*txn, block_hashes[2].bytes, 3));
 
+        // Update progress
+        REQUIRE_NOTHROW(db::stages::write_stage_progress(*txn, db::stages::kBlockHashesKey, 3));
+
         // Commit
         REQUIRE_NOTHROW(txn.commit());
 

--- a/node/silkworm/stagedsync/_test.cpp
+++ b/node/silkworm/stagedsync/_test.cpp
@@ -352,7 +352,9 @@ TEST_CASE("Sync Stages") {
             expected_block_num = 1;  // First storage change is at block 1
             actual_block_num = endian::load_big_u64(db::from_slice(data.key).data());
             REQUIRE(actual_block_num == expected_block_num);
-            REQUIRE(db::stages::read_stage_prune_progress(*txn, db::stages::kExecutionKey) == 3);
+
+            // There is no pruning setting enabled hence no pruning occurred
+            REQUIRE(db::stages::read_stage_prune_progress(*txn, db::stages::kExecutionKey) == 0);
         }
 
         SECTION("Execution Prune History") {

--- a/node/silkworm/stagedsync/_test.cpp
+++ b/node/silkworm/stagedsync/_test.cpp
@@ -66,11 +66,12 @@ TEST_CASE("Sync Stages") {
 
     SECTION("BlockHashes") {
         SECTION("Forward/Unwind/Prune args validation") {
-            stagedsync::BlockHashes stage(&node_settings);
+            stagedsync::SyncContext sync_context{};
+            stagedsync::BlockHashes stage(&node_settings, &sync_context);
 
             // (previous_progress == headers_progress == 0)
             REQUIRE(stage.forward(txn) == stagedsync::StageResult::kSuccess);
-            REQUIRE(stage.unwind(txn, 0) == stagedsync::StageResult::kSuccess);
+            REQUIRE(stage.unwind(txn) == stagedsync::StageResult::kSuccess);
 
             // (previous_progress > headers_progress)
             stage.update_progress(txn, 10);
@@ -91,7 +92,9 @@ TEST_CASE("Sync Stages") {
             }
             db::stages::write_stage_progress(*txn, db::stages::kHeadersKey, 3);
             REQUIRE_NOTHROW(txn.commit(true));
-            stagedsync::BlockHashes stage(&node_settings);
+
+            stagedsync::SyncContext sync_context{};
+            stagedsync::BlockHashes stage(&node_settings, &sync_context);
 
             // Forward
             auto stage_result{stage.forward(txn)};
@@ -124,7 +127,8 @@ TEST_CASE("Sync Stages") {
             }
 
             // Unwind
-            stage_result = stage.unwind(txn, 1);
+            sync_context.unwind_to.emplace(1);
+            stage_result = stage.unwind(txn);
             REQUIRE(stage_result == stagedsync::StageResult::kSuccess);
             {
                 // Verify written data is consistent
@@ -172,7 +176,8 @@ TEST_CASE("Sync Stages") {
         REQUIRE(last_tx_sequence == 2);
 
         // Check forward works
-        stagedsync::Senders stage(&node_settings);
+        stagedsync::SyncContext sync_context{};
+        stagedsync::Senders stage(&node_settings, &sync_context);
         auto stage_result = stage.forward(txn);
         REQUIRE(stage_result == stagedsync::StageResult::kSuccess);
         REQUIRE_NOTHROW(txn.commit());
@@ -195,7 +200,8 @@ TEST_CASE("Sync Stages") {
         }
 
         // Check unwind works
-        stage_result = stage.unwind(txn, 1);
+        sync_context.unwind_to.emplace(1);
+        stage_result = stage.unwind(txn);
         REQUIRE(stage_result == stagedsync::StageResult::kSuccess);
 
         {
@@ -311,8 +317,10 @@ TEST_CASE("Sync Stages") {
             // ---------------------------------------
             // Unwind 3rd block and checks if state is second block
             // ---------------------------------------
-            stagedsync::Execution stage(&node_settings);
-            REQUIRE(stage.unwind(txn, 2) == stagedsync::StageResult::kSuccess);
+            stagedsync::SyncContext sync_context{};
+            sync_context.unwind_to.emplace(2);
+            stagedsync::Execution stage(&node_settings, &sync_context);
+            REQUIRE(stage.unwind(txn) == stagedsync::StageResult::kSuccess);
 
             db::Buffer buffer2{*txn, 0};
 
@@ -335,7 +343,8 @@ TEST_CASE("Sync Stages") {
 
         SECTION("Execution Prune Default") {
             log::Info() << "Pruning with " << node_settings.prune_mode->to_string();
-            stagedsync::Execution stage(&node_settings);
+            stagedsync::SyncContext sync_context{};
+            stagedsync::Execution stage(&node_settings, &sync_context);
             REQUIRE(stage.prune(txn) == stagedsync::StageResult::kSuccess);
 
             // With default settings nothing should be pruned
@@ -365,7 +374,8 @@ TEST_CASE("Sync Stages") {
 
             log::Info() << "Pruning with " << node_settings.prune_mode->to_string();
             REQUIRE(node_settings.prune_mode->history().enabled());
-            stagedsync::Execution stage(&node_settings);
+            stagedsync::SyncContext sync_context{};
+            stagedsync::Execution stage(&node_settings, &sync_context);
             REQUIRE(stage.prune(txn) == stagedsync::StageResult::kSuccess);
 
             db::Cursor account_changeset_table(txn, db::table::kAccountChangeSet);
@@ -378,7 +388,8 @@ TEST_CASE("Sync Stages") {
         }
 
         SECTION("HashState") {
-            stagedsync::HashState stage(&node_settings);
+            stagedsync::SyncContext sync_context{};
+            stagedsync::HashState stage(&node_settings, &sync_context);
             auto expected_stage_result{
                 magic_enum::enum_name<stagedsync::StageResult>(stagedsync::StageResult::kSuccess)};
             auto actual_stage_result = magic_enum::enum_name<stagedsync::StageResult>(stage.forward(txn));
@@ -425,7 +436,8 @@ TEST_CASE("Sync Stages") {
 
             // Unwind the stage to block 1 (i.e. block 1 *is* applied)
             BlockNum unwind_to{1};
-            actual_stage_result = magic_enum::enum_name<stagedsync::StageResult>(stage.unwind(txn, unwind_to));
+            sync_context.unwind_to.emplace(unwind_to);
+            actual_stage_result = magic_enum::enum_name<stagedsync::StageResult>(stage.unwind(txn));
             REQUIRE(expected_stage_result == actual_stage_result);
             hashed_accounts_table.bind(txn, db::table::kHashedAccounts);
             REQUIRE(hashed_accounts_table.seek(db::to_slice(hashed_sender.bytes)));

--- a/node/silkworm/stagedsync/common.cpp
+++ b/node/silkworm/stagedsync/common.cpp
@@ -30,7 +30,7 @@ void IStage::update_progress(db::RWTxn& txn, BlockNum progress) {
 
 void IStage::check_block_sequence(BlockNum actual, BlockNum expected) {
     if (actual != expected) {
-        const std::string what{"Bad block sequence : expected " + std::to_string(expected) + " got " +
+        const std::string what{"bad block sequence : expected " + std::to_string(expected) + " got " +
                                std::to_string(actual)};
         throw StageError(StageResult::kBadChainSequence, what);
     }

--- a/node/silkworm/stagedsync/common.hpp
+++ b/node/silkworm/stagedsync/common.hpp
@@ -140,7 +140,7 @@ class IStage : public Stoppable {
     void update_progress(db::RWTxn& txn, BlockNum progress);
 
     //! \brief Sets the prefix for logging lines produced by stage itself
-    void set_log_prefix(const std::string prefix) { log_prefix_ = prefix; };
+    void set_log_prefix(const std::string& prefix) { log_prefix_ = prefix; };
 
     //! \brief This function implementation MUST be thread safe as is called asynchronously from ASIO thread
     [[nodiscard]] virtual std::vector<std::string> get_log_progress() { return {}; };

--- a/node/silkworm/stagedsync/common.hpp
+++ b/node/silkworm/stagedsync/common.hpp
@@ -116,6 +116,9 @@ class IStage : public Stoppable {
     //! \brief Updates current stage progress
     void update_progress(db::RWTxn& txn, BlockNum progress);
 
+    //! \brief Sets the prefix for logging lines produced by stage itself
+    void set_log_prefix(const std::string prefix) { log_prefix_ = prefix; };
+
     //! \brief This function implementation MUST be thread safe as is called asynchronously from ASIO thread
     [[nodiscard]] virtual std::vector<std::string> get_log_progress() { return {}; };
 
@@ -128,10 +131,12 @@ class IStage : public Stoppable {
     }
 
   protected:
+    static constexpr size_t kSmallSegmentWidth{16};              // A small segment does not require logging of begin/end
     const char* stage_name_;                                     // Human friendly identifier of the stage
     NodeSettings* node_settings_;                                // Pointer to shared node configuration settings
     std::atomic<OperationType> operation_{OperationType::None};  // Actual operation being carried out
     std::mutex sl_mutex_;                                        // To synchronize access by outer sync loop
+    std::string log_prefix_;                                     // Log lines prefix holding the progress among stages
 
     //! \brief Throws if actual block != expected block
     static void check_block_sequence(BlockNum actual, BlockNum expected);

--- a/node/silkworm/stagedsync/common.hpp
+++ b/node/silkworm/stagedsync/common.hpp
@@ -131,7 +131,6 @@ class IStage : public Stoppable {
     }
 
   protected:
-    static constexpr size_t kSmallSegmentWidth{16};              // A small segment does not require logging of begin/end
     const char* stage_name_;                                     // Human friendly identifier of the stage
     NodeSettings* node_settings_;                                // Pointer to shared node configuration settings
     std::atomic<OperationType> operation_{OperationType::None};  // Actual operation being carried out

--- a/node/silkworm/stagedsync/common.hpp
+++ b/node/silkworm/stagedsync/common.hpp
@@ -47,6 +47,7 @@ enum class [[nodiscard]] StageResult{
     kUnknownError,            //
     kDbError,                 //
     kAborted,                 //
+    kStoppedByEnv,            // Encountered "STOP_BEFORE_STAGE" env var
 };
 
 //! \brief Stage execution exception

--- a/node/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.cpp
@@ -48,7 +48,7 @@ StageResult BlockHashes::forward(db::RWTxn& txn) {
         }
 
         const BlockNum segment_width{headers_stage_progress - previous_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -109,8 +109,8 @@ StageResult BlockHashes::unwind(db::RWTxn& txn, BlockNum to) {
         }
 
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin " + std::string(stage_name_),
+        if (segment_width > db::stages::kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(to),

--- a/node/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.cpp
@@ -84,7 +84,7 @@ StageResult BlockHashes::forward(db::RWTxn& txn) {
     return ret;
 }
 
-StageResult BlockHashes::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult BlockHashes::unwind(db::RWTxn& txn) {
     /*
      * Unwinds HeaderNumber index by
      *      select CanonicalHashes->HeaderHash
@@ -97,6 +97,9 @@ StageResult BlockHashes::unwind(db::RWTxn& txn, BlockNum to) {
      */
 
     StageResult ret{StageResult::kSuccess};
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();

--- a/node/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.cpp
@@ -49,7 +49,7 @@ StageResult BlockHashes::forward(db::RWTxn& txn) {
 
         const BlockNum segment_width{headers_stage_progress - previous_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(headers_stage_progress),
@@ -113,7 +113,7 @@ StageResult BlockHashes::unwind(db::RWTxn& txn) {
 
         const BlockNum segment_width{previous_progress - to};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(to),

--- a/node/silkworm/stagedsync/stage_blockhashes.cpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.cpp
@@ -48,7 +48,7 @@ StageResult BlockHashes::forward(db::RWTxn& txn) {
         }
 
         const BlockNum segment_width{headers_stage_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -112,7 +112,7 @@ StageResult BlockHashes::unwind(db::RWTxn& txn) {
         }
 
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),

--- a/node/silkworm/stagedsync/stage_blockhashes.hpp
+++ b/node/silkworm/stagedsync/stage_blockhashes.hpp
@@ -22,11 +22,12 @@ namespace silkworm::stagedsync {
 
 class BlockHashes final : public IStage {
   public:
-    explicit BlockHashes(NodeSettings* node_settings) : IStage(db::stages::kBlockHashesKey, node_settings){};
+    explicit BlockHashes(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kBlockHashesKey, node_settings){};
     ~BlockHashes() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -159,9 +159,9 @@ void Execution::prefetch_blocks(db::RWTxn& txn, const BlockNum from, const Block
     const size_t count{std::min(static_cast<size_t>(to - from + 1), kMaxPrefetchedBlocks)};
     size_t num_read{0};
 
-    db::Cursor hashes_table(txn, db::table::kCanonicalHashes);
+    db::Cursor canonicals(txn, db::table::kCanonicalHashes);
     auto key{db::block_key(from)};
-    if (hashes_table.seek(db::to_slice(key))) {
+    if (canonicals.seek(db::to_slice(key))) {
         BlockNum block_num{from};
         db::WalkFunc walk_function{[&](mdbx::cursor&, mdbx::cursor::move_result& data) {
             BlockNum reached_block_num{endian::load_big_u64(static_cast<const uint8_t*>(data.key.data()))};
@@ -184,7 +184,7 @@ void Execution::prefetch_blocks(db::RWTxn& txn, const BlockNum from, const Block
             ++block_num;
             return true;
         }};
-        num_read = db::cursor_for_count(hashes_table, walk_function, count);
+        num_read = db::cursor_for_count(canonicals, walk_function, count);
     }
 
     if (num_read != count) {

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -498,7 +498,7 @@ StageResult Execution::prune(db::RWTxn& txn) {
         // Prune call traces
         if (const auto prune_threshold{node_settings_->prune_mode->receipts().value_from_head(forward_progress)}; prune_threshold) {
             if (segment_width > db::stages::kSmallSegmentWidth) {
-                log::Info(log_prefix_ ",
+                log::Info(log_prefix_,
                           {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                            "source", "call traces",
                            "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -289,7 +289,7 @@ StageResult Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, Bas
     return ret;
 }
 
-StageResult Execution::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult Execution::unwind(db::RWTxn& txn) {
     static const db::MapConfig unwind_tables[5] = {
         db::table::kAccountChangeSet,  //
         db::table::kStorageChangeSet,  //
@@ -299,6 +299,9 @@ StageResult Execution::unwind(db::RWTxn& txn, BlockNum to) {
     };
 
     StageResult ret{StageResult::kSuccess};
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
     try {
         BlockNum previous_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -68,7 +68,7 @@ StageResult Execution::forward(db::RWTxn& txn) {
         block_num_ = previous_progress + 1;
         BlockNum max_block_num{senders_stage_progress};
         BlockNum segment_width{senders_stage_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(block_num_),
@@ -338,7 +338,7 @@ StageResult Execution::unwind(db::RWTxn& txn) {
 
         operation_ = OperationType::Unwind;
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -418,7 +418,7 @@ StageResult Execution::prune(db::RWTxn& txn) {
 
         // Prune history of changes (changesets)
         if (const auto prune_threshold{node_settings_->prune_mode->history().value_from_head(forward_progress)}; prune_threshold) {
-            if (segment_width > db::stages::kSmallSegmentWidth) {
+            if (segment_width > db::stages::kSmallBlockSegmentWidth) {
                 log::Info(log_prefix_,
                           {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                            "source", "history",
@@ -465,7 +465,7 @@ StageResult Execution::prune(db::RWTxn& txn) {
 
         // Prune receipts
         if (const auto prune_threshold{node_settings_->prune_mode->receipts().value_from_head(forward_progress)}; prune_threshold) {
-            if (segment_width > db::stages::kSmallSegmentWidth) {
+            if (segment_width > db::stages::kSmallBlockSegmentWidth) {
                 log::Info(log_prefix_,
                           {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                            "source", "receipts",
@@ -497,7 +497,7 @@ StageResult Execution::prune(db::RWTxn& txn) {
 
         // Prune call traces
         if (const auto prune_threshold{node_settings_->prune_mode->receipts().value_from_head(forward_progress)}; prune_threshold) {
-            if (segment_width > db::stages::kSmallSegmentWidth) {
+            if (segment_width > db::stages::kSmallBlockSegmentWidth) {
                 log::Info(log_prefix_,
                           {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                            "source", "call traces",

--- a/node/silkworm/stagedsync/stage_execution.hpp
+++ b/node/silkworm/stagedsync/stage_execution.hpp
@@ -27,14 +27,14 @@ namespace silkworm::stagedsync {
 
 class Execution final : public IStage {
   public:
-    explicit Execution(NodeSettings* node_settings)
-        : IStage(db::stages::kExecutionKey, node_settings),
+    explicit Execution(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kExecutionKey, node_settings),
           consensus_engine_{consensus::engine_factory(node_settings->chain_config.value())} {}
 
     ~Execution() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/stage_finish.cpp
+++ b/node/silkworm/stagedsync/stage_finish.cpp
@@ -45,10 +45,10 @@ StageResult Finish::forward(db::RWTxn& txn) {
         update_progress(txn, execution_stage_progress);
 
         // Log the new version of app at this height
-        // TODO Should be done only on first cycle
-        Bytes build_info{byte_ptr_cast(node_settings_->build_info.data())};
-        db::write_build_info_height(*txn, build_info, execution_stage_progress);
-
+        if (sync_context_->is_first_cycle) {
+            Bytes build_info{byte_ptr_cast(node_settings_->build_info.data())};
+            db::write_build_info_height(*txn, build_info, execution_stage_progress);
+        }
         txn.commit();
 
     } catch (const StageError& ex) {

--- a/node/silkworm/stagedsync/stage_finish.cpp
+++ b/node/silkworm/stagedsync/stage_finish.cpp
@@ -51,19 +51,19 @@ StageResult Finish::forward(db::RWTxn& txn) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
@@ -81,19 +81,19 @@ StageResult Finish::unwind(db::RWTxn& txn, BlockNum to) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }

--- a/node/silkworm/stagedsync/stage_finish.hpp
+++ b/node/silkworm/stagedsync/stage_finish.hpp
@@ -22,11 +22,12 @@ namespace silkworm::stagedsync {
 
 class Finish : public IStage {
   public:
-    explicit Finish(NodeSettings* node_settings) : IStage(db::stages::kFinishKey, node_settings){};
+    explicit Finish(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kFinishKey, node_settings){};
     ~Finish() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
 
     // Finish does not prune.
     StageResult prune(db::RWTxn&) final { return StageResult::kSuccess; };

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -43,7 +43,7 @@ StageResult HashState::forward(db::RWTxn& txn) {
         }
 
         BlockNum segment_width{execution_stage_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -53,7 +53,7 @@ StageResult HashState::forward(db::RWTxn& txn) {
 
         reset_log_progress();
 
-        if (!previous_progress || segment_width > db::stages::kLargeSegmentWorthRegen) {
+        if (!previous_progress || segment_width > db::stages::kLargeBlockSegmentWorthRegen) {
             // Clear any previous contents
             log::Info(log_prefix_, {"clearing", db::table::kHashedAccounts.name});
             txn->clear_map(db::table::kHashedAccounts.name);
@@ -121,7 +121,7 @@ StageResult HashState::unwind(db::RWTxn& txn) {
             return ret;
         }
         BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -107,8 +107,11 @@ StageResult HashState::forward(db::RWTxn& txn) {
     return ret;
 }
 
-StageResult HashState::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult HashState::unwind(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -43,7 +43,7 @@ StageResult HashState::forward(db::RWTxn& txn) {
         }
 
         BlockNum segment_width{execution_stage_progress - previous_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -118,7 +118,7 @@ StageResult HashState::unwind(db::RWTxn& txn, BlockNum to) {
             return ret;
         }
         BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),

--- a/node/silkworm/stagedsync/stage_hashstate.hpp
+++ b/node/silkworm/stagedsync/stage_hashstate.hpp
@@ -22,12 +22,12 @@ namespace silkworm::stagedsync {
 
 class HashState final : public IStage {
   public:
-    explicit HashState(NodeSettings* node_settings)
-        : IStage(db::stages::kHashStateKey, node_settings),
+    explicit HashState(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kHashStateKey, node_settings),
           collector_(std::make_unique<etl::Collector>(node_settings)){};
     ~HashState() override = default;
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -98,8 +98,12 @@ StageResult HistoryIndex::forward(db::RWTxn& txn) {
     return is_stopping() ? StageResult::kAborted : ret;
 }
 
-StageResult HistoryIndex::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult HistoryIndex::unwind(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::None;
     try {
         throw_if_stopping();

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -45,7 +45,7 @@ StageResult HistoryIndex::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -123,7 +123,7 @@ StageResult HistoryIndex::unwind(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -190,7 +190,7 @@ StageResult HistoryIndex::prune(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -45,7 +45,7 @@ StageResult HistoryIndex::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -119,7 +119,7 @@ StageResult HistoryIndex::unwind(db::RWTxn& txn, BlockNum to) {
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -186,7 +186,7 @@ StageResult HistoryIndex::prune(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -46,7 +46,7 @@ StageResult HistoryIndex::forward(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(target_progress),
@@ -124,7 +124,7 @@ StageResult HistoryIndex::unwind(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(to),
@@ -191,7 +191,7 @@ StageResult HistoryIndex::prune(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),
                        "to", std::to_string(forward_progress),
@@ -460,8 +460,8 @@ std::map<Bytes, bool> HistoryIndex::collect_unique_keys_from_changeset(
 }
 
 std::vector<std::string> HistoryIndex::get_log_progress() {
-    std::vector<std::string> ret{};
     std::unique_lock log_lck(sl_mutex_);
+    std::vector<std::string> ret{"op", std::string(magic_enum::enum_name<OperationType>(operation_))};
     if (current_source_.empty() && current_target_.empty()) {
         ret.insert(ret.end(), {"db", "waiting ..."});
     } else {
@@ -499,7 +499,6 @@ std::vector<std::string> HistoryIndex::get_log_progress() {
 
 void HistoryIndex::reset_log_progress() {
     std::unique_lock log_lck(sl_mutex_);
-    operation_ = OperationType::None;
     loading_ = false;
     current_source_.clear();
     current_target_.clear();

--- a/node/silkworm/stagedsync/stage_history_index.hpp
+++ b/node/silkworm/stagedsync/stage_history_index.hpp
@@ -23,11 +23,12 @@ namespace silkworm::stagedsync {
 
 class HistoryIndex : public IStage {
   public:
-    explicit HistoryIndex(NodeSettings* node_settings) : IStage(db::stages::kHistoryIndexKey, node_settings){};
+    explicit HistoryIndex(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kHistoryIndexKey, node_settings){};
     ~HistoryIndex() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -113,8 +113,12 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
     return ret;
 }
 
-StageResult InterHashes::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult InterHashes::unwind(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
 
     try {

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -20,7 +20,6 @@
 
 #include <absl/container/btree_set.h>
 
-#include <silkworm/common/assert.hpp>
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/lru_cache.hpp>
 #include <silkworm/common/rlp_err.hpp>
@@ -54,7 +53,7 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
         }
 
         BlockNum segment_width{hashstate_stage_progress - previous_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -128,7 +127,7 @@ StageResult InterHashes::unwind(db::RWTxn& txn, BlockNum to) {
         }
 
         BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -584,7 +584,8 @@ void InterHashes::reset_log_progress() {
 
 std::vector<std::string> InterHashes::get_log_progress() {
     std::unique_lock log_lck(log_mtx_);
-    std::vector<std::string> ret{"mode", (incremental_ ? "incr" : "full")};
+    std::vector<std::string> ret{"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                                 "mode", (incremental_ ? "incr" : "full")};
 
     if (trie_loader_) {
         current_key_ = abridge(trie_loader_->get_log_key(), kAddressLength);

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -32,6 +32,7 @@ namespace silkworm::stagedsync {
 
 StageResult InterHashes::forward(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Forward;
 
     try {
         throw_if_stopping();
@@ -41,31 +42,42 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
         auto hashstate_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kHashStateKey)};
         if (previous_progress == hashstate_stage_progress) {
             // Nothing to process
+            operation_ = OperationType::None;
             return StageResult::kSuccess;
         } else if (previous_progress > hashstate_stage_progress) {
             // Something bad had happened. Not possible hashstate stage is ahead of bodies
             // Maybe we need to unwind ?
-            log::Error() << "Bad progress sequence. InterHashes stage progress " << previous_progress
-                         << " while HashState stage " << hashstate_stage_progress;
-            return StageResult::kInvalidProgress;
+            // Something bad had happened.  Maybe we need to unwind ?
+            throw StageError(StageResult::kInvalidProgress,
+                             "InterHashes progress " + std::to_string(previous_progress) +
+                                 " greater than HashState progress " + std::to_string(hashstate_stage_progress));
         }
 
         BlockNum segment_width{hashstate_stage_progress - previous_progress};
-        if (segment_width > 16) {
-            log::Info("Begin " + std::string(stage_name_),
-                      {"from", std::to_string(previous_progress), "to", std::to_string(hashstate_stage_progress)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(hashstate_stage_progress),
+                       "span", std::to_string(segment_width)});
         }
 
         // Retrieve header's state_root at target block to be compared with the one computed here
         auto header_hash{db::read_canonical_header_hash(*txn, hashstate_stage_progress)};
-        SILKWORM_ASSERT(header_hash.has_value());
+        if (!header_hash.has_value()) {
+            throw std::runtime_error("Could not find hash for canonical header " +
+                                     std::to_string(hashstate_stage_progress));
+        }
         auto header{db::read_header(*txn, hashstate_stage_progress, header_hash->bytes)};
-        SILKWORM_ASSERT(header.has_value());
+        if (!header_hash.has_value()) {
+            throw std::runtime_error("Could not find canonical header number " +
+                                     std::to_string(hashstate_stage_progress) +
+                                     " hash " + to_hex(header_hash->bytes, true));
+        }
         auto expected_state_root{header->state_root};
 
         reset_log_progress();
-
-        if (!previous_progress || segment_width > 100'000) {
+        if (!previous_progress || segment_width > db::stages::kLargeSegmentWorthRegen) {
             // Full regeneration
             ret = regenerate_intermediate_hashes(txn, &expected_state_root);
         } else {
@@ -80,49 +92,67 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
         db::stages::write_stage_progress(*txn, db::stages::kIntermediateHashesKey, hashstate_stage_progress);
         txn.commit();
 
+    } catch (const StageError& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
-    } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
-        return static_cast<StageResult>(ex.err());
     } catch (const std::exception& ex) {
-        reset_log_progress();
-        log::Error(std::string(stage_name_), {"exception", std::string(ex.what())});
-        return StageResult::kUnexpectedError;
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kUnexpectedError;
+    } catch (...) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
+        ret = StageResult::kUnexpectedError;
     }
 
+    operation_ = OperationType::None;
     return ret;
 }
 
 StageResult InterHashes::unwind(db::RWTxn& txn, BlockNum to) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Unwind;
+
     try {
         throw_if_stopping();
         BlockNum previous_progress{get_progress(txn)};
         if (to >= previous_progress) {
             // Actually nothing to unwind
+            operation_ = OperationType::None;
             return StageResult::kSuccess;
         }
 
         BlockNum segment_width{previous_progress - to};
-        if (segment_width > 16) {
-            log::Info("Begin " + std::string(stage_name_) + " unwind",
-                      {"from", std::to_string(previous_progress), "to", std::to_string(to)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(to),
+                       "span", std::to_string(segment_width)});
         }
 
         // Retrieve header's state_root at target block to be compared with the one computed here
+        // Retrieve header's state_root at target block to be compared with the one computed here
         auto header_hash{db::read_canonical_header_hash(*txn, to)};
-        SILKWORM_ASSERT(header_hash.has_value());
+        if (!header_hash.has_value()) {
+            throw std::runtime_error("Could not find hash for canonical header " +
+                                     std::to_string(to));
+        }
         auto header{db::read_header(*txn, to, header_hash->bytes)};
-        SILKWORM_ASSERT(header.has_value());
+        if (!header_hash.has_value()) {
+            throw std::runtime_error("Could not find canonical header number " +
+                                     std::to_string(to) +
+                                     " hash " + to_hex(header_hash->bytes, true));
+        }
         auto expected_state_root{header->state_root};
 
         reset_log_progress();
-
-        if (segment_width > 100'000) {
+        if (segment_width > db::stages::kLargeSegmentWorthRegen) {
             // Full regeneration
             // It will process all HashedState which is already unwound
             ret = regenerate_intermediate_hashes(txn, &expected_state_root);
@@ -137,16 +167,25 @@ StageResult InterHashes::unwind(db::RWTxn& txn, BlockNum to) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
-        return static_cast<StageResult>(ex.err());
+        ret = static_cast<StageResult>(ex.err());
+    } catch (const mdbx::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        reset_log_progress();
-        log::Error(std::string(stage_name_), {"exception", std::string(ex.what())});
-        return StageResult::kUnexpectedError;
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kUnexpectedError;
+    } catch (...) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
+        ret = StageResult::kUnexpectedError;
     }
 
-    return StageResult::kSuccess;
+    operation_ = OperationType::None;
+    return ret;
 }
 
 StageResult InterHashes::prune(db::RWTxn&) { return StageResult::kSuccess; }
@@ -288,7 +327,7 @@ trie::PrefixSet InterHashes::collect_account_changes(db::RWTxn& txn, BlockNum fr
 
     if (sw) {
         const auto [_, duration]{sw->stop()};
-        log::Trace("Gathered Account Changes", {"in", StopWatch::format(duration)});
+        log::Trace(log_prefix_ + " gathered account changes", {"in", StopWatch::format(duration)});
     }
     return ret;
 }
@@ -369,7 +408,7 @@ trie::PrefixSet InterHashes::collect_storage_changes(db::RWTxn& txn, BlockNum fr
 
     if (sw) {
         const auto [_, duration]{sw->stop()};
-        log::Trace("Gathered Storage Changes", {"in", StopWatch::format(duration)});
+        log::Trace(log_prefix_ + " gathered storage changes", {"in", StopWatch::format(duration)});
     }
 
     return ret;
@@ -384,9 +423,11 @@ StageResult InterHashes::regenerate_intermediate_hashes(db::RWTxn& txn, const ev
     StageResult ret{StageResult::kSuccess};
 
     try {
-        txn->clear_map(db::table::kTrieOfAccounts.name);  // Clear
-        txn->clear_map(db::table::kTrieOfStorage.name);   // Clear
-        txn.commit();                                     // Will reuse deleted pages
+        log::Info(log_prefix_, {"clearing", db::table::kTrieOfAccounts.name});
+        txn->clear_map(db::table::kTrieOfAccounts.name);
+        log::Info(log_prefix_, {"clearing", db::table::kTrieOfStorage.name});
+        txn->clear_map(db::table::kTrieOfStorage.name);
+        txn.commit();
 
         account_collector_ = std::make_unique<etl::Collector>(node_settings_);
         storage_collector_ = std::make_unique<etl::Collector>(node_settings_);
@@ -408,27 +449,27 @@ StageResult InterHashes::regenerate_intermediate_hashes(db::RWTxn& txn, const ev
             account_collector_.reset();  // Will invoke dtor which causes all flushed files (if any) to be deleted
             storage_collector_.reset();  // Will invoke dtor which causes all flushed files (if any) to be deleted
             log_lck.unlock();
-            log::Error("Wrong trie root",
-                       {"expected", to_hex(*expected_root, true), "got", to_hex(computed_root, true)});
-            return StageResult::kWrongStateRoot;
+            const std::string what{"expected " + to_hex(*expected_root, true) + " got " + to_hex(computed_root, true)};
+            throw StageError(StageResult::kWrongStateRoot, what);
         }
 
         flush_collected_nodes(txn);
 
-    } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
-        ret = StageResult::kDbError;
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
+    } catch (const mdbx::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_), {"function", std::string(__FUNCTION__), "exception", "undefined"});
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
 
@@ -479,20 +520,21 @@ StageResult InterHashes::increment_intermediate_hashes(db::RWTxn& txn, BlockNum 
 
         flush_collected_nodes(txn);
 
-    } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
-        ret = StageResult::kDbError;
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
+    } catch (const mdbx::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_), {"function", std::string(__FUNCTION__), "exception", "undefined"});
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
 
@@ -561,5 +603,4 @@ std::vector<std::string> InterHashes::get_log_progress() {
     }
     return ret;
 }
-
 }  // namespace silkworm::stagedsync

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -84,7 +84,11 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
             ret = increment_intermediate_hashes(txn, previous_progress, hashstate_stage_progress, &expected_state_root);
         }
 
-        // TODO If I return with kWrongStateRoot begin a binary search backwards
+        if (ret == StageResult::kWrongStateRoot) {
+            // Binary search for the correct block, biased to the lower numbers
+            sync_context_->unwind_to.emplace(previous_progress + (segment_width / 2));
+            sync_context_->bad_block_hash.emplace(header_hash.value());
+        }
 
         success_or_throw(ret);
         throw_if_stopping();

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -53,7 +53,7 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
         }
 
         BlockNum segment_width{hashstate_stage_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -76,7 +76,7 @@ StageResult InterHashes::forward(db::RWTxn& txn) {
         auto expected_state_root{header->state_root};
 
         reset_log_progress();
-        if (!previous_progress || segment_width > db::stages::kLargeSegmentWorthRegen) {
+        if (!previous_progress || segment_width > db::stages::kLargeBlockSegmentWorthRegen) {
             // Full regeneration
             ret = regenerate_intermediate_hashes(txn, &expected_state_root);
         } else {
@@ -135,7 +135,7 @@ StageResult InterHashes::unwind(db::RWTxn& txn) {
         }
 
         BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -159,7 +159,7 @@ StageResult InterHashes::unwind(db::RWTxn& txn) {
         auto expected_state_root{header->state_root};
 
         reset_log_progress();
-        if (segment_width > db::stages::kLargeSegmentWorthRegen) {
+        if (segment_width > db::stages::kLargeBlockSegmentWorthRegen) {
             // Full regeneration
             // It will process all HashedState which is already unwound
             ret = regenerate_intermediate_hashes(txn, &expected_state_root);

--- a/node/silkworm/stagedsync/stage_interhashes.hpp
+++ b/node/silkworm/stagedsync/stage_interhashes.hpp
@@ -26,10 +26,11 @@ namespace silkworm::stagedsync {
 
 class InterHashes final : public IStage {
   public:
-    explicit InterHashes(NodeSettings* node_settings) : IStage(db::stages::kIntermediateHashesKey, node_settings){};
+    explicit InterHashes(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kIntermediateHashesKey, node_settings){};
     ~InterHashes() override = default;
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -40,7 +40,7 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -103,7 +103,7 @@ StageResult LogIndex::unwind(db::RWTxn& txn, BlockNum to) {
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -170,7 +170,7 @@ StageResult LogIndex::prune(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -86,8 +86,12 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
     return ret;
 }
 
-StageResult LogIndex::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult LogIndex::unwind(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -40,7 +40,7 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -107,7 +107,7 @@ StageResult LogIndex::unwind(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -174,7 +174,7 @@ StageResult LogIndex::prune(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -20,6 +20,7 @@ namespace silkworm::stagedsync {
 
 StageResult LogIndex::forward(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Forward;
     try {
         throw_if_stopping();
 
@@ -28,6 +29,7 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
         const auto target_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
         if (previous_progress == target_progress) {
             // Nothing to process
+            operation_ = OperationType::None;
             return ret;
         } else if (previous_progress > target_progress) {
             // Something bad had happened.  Maybe we need to unwind ?
@@ -38,11 +40,12 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > 16) {
-            log::Info("Begin " + std::string(stage_name_),
-                      {"op", std::string(magic_enum::enum_name<OperationType>(OperationType::Forward)), "from",
-                       std::to_string(previous_progress), "to", std::to_string(target_progress), "span",
-                       std::to_string(segment_width)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(target_progress),
+                       "span", std::to_string(segment_width)});
         }
 
         // If this is first time we forward AND we have "prune history" set
@@ -60,27 +63,32 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
+    } catch (const mdbx::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
 
+    operation_ = OperationType::None;
     addresses_collector_.reset();
     topics_collector_.reset();
-    operation_ = OperationType::None;
-    return is_stopping() ? StageResult::kAborted : ret;
+    return ret;
 }
 
 StageResult LogIndex::unwind(db::RWTxn& txn, BlockNum to) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();
 
@@ -89,16 +97,18 @@ StageResult LogIndex::unwind(db::RWTxn& txn, BlockNum to) {
         const auto execution_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
         if (previous_progress <= to || execution_stage_progress <= to) {
             // Nothing to process
+            operation_ = OperationType::None;
             return ret;
         }
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > 16) {
-            log::Info(
-                "Begin " + std::string(stage_name_),
-                {"op", std::string(magic_enum::enum_name<OperationType>(OperationType::Unwind)), "from",
-                 std::to_string(previous_progress), "to", std::to_string(to), "span", std::to_string(segment_width)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(to),
+                       "span", std::to_string(segment_width)});
         }
 
         if (previous_progress && previous_progress > to)
@@ -109,19 +119,19 @@ StageResult LogIndex::unwind(db::RWTxn& txn, BlockNum to) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
@@ -129,31 +139,43 @@ StageResult LogIndex::unwind(db::RWTxn& txn, BlockNum to) {
     addresses_collector_.reset();
     topics_collector_.reset();
     operation_ = OperationType::None;
-    return is_stopping() ? StageResult::kAborted : ret;
+    return ret;
 }
 
 StageResult LogIndex::prune(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Prune;
+
     try {
         throw_if_stopping();
-        if (!node_settings_->prune_mode->history().enabled()) return ret;
+        if (!node_settings_->prune_mode->history().enabled()) {
+            operation_ = OperationType::None;
+            return ret;
+        }
 
         const auto forward_progress{get_progress(txn)};
         const auto prune_progress{get_prune_progress(txn)};
-        if (prune_progress >= forward_progress) return ret;
+        if (prune_progress >= forward_progress){
+            operation_ = OperationType::None;
+            return ret;
+        }
 
         // Need to erase all history info below this threshold
         // If threshold is zero we don't have anything to prune
         const auto prune_threshold{node_settings_->prune_mode->history().value_from_head(forward_progress)};
-        if (!prune_threshold) return StageResult::kSuccess;
+        if (!prune_threshold){
+            operation_ = OperationType::None;
+            return ret;
+        }
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > 16) {
-            log::Info("Begin " + std::string(stage_name_),
-                      {"op", std::string(magic_enum::enum_name<OperationType>(OperationType::Prune)), "from",
-                       std::to_string(prune_progress), "to", std::to_string(forward_progress), "span",
-                       std::to_string(segment_width)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(prune_progress),
+                       "to", std::to_string(forward_progress),
+                       "threshold", std::to_string(prune_threshold)});
         }
 
         if (!prune_progress || prune_progress < forward_progress) {
@@ -166,19 +188,19 @@ StageResult LogIndex::prune(db::RWTxn& txn) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -41,7 +41,7 @@ StageResult LogIndex::forward(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(target_progress),
@@ -108,7 +108,7 @@ StageResult LogIndex::unwind(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(to),
@@ -175,7 +175,7 @@ StageResult LogIndex::prune(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),
                        "to", std::to_string(forward_progress),
@@ -452,7 +452,7 @@ void LogIndex::prune_impl(db::RWTxn& txn, BlockNum threshold, const db::MapConfi
 }
 
 std::vector<std::string> LogIndex::get_log_progress() {
-    std::vector<std::string> ret{};
+    std::vector<std::string> ret{"op", std::string(magic_enum::enum_name<OperationType>(operation_))};
     std::unique_lock log_lck(sl_mutex_);
     if (current_source_.empty() && current_target_.empty()) {
         ret.insert(ret.end(), {"db", "waiting ..."});
@@ -496,7 +496,6 @@ std::vector<std::string> LogIndex::get_log_progress() {
 }
 void LogIndex::reset_log_progress() {
     std::unique_lock log_lck(sl_mutex_);
-    operation_ = OperationType::None;
     loading_ = false;
     current_source_.clear();
     current_target_.clear();

--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -155,7 +155,7 @@ StageResult LogIndex::prune(db::RWTxn& txn) {
 
         const auto forward_progress{get_progress(txn)};
         const auto prune_progress{get_prune_progress(txn)};
-        if (prune_progress >= forward_progress){
+        if (prune_progress >= forward_progress) {
             operation_ = OperationType::None;
             return ret;
         }
@@ -163,7 +163,7 @@ StageResult LogIndex::prune(db::RWTxn& txn) {
         // Need to erase all history info below this threshold
         // If threshold is zero we don't have anything to prune
         const auto prune_threshold{node_settings_->prune_mode->history().value_from_head(forward_progress)};
-        if (!prune_threshold){
+        if (!prune_threshold) {
             operation_ = OperationType::None;
             return ret;
         }

--- a/node/silkworm/stagedsync/stage_log_index.hpp
+++ b/node/silkworm/stagedsync/stage_log_index.hpp
@@ -25,11 +25,12 @@ namespace silkworm::stagedsync {
 
 class LogIndex : public IStage {
   public:
-    explicit LogIndex(NodeSettings* node_settings) : IStage(db::stages::kLogIndexKey, node_settings){};
+    explicit LogIndex(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kLogIndexKey, node_settings){};
     ~LogIndex() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -63,7 +63,7 @@ StageResult Senders::unwind(db::RWTxn& txn) {
         }
 
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -155,7 +155,7 @@ StageResult Senders::prune(db::RWTxn& txn) {
         }
 
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -16,6 +16,8 @@
 
 #include "stage_senders.hpp"
 
+#include <silkworm/common/stopwatch.hpp>
+
 namespace silkworm::stagedsync {
 
 StageResult Senders::forward(db::RWTxn& txn) {
@@ -33,35 +35,179 @@ StageResult Senders::forward(db::RWTxn& txn) {
 }
 
 StageResult Senders::unwind(db::RWTxn& txn, BlockNum to) {
-    const StageResult res{recovery::RecoveryFarm::unwind(*txn, to)};
-    if (res == StageResult::kSuccess) {
-        txn.commit();
+    StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Unwind;
+    current_key_.clear();
+
+    using namespace std::chrono_literals;
+    auto log_time{std::chrono::steady_clock::now()};
+    std::unique_ptr<StopWatch> sw;
+    if (log::test_verbosity(log::Level::kTrace)) {
+        sw = std::make_unique<StopWatch>(/*auto_start=*/true);
     }
-    return res;
+
+    try {
+        throw_if_stopping();
+
+        // Check stage boundaries from previous execution and previous stage execution
+        const auto previous_progress{get_progress(txn)};
+        const auto bodies_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockBodiesKey)};
+        if (previous_progress <= to || bodies_stage_progress <= to) {
+            // Nothing to process
+            operation_ = OperationType::None;
+            return ret;
+        }
+
+        const BlockNum segment_width{previous_progress - to};
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(to),
+                       "span", std::to_string(segment_width)});
+        }
+
+        db::Cursor unwind_table(txn, db::table::kSenders);
+        const auto start_key{db::block_key(to + 1)};
+        size_t erased{0};
+        auto data{unwind_table.lower_bound(db::to_slice(start_key), /*throw_notfound=*/false)};
+        while (data) {
+            // Log and abort check
+            if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+                throw_if_stopping();
+                std::unique_lock log_lck(sl_mutex_);
+                const auto reached_block_number{endian::load_big_u64(db::from_slice(data.key).data())};
+                current_key_ = std::to_string(reached_block_number);
+                log_time = now + 5s;
+            }
+            unwind_table.erase();
+            ++erased;
+            data = unwind_table.to_next(/*throw_notfound=*/false);
+        }
+        if (sw) {
+            const auto [_, duration]{sw->lap()};
+            log::Trace(log_prefix_,
+                       {"origin", db::table::kSenders.name,
+                        "erased", std::to_string(erased),
+                        "in", StopWatch::format(duration)});
+        }
+
+        update_progress(txn, to);
+        txn.commit();
+
+    } catch (const StageError& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = static_cast<StageResult>(ex.err());
+    } catch (const mdbx::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
+    } catch (const std::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kUnexpectedError;
+    } catch (...) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
+        ret = StageResult::kUnexpectedError;
+    }
+
+    operation_ = OperationType::None;
+    return ret;
 }
 
 StageResult Senders::prune(db::RWTxn& txn) {
+    StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Prune;
+    current_key_.clear();
+    std::unique_ptr<StopWatch> sw;
+    if (log::test_verbosity(log::Level::kTrace)) {
+        sw = std::make_unique<StopWatch>(/*auto_start=*/true);
+    }
+
+    using namespace std::chrono_literals;
+    auto log_time{std::chrono::steady_clock::now()};
+
     try {
-        auto head_progress{get_progress(txn)};
-        if (node_settings_->prune_mode->senders().enabled()) {
-            auto prune_to_block{node_settings_->prune_mode->senders().value_from_head(head_progress)};
-            if (prune_to_block) {
-                auto upper_key{db::block_key(prune_to_block + 1)};
-                db::Cursor prune_table(txn, db::table::kSenders);
-                db::cursor_erase(prune_table, upper_key, db::CursorMoveDirection::Reverse);
-                db::stages::write_stage_prune_progress(*txn, db::stages::kSendersKey, head_progress);
-                txn.commit();
+        throw_if_stopping();
+        if (!node_settings_->prune_mode->senders().enabled()) {
+            operation_ = OperationType::None;
+            return ret;
+        }
+        const auto forward_progress{get_progress(txn)};
+        const auto prune_progress{get_prune_progress(txn)};
+        if (prune_progress >= forward_progress) {
+            operation_ = OperationType::None;
+            return ret;
+        }
+
+        // Need to erase all history info below this threshold
+        // If threshold is zero we don't have anything to prune
+        const auto prune_threshold{node_settings_->prune_mode->senders().value_from_head(forward_progress)};
+        if (!prune_threshold) {
+            operation_ = OperationType::None;
+            return ret;
+        }
+
+        const BlockNum segment_width{forward_progress - prune_progress};
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(prune_progress),
+                       "to", std::to_string(forward_progress),
+                       "threshold", std::to_string(prune_threshold)});
+        }
+
+        db::Cursor prune_table(txn, db::table::kSenders);
+        const auto upper_key{db::block_key(prune_threshold)};
+        size_t erased{0};
+        if (prune_table.lower_bound(db::to_slice(upper_key))) {
+            auto prune_data{prune_table.to_previous(/*throw_notfound=*/false)};
+            while (prune_data) {
+                // Log and abort check
+                if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+                    throw_if_stopping();
+                    std::unique_lock log_lck(sl_mutex_);
+                    const auto reached_block_number{endian::load_big_u64(db::from_slice(prune_data.key).data())};
+                    current_key_ = std::to_string(reached_block_number);
+                    log_time = now + 5s;
+                }
+
+                prune_table.erase();
+                ++erased;
+                prune_data = prune_table.to_previous(/*throw_notfound=*/false);
             }
         }
-        return StageResult::kSuccess;
 
+        throw_if_stopping();
+        if (sw) {
+            const auto [_, duration]{sw->lap()};
+            log::Trace(log_prefix_, {"source", db::table::kSenders.name, "erased", std::to_string(erased), "in", StopWatch::format(duration)});
+        }
+        db::stages::write_stage_prune_progress(txn, stage_name_, forward_progress);
+        txn.commit();
+
+    } catch (const StageError& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error() << "Unexpected db error in " << std::string(__FUNCTION__) << " : " << ex.what();
-        return StageResult::kDbError;
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
+    } catch (const std::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error() << "Unexpected unknown error in " << std::string(__FUNCTION__);
-        return StageResult::kUnexpectedError;
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
+        ret = StageResult::kUnexpectedError;
     }
+
+    operation_ = OperationType::None;
+    return ret;
 }
 
 bool Senders::stop() {
@@ -72,10 +218,12 @@ bool Senders::stop() {
 }
 
 std::vector<std::string> Senders::get_log_progress() {
-    if (!farm_) {
-        return {};
+    switch (operation_) {
+        case OperationType::Forward:
+            if (farm_) return farm_->get_log_progress();
+        default:
+            return {"key", current_key_};
     }
-    return farm_->get_log_progress();
 }
 
 }  // namespace silkworm::stagedsync

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -25,7 +25,7 @@ StageResult Senders::forward(db::RWTxn& txn) {
         return StageResult::kUnknownChainId;
     }
 
-    farm_ = std::make_unique<recovery::RecoveryFarm>(txn, node_settings_);
+    farm_ = std::make_unique<recovery::RecoveryFarm>(txn, node_settings_, log_prefix_);
     const auto res{farm_->recover()};
     if (res == StageResult::kSuccess) {
         txn.commit();
@@ -64,7 +64,7 @@ StageResult Senders::unwind(db::RWTxn& txn) {
 
         const BlockNum segment_width{previous_progress - to};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(to),
@@ -156,7 +156,7 @@ StageResult Senders::prune(db::RWTxn& txn) {
 
         const BlockNum segment_width{forward_progress - prune_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),
                        "to", std::to_string(forward_progress),

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -34,8 +34,12 @@ StageResult Senders::forward(db::RWTxn& txn) {
     return res;
 }
 
-StageResult Senders::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult Senders::unwind(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
     current_key_.clear();
 

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -224,7 +224,11 @@ bool Senders::stop() {
 std::vector<std::string> Senders::get_log_progress() {
     switch (operation_) {
         case OperationType::Forward:
-            if (farm_) return farm_->get_log_progress();
+            if (farm_) {
+                return farm_->get_log_progress();
+            } else {
+                return {}
+            }
         default:
             return {"key", current_key_};
     }

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -59,7 +59,7 @@ StageResult Senders::unwind(db::RWTxn& txn, BlockNum to) {
         }
 
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -151,7 +151,7 @@ StageResult Senders::prune(db::RWTxn& txn) {
         }
 
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -227,7 +227,7 @@ std::vector<std::string> Senders::get_log_progress() {
             if (farm_) {
                 return farm_->get_log_progress();
             } else {
-                return {}
+                return {};
             }
         default:
             return {"key", current_key_};

--- a/node/silkworm/stagedsync/stage_senders.hpp
+++ b/node/silkworm/stagedsync/stage_senders.hpp
@@ -34,6 +34,9 @@ class Senders final : public IStage {
 
   private:
     std::unique_ptr<recovery::RecoveryFarm> farm_{nullptr};
+
+    // Logging
+    std::string current_key_{};
 };
 
 }  // namespace silkworm::stagedsync

--- a/node/silkworm/stagedsync/stage_senders.hpp
+++ b/node/silkworm/stagedsync/stage_senders.hpp
@@ -23,11 +23,12 @@ namespace silkworm::stagedsync {
 
 class Senders final : public IStage {
   public:
-    explicit Senders(NodeSettings* node_settings) : IStage(db::stages::kSendersKey, node_settings){};
+    explicit Senders(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kSendersKey, node_settings){};
     ~Senders() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
     bool stop() final;

--- a/node/silkworm/stagedsync/stage_senders/recovery_farm.hpp
+++ b/node/silkworm/stagedsync/stage_senders/recovery_farm.hpp
@@ -33,7 +33,7 @@ class RecoveryFarm : public Stoppable {
 
     //! \brief This class coordinates the recovery of senders' addresses through multiple threads. May eventually handle
     //! the unwinding of already recovered addresses.
-    RecoveryFarm(db::RWTxn& txn, NodeSettings* node_settings);
+    RecoveryFarm(db::RWTxn& txn, NodeSettings* node_settings, std::string log_prefix);
     ~RecoveryFarm() = default;
 
     //! \brief Recover sender's addresses from transactions
@@ -98,6 +98,7 @@ class RecoveryFarm : public Stoppable {
 
     db::RWTxn& txn_;               // Managed transaction
     NodeSettings* node_settings_;  // Global node settings
+    std::string log_prefix_;       // For logging purposes
     etl::Collector collector_;     // Reserved collector
 
     /* Recovery workers */

--- a/node/silkworm/stagedsync/stage_senders/recovery_farm.hpp
+++ b/node/silkworm/stagedsync/stage_senders/recovery_farm.hpp
@@ -49,12 +49,6 @@ class RecoveryFarm : public Stoppable {
         return false;
     }
 
-    //! \brief Unwinds sender's recovery i.e. deletes recovered addresses from storage
-    //! \param [in] db_transaction : the database transaction we should work on
-    //! \param [in] new_height : the new height at which senders' addresses will be registered as recovered in storage
-    //! \return A code indicating process status
-    static StageResult unwind(mdbx::txn& db_transaction, BlockNum new_height);
-
     //! \brief Returns a collection of progress strings to be printed in log
     [[nodiscard]] std::vector<std::string> get_log_progress();
 

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -22,6 +22,7 @@ namespace silkworm::stagedsync {
 
 StageResult TxLookup::forward(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Forward;
     try {
         throw_if_stopping();
 
@@ -30,6 +31,7 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
         const auto target_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockBodiesKey)};
         if (previous_progress == target_progress) {
             // Nothing to process
+            operation_ = OperationType::None;
             return ret;
         } else if (previous_progress > target_progress) {
             // Something bad had happened.  Maybe we need to unwind ?
@@ -40,11 +42,12 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > 16) {
-            log::Info("Begin " + std::string(stage_name_),
-                      {"op", std::string(magic_enum::enum_name<OperationType>(OperationType::Forward)), "from",
-                       std::to_string(previous_progress), "to", std::to_string(target_progress), "span",
-                       std::to_string(segment_width)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(target_progress),
+                       "span", std::to_string(segment_width)});
         }
 
         // If this is first time we forward AND we have "prune history" set
@@ -60,27 +63,31 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
+    } catch (const mdbx::exception& ex) {
+        log::Error(log_prefix_,
+                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
 
-    collector_.reset();
     operation_ = OperationType::None;
-    return is_stopping() ? StageResult::kAborted : ret;
+    collector_.reset();
+    return ret;
 }
 
 StageResult TxLookup::unwind(db::RWTxn& txn, BlockNum to) {
     StageResult ret{StageResult::kSuccess};
-
+    operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();
 
@@ -89,16 +96,18 @@ StageResult TxLookup::unwind(db::RWTxn& txn, BlockNum to) {
         const auto bodies_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockBodiesKey)};
         if (previous_progress <= to || bodies_stage_progress <= to) {
             // Nothing to process
+            operation_ = OperationType::None;
             return ret;
         }
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > 16) {
-            log::Info(
-                "Begin " + std::string(stage_name_),
-                {"op", std::string(magic_enum::enum_name<OperationType>(OperationType::Unwind)), "from",
-                 std::to_string(previous_progress), "to", std::to_string(to), "span", std::to_string(segment_width)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(previous_progress),
+                       "to", std::to_string(to),
+                       "span", std::to_string(segment_width)});
         }
 
         if (previous_progress && previous_progress > to)
@@ -109,50 +118,62 @@ StageResult TxLookup::unwind(db::RWTxn& txn, BlockNum to) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
 
-    collector_.reset();
     operation_ = OperationType::None;
-    return is_stopping() ? StageResult::kAborted : ret;
+    collector_.reset();
+    return ret;
 }
 
 StageResult TxLookup::prune(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+    operation_ = OperationType::Prune;
+
     try {
         throw_if_stopping();
-        if (!node_settings_->prune_mode->tx_index().enabled()) return ret;
+        if (!node_settings_->prune_mode->tx_index().enabled()) {
+            operation_ = OperationType::None;
+            return ret;
+        }
 
         const auto forward_progress{get_progress(txn)};
         const auto prune_progress{get_prune_progress(txn)};
-        if (prune_progress >= forward_progress) return ret;
+        if (prune_progress >= forward_progress) {
+            operation_ = OperationType::None;
+            return ret;
+        }
 
         // Need to erase all history info below this threshold
         // If threshold is zero we don't have anything to prune
         const auto prune_threshold{node_settings_->prune_mode->tx_index().value_from_head(forward_progress)};
-        if (!prune_threshold) return StageResult::kSuccess;
+        if (!prune_threshold) {
+            operation_ = OperationType::None;
+            return ret;
+        }
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > 16) {
-            log::Info("Begin " + std::string(stage_name_),
-                      {"op", std::string(magic_enum::enum_name<OperationType>(OperationType::Prune)), "from",
-                       std::to_string(prune_progress), "to", std::to_string(forward_progress), "span",
-                       std::to_string(segment_width)});
+        if (segment_width > kSmallSegmentWidth) {
+            log::Info(log_prefix_ + " begin",
+                      {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
+                       "from", std::to_string(prune_progress),
+                       "to", std::to_string(forward_progress),
+                       "threshold", std::to_string(prune_threshold)});
         }
 
         if (!prune_progress || prune_progress < forward_progress) {
@@ -166,23 +187,24 @@ StageResult TxLookup::prune(db::RWTxn& txn) {
         txn.commit();
 
     } catch (const StageError& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<StageResult>(ex.err());
     } catch (const mdbx::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kDbError;
     } catch (const std::exception& ex) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = StageResult::kUnexpectedError;
     } catch (...) {
-        log::Error(std::string(stage_name_),
+        log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", "unexpected and undefined"});
         ret = StageResult::kUnexpectedError;
     }
 
+    operation_ = OperationType::None;
     return ret;
 }
 

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -43,7 +43,7 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -107,7 +107,7 @@ StageResult TxLookup::unwind(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -173,7 +173,7 @@ StageResult TxLookup::prune(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > db::stages::kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -43,7 +43,7 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(target_progress),
@@ -107,7 +107,7 @@ StageResult TxLookup::unwind(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
                        "to", std::to_string(to),
@@ -173,7 +173,7 @@ StageResult TxLookup::prune(db::RWTxn& txn) {
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
         if (segment_width > db::stages::kSmallSegmentWidth) {
-            log::Info(log_prefix_ + " begin",
+            log::Info(log_prefix_,
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),
                        "to", std::to_string(forward_progress),
@@ -386,7 +386,7 @@ void TxLookup::collect_transaction_hashes_from_bodies(db::RWTxn& txn,
 }
 
 std::vector<std::string> TxLookup::get_log_progress() {
-    std::vector<std::string> ret{};
+    std::vector<std::string> ret{"op", std::string(magic_enum::enum_name<OperationType>(operation_))};
     std::unique_lock log_lck(sl_mutex_);
     if (current_source_.empty() && current_target_.empty()) {
         ret.insert(ret.end(), {"db", "waiting ..."});
@@ -403,7 +403,6 @@ std::vector<std::string> TxLookup::get_log_progress() {
 
 void TxLookup::reset_log_progress() {
     std::unique_lock log_lck(sl_mutex_);
-    operation_ = OperationType::None;
     loading_ = false;
     current_source_.clear();
     current_target_.clear();

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -28,7 +28,7 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         auto previous_progress{get_progress(txn)};
-        const auto target_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockBodiesKey)};
+        const auto target_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
         if (previous_progress == target_progress) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -37,7 +37,7 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
             // Something bad had happened.  Maybe we need to unwind ?
             throw StageError(StageResult::kInvalidProgress,
                              "TxLookup progress " + std::to_string(previous_progress) +
-                                 " greater than BlockBodies progress " + std::to_string(target_progress));
+                                 " greater than Execution progress " + std::to_string(target_progress));
         }
 
         reset_log_progress();

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -85,8 +85,12 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
     return ret;
 }
 
-StageResult TxLookup::unwind(db::RWTxn& txn, BlockNum to) {
+StageResult TxLookup::unwind(db::RWTxn& txn) {
     StageResult ret{StageResult::kSuccess};
+
+    if (!sync_context_->unwind_to.has_value()) return ret;
+    const BlockNum to{sync_context_->unwind_to.value()};
+
     operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -333,6 +333,7 @@ void TxLookup::collect_transaction_hashes_from_canonical_bodies(db::RWTxn& txn,
     while (canonical_data) {
         reached_block_number = endian::load_big_u64(static_cast<const uint8_t*>(canonical_data.key.data()));
         check_block_sequence(reached_block_number, expected_block_number);
+        if (reached_block_number > max_block_number) break;
 
         // Log and abort check
         if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -42,7 +42,7 @@ StageResult TxLookup::forward(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -102,7 +102,7 @@ StageResult TxLookup::unwind(db::RWTxn& txn, BlockNum to) {
 
         reset_log_progress();
         const BlockNum segment_width{previous_progress - to};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(previous_progress),
@@ -168,7 +168,7 @@ StageResult TxLookup::prune(db::RWTxn& txn) {
 
         reset_log_progress();
         const BlockNum segment_width{forward_progress - prune_progress};
-        if (segment_width > kSmallSegmentWidth) {
+        if (segment_width > db::stages::kSmallSegmentWidth) {
             log::Info(log_prefix_ + " begin",
                       {"op", std::string(magic_enum::enum_name<OperationType>(operation_)),
                        "from", std::to_string(prune_progress),

--- a/node/silkworm/stagedsync/stage_tx_lookup.hpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.hpp
@@ -46,9 +46,8 @@ class TxLookup : public IStage {
 
     void reset_log_progress();  // Clears out all logging vars
 
-    void collect_transaction_hashes_from_bodies(db::RWTxn& txn,
-                                                const db::MapConfig& source_config,
-                                                BlockNum from, BlockNum to,
-                                                bool for_deletion);
+    void collect_transaction_hashes_from_canonical_bodies(db::RWTxn& txn,
+                                                          BlockNum from, BlockNum to,
+                                                          bool for_deletion);
 };
 }  // namespace silkworm::stagedsync

--- a/node/silkworm/stagedsync/stage_tx_lookup.hpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.hpp
@@ -23,11 +23,12 @@ namespace silkworm::stagedsync {
 
 class TxLookup : public IStage {
   public:
-    explicit TxLookup(NodeSettings* node_settings) : IStage(db::stages::kTxLookupKey, node_settings){};
+    explicit TxLookup(NodeSettings* node_settings, SyncContext* sync_context)
+        : IStage(sync_context, db::stages::kTxLookupKey, node_settings){};
     ~TxLookup() override = default;
 
     StageResult forward(db::RWTxn& txn) final;
-    StageResult unwind(db::RWTxn& txn, BlockNum to) final;
+    StageResult unwind(db::RWTxn& txn) final;
     StageResult prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
 

--- a/node/silkworm/stagedsync/sync_loop.cpp
+++ b/node/silkworm/stagedsync/sync_loop.cpp
@@ -50,15 +50,24 @@ void SyncLoop::load_stages() {
      * 15 StageFinish -> stagedsync::Finish
      */
 
-    stages_.emplace(db::stages::kBlockHashesKey, std::make_unique<stagedsync::BlockHashes>(node_settings_));
-    stages_.emplace(db::stages::kSendersKey, std::make_unique<stagedsync::Senders>(node_settings_));
-    stages_.emplace(db::stages::kExecutionKey, std::make_unique<stagedsync::Execution>(node_settings_));
-    stages_.emplace(db::stages::kHashStateKey, std::make_unique<stagedsync::HashState>(node_settings_));
-    stages_.emplace(db::stages::kIntermediateHashesKey, std::make_unique<stagedsync::InterHashes>(node_settings_));
-    stages_.emplace(db::stages::kHistoryIndexKey, std::make_unique<stagedsync::HistoryIndex>(node_settings_));
-    stages_.emplace(db::stages::kLogIndexKey, std::make_unique<stagedsync::LogIndex>(node_settings_));
-    stages_.emplace(db::stages::kTxLookupKey, std::make_unique<stagedsync::TxLookup>(node_settings_));
-    stages_.emplace(db::stages::kFinishKey, std::make_unique<stagedsync::Finish>(node_settings_));
+    stages_.emplace(db::stages::kBlockHashesKey,
+                    std::make_unique<stagedsync::BlockHashes>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kSendersKey,
+                    std::make_unique<stagedsync::Senders>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kExecutionKey,
+                    std::make_unique<stagedsync::Execution>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kHashStateKey,
+                    std::make_unique<stagedsync::HashState>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kIntermediateHashesKey,
+                    std::make_unique<stagedsync::InterHashes>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kHistoryIndexKey,
+                    std::make_unique<stagedsync::HistoryIndex>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kLogIndexKey,
+                    std::make_unique<stagedsync::LogIndex>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kTxLookupKey,
+                    std::make_unique<stagedsync::TxLookup>(node_settings_, sync_context_.get()));
+    stages_.emplace(db::stages::kFinishKey,
+                    std::make_unique<stagedsync::Finish>(node_settings_, sync_context_.get()));
     current_stage_ = stages_.begin();
 
     stages_forward_order_.insert(stages_forward_order_.begin(),

--- a/node/silkworm/stagedsync/sync_loop.cpp
+++ b/node/silkworm/stagedsync/sync_loop.cpp
@@ -157,11 +157,11 @@ void SyncLoop::work() {
                 // A single commit at the end of the cycle
                 external_txn = chaindata_env_->start_write();
                 cycle_txn = std::make_unique<db::RWTxn>(external_txn);
-                log::Trace("SyncLoop", {"db transactions", "per cycle"});
+                log::Trace("SyncLoop", {"MDBX tx", "per cycle"});
             } else {
                 // Single stages will commit
                 cycle_txn = std::make_unique<db::RWTxn>(*chaindata_env_);
-                log::Trace("SyncLoop", {"db transactions", "per stage"});
+                log::Trace("SyncLoop", {"MDBX tx", "per stage"});
             }
 
             // Run forward

--- a/node/silkworm/stagedsync/sync_loop.hpp
+++ b/node/silkworm/stagedsync/sync_loop.hpp
@@ -52,8 +52,14 @@ class SyncLoop final : public Worker {
     void work() final;   // The loop itself
     void load_stages();  // Fills the vector with stages
 
-    //! \brief Runs a full sync cycle
+    //! \brief Runs a full forward cycle
     [[nodiscard]] StageResult run_cycle_forward(db::RWTxn& cycle_txn, Timer& log_timer);
+
+    //! \brief Runs a full unwind cycle
+    [[nodiscard]] StageResult run_cycle_unwind(db::RWTxn& cycle_txn, Timer& log_timer);
+
+    //! \brief Runs a full prune cycle
+    [[nodiscard]] StageResult run_cycle_prune(db::RWTxn& cycle_txn, Timer& log_timer);
 
     void throttle_next_cycle(const StopWatch::Duration& cycle_duration);  // Delays (if required) next cycle run
     std::string get_log_prefix() const;                                   // Returns the current log lines prefix on behalf of current stage


### PR DESCRIPTION
- logging and checks fixes
- log_prefix passed across stages
- sync_context injection
- implemented logic for unwind and prune
- txLookup to index transactions from canonical blocks only
- txLookup's pruning in range (avoid traversing the whole table which is huge)

It may still miss some naive optimizations but it was rushed a bit to allow plugging of downloader.
Tested on my machine with blocks downloaded from Erigon stable and handles properly uniwnd due to reorgs.
