### PR TITLE
Fix flaky log tests

### DIFF
--- a/node/silkworm/common/log.cpp
+++ b/node/silkworm/common/log.cpp
@@ -48,6 +48,8 @@ void tee_file(const std::filesystem::path& path) {
     }
 }
 
+Level get_verbosity() { return settings_.log_verbosity; }
+
 void set_verbosity(Level level) { settings_.log_verbosity = level; }
 
 bool test_verbosity(Level level) { return level <= settings_.log_verbosity; }

--- a/node/silkworm/common/log.hpp
+++ b/node/silkworm/common/log.hpp
@@ -50,6 +50,10 @@ struct Settings {
 //! \note This function is not thread safe as it's meant to be used at start of process and never called again
 void init(Settings& settings);
 
+//! \brief Get the current logging verbosity
+//! \note This function is not thread safe as it's meant to be used in tests
+Level get_verbosity();
+
 //! \brief Sets logging verbosity
 //! \note This function is not thread safe as it's meant to be used at start of process and never called again
 void set_verbosity(Level level);

--- a/node/silkworm/common/log_test.cpp
+++ b/node/silkworm/common/log_test.cpp
@@ -22,13 +22,15 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/test/log.hpp>
+
 namespace silkworm::log {
 
 // Custom LogBuffer just for testing to access buffered content
 template <Level level>
 class TestLogBuffer : public LogBuffer<level> {
   public:
-    std::string content() const { return LogBuffer<level>::ss_.str(); }
+    [[nodiscard]] std::string content() const { return LogBuffer<level>::ss_.str(); }
 };
 
 // Utility test function enforcing that log buffered content *IS* empty
@@ -88,14 +90,14 @@ TEST_CASE("LogBuffer", "[silkworm][common][log]") {
     }
 
     SECTION("LogBuffer stores nothing for verbosity higher than configured one") {
-        set_verbosity(Level::kWarning);
+        test::SetLogVerbosityGuard guard{Level::kWarning};
         check_log_empty<Level::kInfo>();
         check_log_empty<Level::kDebug>();
         check_log_empty<Level::kTrace>();
     }
 
     SECTION("LogBuffer stores content for verbosity lower than or equal to configured one") {
-        set_verbosity(Level::kWarning);
+        test::SetLogVerbosityGuard guard{Level::kWarning};
         check_log_not_empty<Level::kWarning>();
         check_log_not_empty<Level::kError>();
         check_log_not_empty<Level::kCritical>();

--- a/node/silkworm/rpc/completion_end_point_test.cpp
+++ b/node/silkworm/rpc/completion_end_point_test.cpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/common/log.hpp>
 #include <silkworm/rpc/completion_tag.hpp>
+#include <silkworm/test/log.hpp>
 
 namespace silkworm::rpc {
 
@@ -34,7 +35,7 @@ using namespace std::chrono_literals;
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::CompletionQueue queue;
     CompletionEndPoint completion_end_point{queue};
 
@@ -90,7 +91,7 @@ TEST_CASE("CompletionEndPoint::poll_one", "[silkworm][rpc][completion_end_point]
 }
 
 TEST_CASE("CompletionEndPoint::post_one", "[silkworm][rpc][completion_end_point]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::CompletionQueue queue;
     CompletionEndPoint completion_end_point{queue};
     boost::asio::io_context io_context;

--- a/node/silkworm/rpc/server/server_context_pool_test.cpp
+++ b/node/silkworm/rpc/server/server_context_pool_test.cpp
@@ -26,6 +26,7 @@
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/log.hpp>
+#include <silkworm/test/log.hpp>
 
 // Factory function creating one null output stream (all characters are discarded)
 inline std::ostream& null_stream() {
@@ -82,13 +83,13 @@ TEST_CASE("ServerContext", "[silkworm][rpc][server_context]") {
     }
 
     SECTION("print") {
-        silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+        test::SetLogVerbosityGuard guard{log::Level::kNone};
         CHECK_NOTHROW(null_stream() << server_context);
     }
 }
 
 TEST_CASE("ServerContextPool", "[silkworm][rpc][server_context]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
 
     SECTION("ServerContextPool OK") {

--- a/node/silkworm/rpc/server/server_test.cpp
+++ b/node/silkworm/rpc/server/server_test.cpp
@@ -26,6 +26,7 @@
 
 #include <silkworm/common/log.hpp>
 #include <silkworm/rpc/util.hpp>
+#include <silkworm/test/log.hpp>
 
 namespace silkworm::rpc {
 
@@ -34,7 +35,7 @@ namespace {  // Trick suggested by gRPC team to avoid name clashes in multiple t
 
     class EmptyServer : public Server {
       public:
-        EmptyServer(const ServerConfig& config) : Server(config) {}
+        explicit EmptyServer(const ServerConfig& config) : Server(config) {}
 
       protected:
         void register_async_services(grpc::ServerBuilder& builder) override {
@@ -73,7 +74,7 @@ TEST_CASE("Barebone gRPC Server", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::Server", "[silkworm][node][rpc]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
 
     SECTION("OK: create an empty Server", "[silkworm][node][rpc]") {
         ServerConfig config;
@@ -83,7 +84,7 @@ TEST_CASE("Server::Server", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::build_and_start", "[silkworm][node][rpc]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard set_log_verbosity_guard{log::Level::kNone};
 
     // TODO(canepat): use GMock
     class TestServer : public EmptyServer {
@@ -138,7 +139,7 @@ TEST_CASE("Server::build_and_start", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::shutdown", "[silkworm][node][rpc]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
 
     SECTION("OK: build_and_start/shutdown", "[silkworm][node][rpc]") {
         ServerConfig config;
@@ -159,7 +160,7 @@ TEST_CASE("Server::shutdown", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::join", "[silkworm][node][rpc]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
 
     SECTION("OK: build_and_start/join/shutdown", "[silkworm][node][rpc]") {
         ServerConfig config;

--- a/node/silkworm/rpc/util_test.cpp
+++ b/node/silkworm/rpc/util_test.cpp
@@ -18,8 +18,8 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/common/base.hpp>
 #include <silkworm/common/log.hpp>
+#include <silkworm/test/log.hpp>
 
 namespace silkworm::rpc {
 
@@ -55,7 +55,7 @@ TEST_CASE("compare grpc::Status", "[silkworm][rpc][util]") {
     CHECK(!(status3 == status4));
 }
 
-// Necesary at namespace level for TEST_CASE GrpcLogGuard
+// Necessary at namespace level for TEST_CASE GrpcLogGuard
 static bool gpr_test_log_reached{false};
 static void gpr_test_log(gpr_log_func_args* /*args*/) {
     gpr_test_log_reached = true;
@@ -72,7 +72,7 @@ TEST_CASE("GrpcLogGuard", "[silkworm][rpc][util]") {
 }
 
 TEST_CASE("gpr_silkworm_log", "[silkworm][rpc][util]") {
-    silkworm::log::set_verbosity(silkworm::log::Level::kNone);
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
     const char* FILE_NAME{"file.cpp"};
     const int LINE_NUMBER{10};
     Grpc2SilkwormLogGuard log_guard;

--- a/node/silkworm/test/log.hpp
+++ b/node/silkworm/test/log.hpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/common/log.hpp>
+
+namespace silkworm::test {
+
+//! Utility class using RAII to change the log verbosity level (necessary to make tests work in shuffled order)
+class SetLogVerbosityGuard {
+  public:
+    explicit SetLogVerbosityGuard(log::Level new_level) : current_level_(log::get_verbosity()) {
+        set_verbosity(new_level);
+    }
+    ~SetLogVerbosityGuard() { log::set_verbosity(current_level_); }
+
+  private:
+    log::Level current_level_;
+};
+
+}  // namespace silkworm::test


### PR DESCRIPTION
This PR fixes a couple of failures in `node_test` when executed within CLion IDE that shuffles the execution order of tests.

The problem shows in `LogBuffer stores content for verbosity lower than or equal to default` test but it is indeed caused by other tests which change the default log verbosity _without_ restoring the default value at the end of the test.