### PR TITLE
Fix stop sequence for Silkworm executable

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
         // Keep waiting till sync_loop stops
         // Signals are handled in sync_loop and below
         auto t1{std::chrono::steady_clock::now()};
-        while (sync_loop.get_state() != Worker::State::kStopped) {
+        while (sync_loop.get_state() != Worker::State::kStopped && sync_loop.get_state() != Worker::State::kStopping) {
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
             // Check signals

--- a/node/silkworm/downloader/internals/grpc_sync_client.hpp
+++ b/node/silkworm/downloader/internals/grpc_sync_client.hpp
@@ -118,13 +118,9 @@ class Client {
         call.execute(stub_.get());  // provide the stub to the call, it is the call that know what procedure to execute
     }
 
-    bool wait_reconnection() {
+    bool is_connected() {
         bool try_to_connect = true;
-        grpc_connectivity_state state;
-        do {
-            state = channel_->GetState(try_to_connect);
-        } while (state != GRPC_CHANNEL_READY && state != GRPC_CHANNEL_SHUTDOWN);
-
+        grpc_connectivity_state state = channel_->GetState(try_to_connect);
         return (state == GRPC_CHANNEL_READY);
     }
 

--- a/node/silkworm/downloader/rpc/hand_shake.hpp
+++ b/node/silkworm/downloader/rpc/hand_shake.hpp
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <silkworm/downloader/internals/types.hpp>
-#include <silkworm/downloader/sentry_client.hpp>
+#include <p2psentry/sentry.grpc.pb.h>
+
+#include <silkworm/downloader/internals/grpc_sync_client.hpp>
 
 namespace silkworm::rpc {
 

--- a/node/silkworm/downloader/sentry_client.hpp
+++ b/node/silkworm/downloader/sentry_client.hpp
@@ -26,6 +26,7 @@
 #include <silkworm/downloader/internals/grpc_sync_client.hpp>
 #include <silkworm/downloader/internals/sentry_type_casts.hpp>
 #include <silkworm/downloader/internals/types.hpp>
+#include <silkworm/downloader/rpc/hand_shake.hpp>
 #include <silkworm/downloader/rpc/receive_messages.hpp>
 #include <silkworm/downloader/rpc/receive_peer_stats.hpp>
 
@@ -72,6 +73,7 @@ class SentryClient : public rpc::Client<sentry::Sentry>, public ActiveComponent 
     db::ROAccess db_access_;
     const ChainConfig& chain_config_;
 
+    std::shared_ptr<rpc::HandShake> handshake_;
     std::shared_ptr<rpc::ReceiveMessages> receive_messages_;
     std::shared_ptr<rpc::ReceivePeerStats> receive_peer_stats_;
 


### PR DESCRIPTION
This PR fixes three conditions preventing Silkworm to execute a graceful termination:
- the sync-loop `Worker` sometimes remains stuck into the main loop because of a race condition in Worker thread termination that can leave it in the `Stopping` state instead of the expected `Stopped` state. Given that such loop is currently used only in `main`, adding an additional check temporarily solves the issue (#777 opened to track the problem)
- sync Sentry client remains stuck waiting for a connection in case the Sentry component is not reachable, thus preventing a clean shutdown
- sync Sentry client may remain stuck executing the `handshake` with the Sentry component, thus preventing a clean shutdown