### PR TITLE
Fix Sentry client shutdown hang in PeerCount RPC

### DIFF
--- a/node/silkworm/downloader/rpc/peer_count.hpp
+++ b/node/silkworm/downloader/rpc/peer_count.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include <silkworm/downloader/sentry_client.hpp>
+#include <p2psentry/sentry.grpc.pb.h>
+
+#include <silkworm/downloader/internals/grpc_sync_client.hpp>
 
 namespace silkworm::rpc {
 

--- a/node/silkworm/downloader/sentry_client.cpp
+++ b/node/silkworm/downloader/sentry_client.cpp
@@ -188,19 +188,20 @@ void SentryClient::stats_receiving_loop() {
 
 uint64_t SentryClient::count_active_peers() {
     using namespace std::chrono_literals;
-    rpc::PeerCount rpc;
+    auto rpc = std::make_shared<rpc::PeerCount>();
+    std::atomic_store(&peer_count_, rpc);
 
-    rpc.timeout(1s);
-    rpc.do_not_throw_on_failure();
+    peer_count_->timeout(1s);
+    peer_count_->do_not_throw_on_failure();
 
-    exec_remotely(rpc);
+    exec_remotely(*peer_count_);
 
-    if (!rpc.status().ok()) {
-        SILK_TRACE << "Failure of rpc PeerCount: " << rpc.status().error_message();
+    if (!peer_count_->status().ok()) {
+        SILK_TRACE << "Failure of rpc PeerCount: " << peer_count_->status().error_message();
         return 0;
     }
 
-    sentry::PeerCountReply peers = rpc.reply();
+    sentry::PeerCountReply peers = peer_count_->reply();
     active_peers_.store(peers.count());
 
     return peers.count();
@@ -221,6 +222,9 @@ bool SentryClient::stop() {
     auto handshake = std::atomic_load(&handshake_);
     if (handshake)
         handshake->try_cancel();
+    auto peer_count = std::atomic_load(&peer_count_);
+    if (peer_count)
+        peer_count->try_cancel();
     return expected;
 }
 

--- a/node/silkworm/downloader/sentry_client.hpp
+++ b/node/silkworm/downloader/sentry_client.hpp
@@ -27,7 +27,6 @@
 #include <silkworm/downloader/internals/sentry_type_casts.hpp>
 #include <silkworm/downloader/internals/types.hpp>
 #include <silkworm/downloader/rpc/hand_shake.hpp>
-#include <silkworm/downloader/rpc/peer_count.hpp>
 #include <silkworm/downloader/rpc/receive_messages.hpp>
 #include <silkworm/downloader/rpc/receive_peer_stats.hpp>
 
@@ -75,7 +74,6 @@ class SentryClient : public rpc::Client<sentry::Sentry>, public ActiveComponent 
     const ChainConfig& chain_config_;
 
     std::shared_ptr<rpc::HandShake> handshake_;
-    std::shared_ptr<rpc::PeerCount> peer_count_;
     std::shared_ptr<rpc::ReceiveMessages> receive_messages_;
     std::shared_ptr<rpc::ReceivePeerStats> receive_peer_stats_;
 

--- a/node/silkworm/downloader/sentry_client.hpp
+++ b/node/silkworm/downloader/sentry_client.hpp
@@ -27,6 +27,7 @@
 #include <silkworm/downloader/internals/sentry_type_casts.hpp>
 #include <silkworm/downloader/internals/types.hpp>
 #include <silkworm/downloader/rpc/hand_shake.hpp>
+#include <silkworm/downloader/rpc/peer_count.hpp>
 #include <silkworm/downloader/rpc/receive_messages.hpp>
 #include <silkworm/downloader/rpc/receive_peer_stats.hpp>
 
@@ -74,6 +75,7 @@ class SentryClient : public rpc::Client<sentry::Sentry>, public ActiveComponent 
     const ChainConfig& chain_config_;
 
     std::shared_ptr<rpc::HandShake> handshake_;
+    std::shared_ptr<rpc::PeerCount> peer_count_;
     std::shared_ptr<rpc::ReceiveMessages> receive_messages_;
     std::shared_ptr<rpc::ReceivePeerStats> receive_peer_stats_;
 


### PR DESCRIPTION
This PR fixes an hang in sync Sentry client during the shutdown sequence of Silkworm. The issue is reproducible with 30% frequency in the following scenario:
- start Silkworm w/ Sentry down
- start Sentry and let Silkworm connect to it
- stop Sentry
- try to stop Silkworm sending Ctrl-C signal

The problem can be tracked down to the blocking `PeerCount` call.