### PR TITLE
Simplify signature of WalkFunc

### DIFF
--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -263,7 +263,7 @@ dbTablesInfo get_tablesInfo(::mdbx::txn& txn) {
     ret.size += table->size();
     ret.tables.push_back(*table);
 
-    const auto collect_func{[&ret, &txn](ByteView key, ByteView) {
+    const auto& collect_func{[&ret, &txn](ByteView key, ByteView) {
         auto named_map{txn.open_map(byte_ptr_cast(key.data()))};
         auto stat2{txn.get_map_stat(named_map)};
         auto info2{txn.get_handle_info(named_map)};

--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -32,6 +32,7 @@
 #include <silkworm/chain/genesis.hpp>
 #include <silkworm/common/as_range.hpp>
 #include <silkworm/common/assert.hpp>
+#include <silkworm/common/cast.hpp>
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/log.hpp>
@@ -219,16 +220,15 @@ dbFreeInfo get_freeInfo(::mdbx::txn& txn) {
     ::mdbx::map_handle free_map{0};
     auto page_size{txn.get_map_stat(free_map).ms_psize};
 
-    const auto& collect_func{[&ret, &page_size](const ::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
+    const auto& collect_func{[&ret, &page_size](ByteView key, ByteView value) {
         size_t txId;
-        std::memcpy(&txId, data.key.data(), sizeof(size_t));
+        std::memcpy(&txId, key.data(), sizeof(size_t));
         uint32_t pagesCount;
-        std::memcpy(&pagesCount, data.value.data(), sizeof(uint32_t));
+        std::memcpy(&pagesCount, value.data(), sizeof(uint32_t));
         size_t pagesSize = pagesCount * page_size;
         ret.pages += pagesCount;
         ret.size += pagesSize;
         ret.entries.push_back({txId, pagesCount, pagesSize});
-        return true;
     }};
 
     auto free_crs{txn.open_cursor(free_map)};
@@ -263,23 +263,21 @@ dbTablesInfo get_tablesInfo(::mdbx::txn& txn) {
     ret.size += table->size();
     ret.tables.push_back(*table);
 
-    const auto& collect_func{[&ret, &txn](const ::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
-        auto named_map{txn.open_map(data.key.as_string())};
+    const auto collect_func{[&ret, &txn](ByteView key, ByteView) {
+        auto named_map{txn.open_map(byte_ptr_cast(key.data()))};
         auto stat2{txn.get_map_stat(named_map)};
         auto info2{txn.get_handle_info(named_map)};
-        auto* table2 = new dbTableEntry{named_map.dbi, data.key.as_string(), stat2, info2};
+        auto* table2 = new dbTableEntry{named_map.dbi, std::string{byte_view_to_string_view(key)}, stat2, info2};
 
         ret.pageSize += table2->stat.ms_psize;
         ret.pages += table2->pages();
         ret.size += table2->size();
         ret.tables.push_back(*table2);
-
-        return true;
     }};
 
     // Get all tables from the unnamed database
     auto main_crs{txn.open_cursor(main_map)};
-    (void)db::cursor_for_each(main_crs, collect_func);
+    db::cursor_for_each(main_crs, collect_func);
     return ret;
 }
 
@@ -889,9 +887,9 @@ void do_first_byte_analysis(db::EnvConfig& config) {
 
     code_cursor.to_first();
     db::cursor_for_each(code_cursor,
-                        [&histogram, &batch_size, &progress](const ::mdbx::cursor&, mdbx::cursor::move_result& entry) {
-                            if (entry.value.length() > 0) {
-                                uint8_t first_byte{entry.value.at(0)};
+                        [&histogram, &batch_size, &progress](ByteView, ByteView value) {
+                            if (value.length() > 0) {
+                                uint8_t first_byte{value.at(0)};
                                 ++histogram[first_byte];
                             }
                             if (!--batch_size) {
@@ -899,7 +897,6 @@ void do_first_byte_analysis(db::EnvConfig& config) {
                                 std::cout << progress.print_interval('.') << std::flush;
                                 batch_size = progress.get_increment_count();
                             }
-                            return true;
                         });
 
     BlockNum last_block{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
@@ -1005,14 +1002,13 @@ void do_trie_account_analysis(db::EnvConfig& config) {
 
     code_cursor.to_first();
     db::cursor_for_each(code_cursor,
-                        [&histogram, &batch_size, &progress](const ::mdbx::cursor&, mdbx::cursor::move_result& entry) {
-                            ++histogram[entry.key.length()];
+                        [&histogram, &batch_size, &progress](ByteView key, ByteView) {
+                            ++histogram[key.length()];
                             if (!--batch_size) {
                                 progress.set_current(progress.get_current() + progress.get_increment_count());
                                 std::cout << progress.print_interval('.') << std::flush;
                                 batch_size = progress.get_increment_count();
                             }
-                            return true;
                         });
 
     progress.set_current(total_entries);

--- a/core/silkworm/common/cast.hpp
+++ b/core/silkworm/common/cast.hpp
@@ -43,6 +43,8 @@ bit_cast(const From& src) noexcept {
     return dst;
 }
 
-inline ByteView string_view_to_byte_view(std::string_view sv) { return {byte_ptr_cast(sv.data()), sv.length()}; }
+inline ByteView string_view_to_byte_view(std::string_view v) { return {byte_ptr_cast(v.data()), v.length()}; }
+
+inline std::string_view byte_view_to_string_view(ByteView v) { return {byte_ptr_cast(v.data()), v.length()}; }
 
 }  // namespace silkworm

--- a/node/silkworm/db/access_layer_test.cpp
+++ b/node/silkworm/db/access_layer_test.cpp
@@ -135,7 +135,7 @@ namespace db {
         auto main_crs{txn.open_cursor(main_map)};
         std::vector<std::string> table_names{};
 
-        const db::WalkFunc walk_func{[&table_names](ByteView key, ByteView) {
+        const auto walk_func{[&table_names](ByteView key, ByteView) {
             table_names.push_back(byte_ptr_cast(key.data()));
         }};
 

--- a/node/silkworm/db/access_layer_test.cpp
+++ b/node/silkworm/db/access_layer_test.cpp
@@ -134,9 +134,8 @@ namespace db {
         auto main_crs{txn.open_cursor(main_map)};
         std::vector<std::string> table_names{};
 
-        const db::WalkFunc walk_func{[&table_names](::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
+        const db::WalkFunc walk_func{[&table_names](::mdbx::cursor&, ::mdbx::cursor::move_result& data) {
             table_names.push_back(data.key.as_string());
-            return true;
         }};
 
         main_crs.to_first();

--- a/node/silkworm/db/access_layer_test.cpp
+++ b/node/silkworm/db/access_layer_test.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/chain/genesis.hpp>
 #include <silkworm/chain/protocol_param.hpp>
+#include <silkworm/common/cast.hpp>
 #include <silkworm/common/test_context.hpp>
 #include <silkworm/common/test_util.hpp>
 #include <silkworm/db/buffer.hpp>
@@ -134,8 +135,8 @@ namespace db {
         auto main_crs{txn.open_cursor(main_map)};
         std::vector<std::string> table_names{};
 
-        const db::WalkFunc walk_func{[&table_names](::mdbx::cursor&, ::mdbx::cursor::move_result& data) {
-            table_names.push_back(data.key.as_string());
+        const db::WalkFunc walk_func{[&table_names](ByteView key, ByteView) {
+            table_names.push_back(byte_ptr_cast(key.data()));
         }};
 
         main_crs.to_first();

--- a/node/silkworm/db/bitmap.cpp
+++ b/node/silkworm/db/bitmap.cpp
@@ -84,7 +84,7 @@ void IndexLoader::unwind_bitmaps(RWTxn& txn, BlockNum to, const std::map<Bytes, 
         if (created) {
             // Key was created in the batch we're unwinding
             // Delete all its history
-            db::cursor_for_prefix(target, db::to_slice(key), db::walk_erase);
+            db::cursor_erase_prefix(target, key);
             continue;
         }
 

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -280,7 +280,7 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const Cur
     return ret;
 }
 
-size_t cursor_for_prefix(::mdbx::cursor& cursor, ::mdbx::slice prefix, const WalkFunc& walker,
+size_t cursor_for_prefix(::mdbx::cursor& cursor, const ByteView prefix, const WalkFunc& walker,
                          CursorMoveDirection direction) {
     const mdbx::cursor::move_operation move_operation{direction == CursorMoveDirection::Forward
                                                           ? mdbx::cursor::move_operation::next

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -34,10 +34,10 @@ static inline ::mdbx::cursor::move_result adjust_cursor_position_if_unpositioned
     return c.current(/*throw_notfound=*/false);
 }
 
-// Last entry whose key is strictly less than the key
+// Last entry whose key is strictly less than the given key
 static inline mdbx::cursor::move_result strict_lower_bound(mdbx::cursor& cursor, const ByteView key) {
     if (!cursor.lower_bound(key, /*throw_notfound=*/false)) {
-        // all DB keys are less than the key
+        // all DB keys are less than the given key
         return cursor.to_last(/*throw_notfound=*/false);
     }
     // return lower_bound - 1

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -272,7 +272,7 @@ bool has_map(::mdbx::txn& tx, const char* map_name) {
     }
 }
 
-size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const CursorMoveDirection direction) {
+size_t cursor_for_each(::mdbx::cursor& cursor, WalkFuncRef walker, const CursorMoveDirection direction) {
     size_t ret{0};
     auto data{adjust_cursor_position_if_unpositioned(cursor, direction)};
     while (data) {
@@ -283,7 +283,7 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const Cur
     return ret;
 }
 
-size_t cursor_for_prefix(::mdbx::cursor& cursor, const ByteView prefix, const WalkFunc& walker,
+size_t cursor_for_prefix(::mdbx::cursor& cursor, const ByteView prefix, WalkFuncRef walker,
                          CursorMoveDirection direction) {
     size_t ret{0};
     auto data{cursor.lower_bound(prefix, false)};
@@ -312,7 +312,7 @@ size_t cursor_erase_prefix(::mdbx::cursor& cursor, const ByteView prefix) {
     return ret;
 }
 
-size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& walker, size_t count,
+size_t cursor_for_count(::mdbx::cursor& cursor, WalkFuncRef walker, size_t count,
                         const CursorMoveDirection direction) {
     size_t ret{0};
     auto data{adjust_cursor_position_if_unpositioned(cursor, direction)};

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -24,7 +24,7 @@ namespace detail {
     //! provided direction if the cursor is not positioned.
     //! \param [in] c : A reference to an open cursor
     //! \param [in] d : Direction cursor should have \return ::mdbx::cursor::move_result
-    static inline ::mdbx::cursor::move_result adjust_cursor_position_if_unpositioned_and_return_data(
+    static inline ::mdbx::cursor::move_result adjust_cursor_position_if_unpositioned(
         ::mdbx::cursor& c, CursorMoveDirection d) {
         // Warning: eof() is not exactly what we need here since it returns true not only for cursors
         // that are not positioned, but also for those pointing to the end of data.
@@ -276,7 +276,7 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const Cur
                                                           : mdbx::cursor::move_operation::previous};
 
     size_t ret{0};
-    auto data{detail::adjust_cursor_position_if_unpositioned_and_return_data(cursor, direction)};
+    auto data{detail::adjust_cursor_position_if_unpositioned(cursor, direction)};
     while (data) {
         ++ret;
         walker(cursor, data);
@@ -323,7 +323,7 @@ size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& walker, size_t c
                                                           ? mdbx::cursor::move_operation::next
                                                           : mdbx::cursor::move_operation::previous};
     size_t ret{0};
-    auto data{detail::adjust_cursor_position_if_unpositioned_and_return_data(cursor, direction)};
+    auto data{detail::adjust_cursor_position_if_unpositioned(cursor, direction)};
     while (count && data) {
         ++ret;
         --count;

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -274,9 +274,7 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const Cur
     auto data{detail::adjust_cursor_position_if_unpositioned_and_return_data(cursor, direction)};
     while (data.done) {
         ++ret;
-        if (!walker(cursor, data)) {
-            break;  // Walker function has returned false hence stop
-        }
+        walker(cursor, data);
         data = cursor.move(move_operation, /*throw_notfound=*/false);
     }
     return ret;
@@ -294,9 +292,7 @@ size_t cursor_for_prefix(::mdbx::cursor& cursor, ::mdbx::slice prefix, const Wal
             break;
         }
         ++ret;
-        if (!walker(cursor, data)) {
-            break;  // Walker function has returned false hence stop
-        }
+        walker(cursor, data);
         data = cursor.move(move_operation, /*throw_notfound=*/false);
     }
     return ret;
@@ -312,9 +308,7 @@ size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& walker, size_t c
     while (count && data.done) {
         ++ret;
         --count;
-        if (!walker(cursor, data)) {
-            break;  // Walker function has returned false hence stop
-        }
+        walker(cursor, data);
         data = cursor.move(move_operation, /*throw_notfound=*/false);
     }
     return ret;

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -277,7 +277,7 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const Cur
 
     size_t ret{0};
     auto data{detail::adjust_cursor_position_if_unpositioned_and_return_data(cursor, direction)};
-    while (data.done) {
+    while (data) {
         ++ret;
         walker(cursor, data);
         data = cursor.move(move_operation, /*throw_notfound=*/false);
@@ -292,7 +292,7 @@ size_t cursor_for_prefix(::mdbx::cursor& cursor, const ByteView prefix, const Wa
                                                           : mdbx::cursor::move_operation::previous};
     size_t ret{0};
     auto data{cursor.lower_bound(prefix, false)};
-    while (data.done) {
+    while (data) {
         if (!data.key.starts_with(prefix)) {
             break;
         }
@@ -306,7 +306,7 @@ size_t cursor_for_prefix(::mdbx::cursor& cursor, const ByteView prefix, const Wa
 size_t cursor_erase_prefix(::mdbx::cursor& cursor, const ByteView prefix) {
     size_t ret{0};
     auto data{cursor.lower_bound(prefix, /*throw_notfound=*/false)};
-    while (data.done) {
+    while (data) {
         if (!data.key.starts_with(prefix)) {
             break;
         }
@@ -324,7 +324,7 @@ size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& walker, size_t c
                                                           : mdbx::cursor::move_operation::previous};
     size_t ret{0};
     auto data{detail::adjust_cursor_position_if_unpositioned_and_return_data(cursor, direction)};
-    while (count && data.done) {
+    while (count && data) {
         ++ret;
         --count;
         walker(cursor, data);

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -277,7 +277,7 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& walker, const Cur
     auto data{adjust_cursor_position_if_unpositioned(cursor, direction)};
     while (data) {
         ++ret;
-        walker(cursor, data);
+        walker(from_slice(data.key), from_slice(data.value));
         data = cursor.move(move_operation(direction), /*throw_notfound=*/false);
     }
     return ret;
@@ -292,7 +292,7 @@ size_t cursor_for_prefix(::mdbx::cursor& cursor, const ByteView prefix, const Wa
             break;
         }
         ++ret;
-        walker(cursor, data);
+        walker(from_slice(data.key), from_slice(data.value));
         data = cursor.move(move_operation(direction), /*throw_notfound=*/false);
     }
     return ret;
@@ -319,7 +319,7 @@ size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& walker, size_t c
     while (count && data) {
         ++ret;
         --count;
-        walker(cursor, data);
+        walker(from_slice(data.key), from_slice(data.value));
         data = cursor.move(move_operation(direction), /*throw_notfound=*/false);
     }
     return ret;

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -138,9 +138,7 @@ class RWAccess : public ROAccess {
 };
 
 //! \brief Pointer to a processing function invoked by cursor_for_each & cursor_for_count on each record
-//! \param [in] _cursor : A reference to the cursor
-//! \param [in] _data : The result of recent move operation on the cursor
-using WalkFunc = std::function<void(::mdbx::cursor& cursor, ::mdbx::cursor::move_result& data)>;
+using WalkFunc = std::function<void(ByteView key, ByteView value)>;
 
 //! \brief Essential environment settings
 struct EnvConfig {

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -28,6 +28,8 @@
 #include <mdbx.h++>
 #pragma GCC diagnostic pop
 
+#include <absl/functional/function_ref.h>
+
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/object_pool.hpp>
 #include <silkworm/common/util.hpp>
@@ -137,8 +139,8 @@ class RWAccess : public ROAccess {
     RWTxn start_rw_tx() { return RWTxn(env_); }
 };
 
-//! \brief Pointer to a processing function invoked by cursor_for_each & cursor_for_count on each record
-using WalkFunc = std::function<void(ByteView key, ByteView value)>;
+//! \brief Reference to a processing function invoked by cursor_for_each & cursor_for_count on each record
+using WalkFuncRef = absl::FunctionRef<void(ByteView key, ByteView value)>;
 
 //! \brief Essential environment settings
 struct EnvConfig {
@@ -261,28 +263,28 @@ enum class CursorMoveDirection {
 
 //! \brief Executes a function on each record reachable by the provided cursor
 //! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] func : A pointer to a std::function with the code to execute on records. Note the return value of the
+//! \param [in] func : A reference to a function with the code to execute on records. Note the return value of the
 //! function may stop the loop
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
 //! \return The overall number of processed records
 //! \remarks If the provided cursor is *not* positioned on any record it will be moved to either the beginning or the
 //! end of the table on behalf of the move criteria
-size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& func,
+size_t cursor_for_each(::mdbx::cursor& cursor, WalkFuncRef func,
                        CursorMoveDirection direction = CursorMoveDirection::Forward);
 
 //! \brief Executes a function on each record reachable by the provided cursor asserting keys start with provided prefix
 //! \param [in] cursor : A reference to a cursor opened on a map
 //! \param [in] prefix : The prefix each key must start with
-//! \param [in] func : A pointer to a std::function with the code to execute on records. Note the return value of the
+//! \param [in] func : A reference to a function with the code to execute on records. Note the return value of the
 //! function may stop the loop
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
 //! \return The overall number of processed records
-size_t cursor_for_prefix(::mdbx::cursor& cursor, ByteView prefix, const WalkFunc& func,
+size_t cursor_for_prefix(::mdbx::cursor& cursor, ByteView prefix, WalkFuncRef func,
                          CursorMoveDirection direction = CursorMoveDirection::Forward);
 
 //! \brief Executes a function on each record reachable by the provided cursor up to a max number of iterations
 //! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] func : A pointer to a std::function with the code to execute on records. Note the return value of the
+//! \param [in] func : A reference to a function with the code to execute on records. Note the return value of the
 //! function may stop the loop
 //! \param [in] max_count : Max number of iterations
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
@@ -290,7 +292,7 @@ size_t cursor_for_prefix(::mdbx::cursor& cursor, ByteView prefix, const WalkFunc
 //! reached either the end or the beginning of table earlier
 //! \remarks If the provided cursor is *not* positioned on any record it will be moved to either the beginning or the
 //! end of the table on behalf of the move criteria
-size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& func, size_t max_count,
+size_t cursor_for_count(::mdbx::cursor& cursor, WalkFuncRef func, size_t max_count,
                         CursorMoveDirection direction = CursorMoveDirection::Forward);
 
 //! \brief Erases map records by cursor until any record is found

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -140,12 +140,11 @@ class RWAccess : public ROAccess {
 //! \brief Pointer to a processing function invoked by cursor_for_each & cursor_for_count on each record
 //! \param [in] _cursor : A reference to the cursor
 //! \param [in] _data : The result of recent move operation on the cursor
-//! \remarks Return value signals whether the loop should continue on next record
-using WalkFunc = std::function<bool(::mdbx::cursor& cursor, ::mdbx::cursor::move_result& data)>;
+using WalkFunc = std::function<void(::mdbx::cursor& cursor, ::mdbx::cursor::move_result& data)>;
 
 //! \brief Convenience function to erase records of cursor
-static const WalkFunc walk_erase{[](::mdbx::cursor& cursor, ::mdbx::cursor::move_result&) -> bool {
-    return cursor.erase();
+static const WalkFunc walk_erase{[](::mdbx::cursor& cursor, ::mdbx::cursor::move_result&) {
+    cursor.erase();
 }};
 
 //! \brief Essential environment settings

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -274,12 +274,12 @@ size_t cursor_for_each(::mdbx::cursor& cursor, const WalkFunc& func,
 
 //! \brief Executes a function on each record reachable by the provided cursor asserting keys start with provided prefix
 //! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] prefix : The slice each key must start with
+//! \param [in] prefix : The prefix each key must start with
 //! \param [in] func : A pointer to a std::function with the code to execute on records. Note the return value of the
 //! function may stop the loop
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
 //! \return The overall number of processed records
-size_t cursor_for_prefix(::mdbx::cursor& cursor, ::mdbx::slice prefix, const WalkFunc& func,
+size_t cursor_for_prefix(::mdbx::cursor& cursor, ByteView prefix, const WalkFunc& func,
                          CursorMoveDirection direction = CursorMoveDirection::Forward);
 
 //! \brief Executes a function on each record reachable by the provided cursor up to a max number of iterations

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -142,11 +142,6 @@ class RWAccess : public ROAccess {
 //! \param [in] _data : The result of recent move operation on the cursor
 using WalkFunc = std::function<void(::mdbx::cursor& cursor, ::mdbx::cursor::move_result& data)>;
 
-//! \brief Convenience function to erase records of cursor
-static const WalkFunc walk_erase{[](::mdbx::cursor& cursor, ::mdbx::cursor::move_result&) {
-    cursor.erase();
-}};
-
 //! \brief Essential environment settings
 struct EnvConfig {
     std::string path{};
@@ -316,7 +311,7 @@ size_t cursor_erase(::mdbx::cursor& cursor, CursorMoveDirection direction = Curs
 //! \return The overall number of erased records
 //! \remarks When direction is forward all keys greater equal set_key will be deleted. When direction is reverse all
 //! keys lower than set_key will be deleted.
-size_t cursor_erase(::mdbx::cursor& cursor, const silkworm::ByteView& set_key,
+size_t cursor_erase(::mdbx::cursor& cursor, ByteView set_key,
                     CursorMoveDirection direction = CursorMoveDirection::Forward);
 
 //! \brief Erases map records by cursor until any record is found or max_count of deletions is reached
@@ -336,7 +331,12 @@ size_t cursor_erase(::mdbx::cursor& cursor, size_t max_count,
 //! \return The overall number of erased records
 //! \remarks When direction is forward all keys greater equal set_key will be deleted. When direction is reverse all
 //! keys lower than set_key will be deleted.
-size_t cursor_erase(::mdbx::cursor& cursor, const silkworm::ByteView& set_key, size_t max_count,
+size_t cursor_erase(::mdbx::cursor& cursor, ByteView set_key, size_t max_count,
                     CursorMoveDirection direction = CursorMoveDirection::Forward);
+
+//! \brief Erases all records whose key starts with a prefix
+//! \param [in] cursor : A reference to a cursor opened on a map
+//! \param [in] prefix : Delete keys starting with this prefix
+size_t cursor_erase_prefix(mdbx::cursor& cursor, ByteView prefix);
 
 }  // namespace silkworm::db

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -297,15 +297,6 @@ size_t cursor_for_count(::mdbx::cursor& cursor, const WalkFunc& func, size_t max
 
 //! \brief Erases map records by cursor until any record is found
 //! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
-//! \return The overall number of erased records
-//! \remarks If the provided cursor is *not* positioned on any record it will be moved to either the beginning or the
-//! end of the table on behalf of the move criteria.
-//! \warning Might nuke all your table records if not used properly
-size_t cursor_erase(::mdbx::cursor& cursor, CursorMoveDirection direction = CursorMoveDirection::Forward);
-
-//! \brief Erases map records by cursor until any record is found
-//! \param [in] cursor : A reference to a cursor opened on a map
 //! \param [in] set_key : A reference to a key where to set the cursor.
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards.
 //! \return The overall number of erased records
@@ -314,29 +305,9 @@ size_t cursor_erase(::mdbx::cursor& cursor, CursorMoveDirection direction = Curs
 size_t cursor_erase(::mdbx::cursor& cursor, ByteView set_key,
                     CursorMoveDirection direction = CursorMoveDirection::Forward);
 
-//! \brief Erases map records by cursor until any record is found or max_count of deletions is reached
-//! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] max_count : Max number of deletions
-//! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
-//! \return The overall number of erased records
-//! \warning Might nuke all your table records if not used properly
-size_t cursor_erase(::mdbx::cursor& cursor, size_t max_count,
-                    CursorMoveDirection direction = CursorMoveDirection::Forward);
-
-//! \brief Erases map records by cursor until any record is found or max_count of deletions is reached
-//! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] set_key : A reference to a key where to set the cursor.
-//! \param [in] max_count : Max number of deletions
-//! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
-//! \return The overall number of erased records
-//! \remarks When direction is forward all keys greater equal set_key will be deleted. When direction is reverse all
-//! keys lower than set_key will be deleted.
-size_t cursor_erase(::mdbx::cursor& cursor, ByteView set_key, size_t max_count,
-                    CursorMoveDirection direction = CursorMoveDirection::Forward);
-
 //! \brief Erases all records whose key starts with a prefix
 //! \param [in] cursor : A reference to a cursor opened on a map
 //! \param [in] prefix : Delete keys starting with this prefix
-size_t cursor_erase_prefix(mdbx::cursor& cursor, ByteView prefix);
+size_t cursor_erase_prefix(::mdbx::cursor& cursor, ByteView prefix);
 
 }  // namespace silkworm::db

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -297,7 +297,7 @@ size_t cursor_for_count(::mdbx::cursor& cursor, WalkFuncRef func, size_t max_cou
 
 //! \brief Erases map records by cursor until any record is found
 //! \param [in] cursor : A reference to a cursor opened on a map
-//! \param [in] set_key : A reference to a key where to set the cursor.
+//! \param [in] set_key : The key where to set the cursor to.
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards.
 //! \return The overall number of erased records
 //! \remarks When direction is forward all keys greater equal set_key will be deleted. When direction is reverse all

--- a/node/silkworm/db/mdbx_test.cpp
+++ b/node/silkworm/db/mdbx_test.cpp
@@ -340,7 +340,7 @@ TEST_CASE("Cursor walk") {
         Bytes prefix{};
         prefix.assign({'A', 'A'});
         auto count{cursor_for_prefix(table_cursor,
-                                     to_slice(prefix),
+                                     prefix,
                                      [](::mdbx::cursor&, ::mdbx::cursor::move_result&) {
                                          // do nothing
                                      })};

--- a/node/silkworm/db/mdbx_test.cpp
+++ b/node/silkworm/db/mdbx_test.cpp
@@ -264,13 +264,13 @@ TEST_CASE("Cursor walk") {
 
     // A map to collect data
     std::map<std::string, std::string> data_map;
-    WalkFunc save_all_data_map{[&data_map](ByteView key, ByteView value) {
+    auto save_all_data_map{[&data_map](ByteView key, ByteView value) {
         data_map.emplace(byte_view_to_string_view(key), byte_view_to_string_view(value));
     }};
 
     // A vector to collect data
     std::vector<std::pair<std::string, std::string>> data_vec;
-    WalkFunc save_all_data_vec{[&data_vec](ByteView key, ByteView value) {
+    auto save_all_data_vec{[&data_vec](ByteView key, ByteView value) {
         data_vec.emplace_back(byte_view_to_string_view(key), byte_view_to_string_view(value));
     }};
 

--- a/node/silkworm/db/mdbx_test.cpp
+++ b/node/silkworm/db/mdbx_test.cpp
@@ -315,9 +315,7 @@ TEST_CASE("Cursor walk") {
         data_map.clear();
     }
 
-    SECTION("cursor_for_prefix") {
-        Bytes prefix{};
-
+    SECTION("cursor_erase_prefix") {
         // populate table
         for (const auto& [key, value] : kGeneticCode) {
             table_cursor.upsert(mdbx::slice{key}, mdbx::slice{value});
@@ -326,11 +324,20 @@ TEST_CASE("Cursor walk") {
         REQUIRE(table_cursor.empty() == false);
 
         // Delete all records starting with "AC"
+        Bytes prefix{};
         prefix.append({'A', 'C'});
-        auto erased{cursor_for_prefix(table_cursor, to_slice(prefix), walk_erase)};
+        auto erased{cursor_erase_prefix(table_cursor, prefix)};
         REQUIRE(erased == 4);
         REQUIRE(table_cursor.size() == (kGeneticCode.size() - erased));
+    }
 
+    SECTION("cursor_for_prefix") {
+        // populate table
+        for (const auto& [key, value] : kGeneticCode) {
+            table_cursor.upsert(mdbx::slice{key}, mdbx::slice{value});
+        }
+
+        Bytes prefix{};
         prefix.assign({'A', 'A'});
         auto count{cursor_for_prefix(table_cursor,
                                      to_slice(prefix),

--- a/node/silkworm/downloader/internals/db_utils.cpp
+++ b/node/silkworm/downloader/internals/db_utils.cpp
@@ -22,7 +22,7 @@
 namespace silkworm {
 
 // Read all headers up to limit, in reverse order from last, processing each via a user defined callback
-// alternative implementation: use cursor_for_count(cursor, const WalkFunc&, size_t max_count, CursorMoveDirection)
+// alternative implementation: use cursor_for_count(cursor, WalkFuncRef, size_t max_count, CursorMoveDirection)
 void read_headers_in_reverse_order(mdbx::txn& txn, size_t limit, std::function<void(BlockHeader&&)> callback) {
     db::Cursor header_table(txn, db::table::kHeaders);
 
@@ -51,8 +51,8 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(mdbx::txn& txn, const std::set
 
     auto td_cursor = db::open_cursor(txn, db::table::kDifficulty);
 
-    db::WalkFunc find_max = [bad_headers, &max_block_num, &max_hash, &max_td](
-                                ByteView key, ByteView value) {
+    auto find_max = [bad_headers, &max_block_num, &max_hash, &max_td](
+                        ByteView key, ByteView value) {
         SILKWORM_ASSERT(key.size() == sizeof(BlockNum) + kHashLength);
 
         Hash hash{key.substr(sizeof(BlockNum))};

--- a/node/silkworm/downloader/internals/db_utils.cpp
+++ b/node/silkworm/downloader/internals/db_utils.cpp
@@ -52,7 +52,7 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(mdbx::txn& txn, const std::set
     auto td_cursor = db::open_cursor(txn, db::table::kDifficulty);
 
     db::WalkFunc find_max = [bad_headers, &max_block_num, &max_hash, &max_td](
-                                const ::mdbx::cursor&, const ::mdbx::cursor::move_result& result) -> bool {
+                                const ::mdbx::cursor&, const ::mdbx::cursor::move_result& result) {
         ByteView key = db::from_slice(result.key);
         ByteView value = db::from_slice(result.value);
 
@@ -62,7 +62,7 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(mdbx::txn& txn, const std::set
         ByteView block_num = key.substr(0, sizeof(BlockNum));
 
         if (bad_headers && bad_headers->contains(hash)) {
-            return true;  // = continue loop
+            return;
         }
 
         BigInt td = 0;
@@ -74,7 +74,7 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(mdbx::txn& txn, const std::set
             max_block_num = endian::load_big_u64(block_num.data());
         }
 
-        return true;  // = continue loop - todo: check if we really need to parse all the table
+        // TODO: check if we really need to parse all the table
     };
 
     db::cursor_for_each(td_cursor, find_max, db::CursorMoveDirection::Reverse);

--- a/node/silkworm/downloader/internals/db_utils.cpp
+++ b/node/silkworm/downloader/internals/db_utils.cpp
@@ -52,10 +52,7 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(mdbx::txn& txn, const std::set
     auto td_cursor = db::open_cursor(txn, db::table::kDifficulty);
 
     db::WalkFunc find_max = [bad_headers, &max_block_num, &max_hash, &max_td](
-                                const ::mdbx::cursor&, const ::mdbx::cursor::move_result& result) {
-        ByteView key = db::from_slice(result.key);
-        ByteView value = db::from_slice(result.value);
-
+                                ByteView key, ByteView value) {
         SILKWORM_ASSERT(key.size() == sizeof(BlockNum) + kHashLength);
 
         Hash hash{key.substr(sizeof(BlockNum))};

--- a/node/silkworm/stagedsync/_test.cpp
+++ b/node/silkworm/stagedsync/_test.cpp
@@ -109,12 +109,12 @@ TEST_CASE("Sync Stages") {
                         block_hashes.size() + 1);  // +1 cause block 0 is genesis
 
                 std::vector<std::pair<evmc::bytes32, BlockNum>> written_data{};
-                db::WalkFunc walk_func = [&written_data](::mdbx::cursor&, ::mdbx::cursor::move_result& data) {
-                    auto written_block_num{endian::load_big_u64(static_cast<uint8_t*>(data.value.data()))};
-                    auto written_hash{to_bytes32(db::from_slice(data.key))};
+                db::WalkFunc walk_func = [&written_data](ByteView key, ByteView value) {
+                    auto written_block_num{endian::load_big_u64(value.data())};
+                    auto written_hash{to_bytes32(key)};
                     written_data.emplace_back(written_hash, written_block_num);
                 };
-                (void)db::cursor_for_each(target_table, walk_func);
+                db::cursor_for_each(target_table, walk_func);
 
                 REQUIRE(written_data.size() == block_hashes.size() + 1);
                 for (const auto& [written_hash, written_block_num] : written_data) {

--- a/node/silkworm/stagedsync/_test.cpp
+++ b/node/silkworm/stagedsync/_test.cpp
@@ -106,11 +106,10 @@ TEST_CASE("Sync Stages") {
                         block_hashes.size() + 1);  // +1 cause block 0 is genesis
 
                 std::vector<std::pair<evmc::bytes32, BlockNum>> written_data{};
-                db::WalkFunc walk_func = [&written_data](::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
+                db::WalkFunc walk_func = [&written_data](::mdbx::cursor&, ::mdbx::cursor::move_result& data) {
                     auto written_block_num{endian::load_big_u64(static_cast<uint8_t*>(data.value.data()))};
                     auto written_hash{to_bytes32(db::from_slice(data.key))};
                     written_data.emplace_back(written_hash, written_block_num);
-                    return true;
                 };
                 (void)db::cursor_for_each(target_table, walk_func);
 

--- a/node/silkworm/stagedsync/_test.cpp
+++ b/node/silkworm/stagedsync/_test.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Sync Stages") {
                         block_hashes.size() + 1);  // +1 cause block 0 is genesis
 
                 std::vector<std::pair<evmc::bytes32, BlockNum>> written_data{};
-                db::WalkFunc walk_func = [&written_data](ByteView key, ByteView value) {
+                auto walk_func = [&written_data](ByteView key, ByteView value) {
                     auto written_block_num{endian::load_big_u64(value.data())};
                     auto written_hash{to_bytes32(key)};
                     written_data.emplace_back(written_hash, written_block_num);

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -160,8 +160,8 @@ void Execution::prefetch_blocks(db::RWTxn& txn, const BlockNum from, const Block
     size_t num_read{0};
 
     db::Cursor canonicals(txn, db::table::kCanonicalHashes);
-    auto key{db::block_key(from)};
-    if (canonicals.seek(db::to_slice(key))) {
+    Bytes starting_key{db::block_key(from)};
+    if (canonicals.seek(db::to_slice(starting_key))) {
         BlockNum block_num{from};
         auto walk_function{[&](ByteView key, ByteView value) {
             BlockNum reached_block_num{endian::load_big_u64(key.data())};

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -144,7 +144,6 @@ void Execution::prefetch_blocks(db::RWTxn& txn, const BlockNum from, const Block
                 throw std::runtime_error("Unable to read block " + std::to_string(block_num));
             }
             ++block_num;
-            return true;
         }};
         num_read = db::cursor_for_count(hashes_table, walk_function, count);
     }

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -163,7 +163,7 @@ void Execution::prefetch_blocks(db::RWTxn& txn, const BlockNum from, const Block
     auto key{db::block_key(from)};
     if (canonicals.seek(db::to_slice(key))) {
         BlockNum block_num{from};
-        db::WalkFunc walk_function{[&](ByteView key, ByteView value) {
+        auto walk_function{[&](ByteView key, ByteView value) {
             BlockNum reached_block_num{endian::load_big_u64(key.data())};
             if (reached_block_num != block_num) {
                 throw std::runtime_error("Bad canonical header sequence: expected " + std::to_string(block_num) +

--- a/node/silkworm/stagedsync/stage_history_index_test.cpp
+++ b/node/silkworm/stagedsync/stage_history_index_test.cpp
@@ -329,7 +329,7 @@ TEST_CASE("Stage History Index") {
             Bytes prefix(kAddressLength, '\0');
             std::memcpy(&prefix[0], address.bytes, kAddressLength);
             auto count{
-                db::cursor_for_prefix(account_history, db::to_slice(prefix),
+                db::cursor_for_prefix(account_history, prefix,
                                       [](::mdbx::cursor&, ::mdbx::cursor::move_result&) -> bool { return true; })};
             REQUIRE(count == 2);
         }
@@ -373,7 +373,7 @@ TEST_CASE("Stage History Index") {
             Bytes prefix(kAddressLength, '\0');
             std::memcpy(&prefix[0], addresses.back().bytes, kAddressLength);
             auto count{
-                db::cursor_for_prefix(account_history, db::to_slice(prefix),
+                db::cursor_for_prefix(account_history, prefix,
                                       [](::mdbx::cursor&, ::mdbx::cursor::move_result&) -> bool { return true; })};
             REQUIRE(count == 0);
             addresses.pop_back();  // Remove unused address for next tests
@@ -384,7 +384,7 @@ TEST_CASE("Stage History Index") {
             Bytes prefix(kAddressLength, '\0');
             std::memcpy(&prefix[0], address.bytes, kAddressLength);
             auto count{db::cursor_for_prefix(
-                account_history, db::to_slice(prefix), [](::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
+                account_history, prefix, [](::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
                     const auto data_key_view{db::from_slice(data.key)};
                     CHECK(endian::load_big_u64(&data_key_view[data_key_view.size() - sizeof(BlockNum)]) == UINT64_MAX);
                     const auto bitmap{db::bitmap::parse(data.value)};
@@ -411,7 +411,7 @@ TEST_CASE("Stage History Index") {
             Bytes prefix(kAddressLength, '\0');
             std::memcpy(&prefix[0], address.bytes, kAddressLength);
             auto count{db::cursor_for_prefix(
-                account_history, db::to_slice(prefix), [](::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
+                account_history, prefix, [](::mdbx::cursor&, ::mdbx::cursor::move_result& data) -> bool {
                     const auto data_key_view{db::from_slice(data.key)};
                     CHECK(endian::load_big_u64(&data_key_view[data_key_view.size() - sizeof(BlockNum)]) == UINT64_MAX);
                     const auto bitmap{db::bitmap::parse(data.value)};

--- a/node/silkworm/stagedsync/stage_interhashes/_test.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes/_test.cpp
@@ -322,7 +322,6 @@ static std::map<Bytes, Node> read_all_nodes(mdbx::cursor& cursor) {
     db::WalkFunc save_nodes{[&out](mdbx::cursor&, mdbx::cursor::move_result& entry) {
         const Node node{*Node::decode_from_storage(db::from_slice(entry.value))};
         out.emplace(db::from_slice(entry.key), node);
-        return true;
     }};
     db::cursor_for_each(cursor, save_nodes);
     return out;

--- a/node/silkworm/stagedsync/stage_interhashes/_test.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes/_test.cpp
@@ -319,7 +319,7 @@ static evmc::bytes32 setup_storage(mdbx::txn& txn, ByteView storage_key) {
 static std::map<Bytes, Node> read_all_nodes(mdbx::cursor& cursor) {
     cursor.to_first(/*throw_notfound=*/false);
     std::map<Bytes, Node> out;
-    db::WalkFunc save_nodes{[&out](ByteView key, ByteView value) {
+    auto save_nodes{[&out](ByteView key, ByteView value) {
         const Node node{*Node::decode_from_storage(value)};
         out.emplace(key, node);
     }};

--- a/node/silkworm/stagedsync/stage_interhashes/_test.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes/_test.cpp
@@ -319,9 +319,9 @@ static evmc::bytes32 setup_storage(mdbx::txn& txn, ByteView storage_key) {
 static std::map<Bytes, Node> read_all_nodes(mdbx::cursor& cursor) {
     cursor.to_first(/*throw_notfound=*/false);
     std::map<Bytes, Node> out;
-    db::WalkFunc save_nodes{[&out](mdbx::cursor&, mdbx::cursor::move_result& entry) {
-        const Node node{*Node::decode_from_storage(db::from_slice(entry.value))};
-        out.emplace(db::from_slice(entry.key), node);
+    db::WalkFunc save_nodes{[&out](ByteView key, ByteView value) {
+        const Node node{*Node::decode_from_storage(value)};
+        out.emplace(key, node);
     }};
     db::cursor_for_each(cursor, save_nodes);
     return out;


### PR DESCRIPTION
Change
```
using WalkFunc = std::function<bool(::mdbx::cursor& cursor, ::mdbx::cursor::move_result& data)>
```
to
```
using WalkFuncRef = absl::FunctionRef<void(ByteView key, ByteView value)>
```

Rationale:
1. The early termination feature was unused, so no longer `bool` return.
2. The new function signature is simpler.
3. `absl::FunctionRef` is preferable to `const std::function&`: see C++26 proposal [P0792](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0792r10.html) for motivation.