### PR TITLE
Fix race condition in Worker termination state

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
         // Keep waiting till sync_loop stops
         // Signals are handled in sync_loop and below
         auto t1{std::chrono::steady_clock::now()};
-        while (sync_loop.get_state() != Worker::State::kStopped && sync_loop.get_state() != Worker::State::kStopping) {
+        while (sync_loop.get_state() != Worker::State::kStopped) {
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
             // Check signals

--- a/node/silkworm/concurrency/_test.cpp
+++ b/node/silkworm/concurrency/_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE("Worker") {
         REQUIRE(worker.get_state() == Worker::State::kKickWaiting);
         worker.kick();
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        REQUIRE(worker.get_state() == Worker::State::kStopped); // likely
+        REQUIRE(worker.get_state() == Worker::State::kStopped);  // likely
         worker.stop(true);
         REQUIRE(worker.get_state() == Worker::State::kStopped);
     }

--- a/node/silkworm/concurrency/_test.cpp
+++ b/node/silkworm/concurrency/_test.cpp
@@ -70,6 +70,27 @@ TEST_CASE("Worker") {
         REQUIRE(worker.has_exception() == true);
         REQUIRE_THROWS(worker.rethrow());
     }
+
+    SECTION("Stop when already exited") {
+        ThreadWorker worker(true);
+        REQUIRE(worker.get_state() == Worker::State::kStopped);
+        worker.start(true);
+        REQUIRE(worker.get_state() == Worker::State::kKickWaiting);
+        worker.kick();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        REQUIRE(worker.get_state() == Worker::State::kStopped); // likely
+        worker.stop(true);
+        REQUIRE(worker.get_state() == Worker::State::kStopped);
+    }
+
+    SECTION("Stop while waiting for kick") {
+        ThreadWorker worker(false);
+        REQUIRE(worker.get_state() == Worker::State::kStopped);
+        worker.start(true);
+        REQUIRE(worker.get_state() == Worker::State::kKickWaiting);
+        worker.stop(true);
+        REQUIRE(worker.get_state() == Worker::State::kStopped);
+    }
 }
 
 TEST_CASE("Signal Handler") {


### PR DESCRIPTION
This PR hopefully fixes a race condition in `Worker` termination state occurring between:
- the worker thread itself updating the state to `Stopped` before terminating
- any external thread calling `Worker::stop` method to stop the worker updating the state to `Stopping`

Fixes #777 