### PR TITLE
Integrate BackEndKV server in Silkworm core component

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -14,8 +14,8 @@
    limitations under the License.
 */
 
+#include <filesystem>
 #include <string>
-#include <thread>
 
 #include <CLI/CLI.hpp>
 #include <boost/asio/io_context.hpp>
@@ -33,26 +33,6 @@
 #include <silkworm/rpc/util.hpp>
 
 #include "common.hpp"
-
-//! Assemble the full node name using the Cable build information
-std::string get_node_name_from_build_info() {
-    const auto build_info{silkworm_get_buildinfo()};
-
-    std::string node_name{"silkworm/"};
-    node_name.append(build_info->git_branch);
-    node_name.append(build_info->project_version);
-    node_name.append("/");
-    node_name.append(build_info->system_name);
-    node_name.append("-");
-    node_name.append(build_info->system_processor);
-    node_name.append("_");
-    node_name.append(build_info->build_type);
-    node_name.append("/");
-    node_name.append(build_info->compiler_id);
-    node_name.append("-");
-    node_name.append(build_info->compiler_version);
-    return node_name;
-}
 
 //! Assemble the relevant library version information
 std::string get_library_versions() {
@@ -72,54 +52,41 @@ struct BackEndKvSettings {
 
 //! Parse the command-line arguments into the BackEnd and KV server settings
 int parse_command_line(int argc, char* argv[], CLI::App& app, BackEndKvSettings& settings) {
+    using namespace silkworm::cmd;
+
     auto& log_settings = settings.log_settings;
     auto& node_settings = settings.node_settings;
     auto& server_settings = settings.server_settings;
 
-    std::string data_dir{silkworm::DataDirectory::get_default_storage_path().string()};
-    std::string etherbase_address{""};
-    uint32_t num_contexts{std::thread::hardware_concurrency() / 2};
-    silkworm::rpc::WaitMode wait_mode{silkworm::rpc::WaitMode::blocking};
-    uint32_t max_readers{silkworm::db::EnvConfig{}.max_readers};
-    app.add_option("--datadir", data_dir, "The path to data directory")->capture_default_str();
-    app.add_option("--etherbase", etherbase_address, "The coinbase address as string")->capture_default_str();
-    // TODO(canepat) add check on etherbase using EthAddressValidator [TBD]
-    silkworm::cmd::add_option_num_contexts(app, num_contexts);
-    silkworm::cmd::add_option_wait_mode(app, wait_mode);
-    app.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
-        ->capture_default_str()
-        ->check(CLI::Range(1, 32767));
+    // Node options
+    add_option_chain(app, node_settings.network_id);
+
+    std::filesystem::path data_dir;
+    add_option_data_dir(app, data_dir);
+
+    std::string etherbase_address;
+    add_option_etherbase(app, etherbase_address);
+
+    uint32_t max_readers;
+    add_option_db_max_readers(app, max_readers);
 
     // RPC Server options
-    app.add_option("--private.api.addr", node_settings.private_api_addr,
-                   "Private API network address to serve remote database interface\n"
-                   "An empty string means to not start the listener\n"
-                   "Use the endpoint form i.e. ip-address:port\n"
-                   "DO NOT EXPOSE TO THE INTERNET")
-        ->capture_default_str();
-    // TODO(canepat) add check on private.api.addr using IPEndPointValidator
-    app.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")->capture_default_str();
-    // TODO(canepat) add check on sentry_api_addr using IPEndPointValidator
+    add_option_private_api_address(app, node_settings.private_api_addr);
+    add_option_sentry_api_address(app, node_settings.sentry_api_addr);
 
-    // Chain options
-    auto& chain_opts = *app.add_option_group("Chain", "Chain selection options");
-    auto chain_name = chain_opts.add_option("--chain", "Name of the network to join (default: \"mainnet\")")
-                          ->transform(CLI::Transformer(silkworm::get_known_chains_map(), CLI::ignore_case));
-    chain_opts
-        .add_option("--networkid", node_settings.network_id,
-                    "Explicitly set network id\n"
-                    "For known networks: use --chain <testnet_name> instead")
-        ->capture_default_str()
-        ->excludes(chain_name);
+    uint32_t num_contexts;
+    add_option_num_contexts(app, num_contexts);
 
-    silkworm::cmd::add_logging_options(app, log_settings);
+    silkworm::rpc::WaitMode wait_mode;
+    add_option_wait_mode(app, wait_mode);
+
+    // Logging options
+    add_logging_options(app, log_settings);
 
     app.parse(argc, argv);
 
-    if (chain_name->count()) {
-        node_settings.network_id = chain_name->as<uint32_t>();
-    }
-
+    // Validate and assign settings
+    // TODO (canepat) read chain config from database (allows for custom config)
     const auto known_chain_config{silkworm::lookup_known_chain(node_settings.network_id)};
     if (!known_chain_config.has_value()) {
         SILK_CRIT << "Unknown chain identifier: " << node_settings.network_id;
@@ -160,9 +127,6 @@ int main(int argc, char* argv[]) {
             return result_code;
         }
 
-        const auto node_name{get_node_name_from_build_info()};
-        SILK_LOG << "BackEndKvServer build info: " << node_name << " " << get_library_versions();
-
         const auto pid = boost::this_process::get_id();
         const auto tid = std::this_thread::get_id();
 
@@ -176,8 +140,12 @@ int main(int argc, char* argv[]) {
         // TODO(canepat): this could be an option in Silkworm logging facility
         silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
 
-        SILK_LOG << "BackEndKvServer launched with address: " << server_settings.address_uri()
-                 << ", contexts: " << server_settings.num_contexts();
+        const auto node_name{silkworm::cmd::get_node_name_from_build_info(silkworm_get_buildinfo())};
+        SILK_LOG << "BackEndKvServer build info: " << node_name;
+        SILK_LOG << "BackEndKvServer library info: " << get_library_versions();
+        SILK_LOG << "BackEndKvServer launched with chain id: " << node_settings.network_id
+                 << " address: " << server_settings.address_uri()
+                 << " contexts: " << server_settings.num_contexts();
 
         auto database_env = silkworm::db::open_env(node_settings.chaindata_env_config);
         silkworm::EthereumBackEnd backend{node_settings, &database_env};
@@ -199,10 +167,10 @@ int main(int argc, char* argv[]) {
             server.shutdown();
         });
 
-        SILK_LOG << "BackEndKvServer is now running [pid=" << pid << ", main thread=" << tid << "]";
+        SILK_LOG << "BackEndKvServer is now running [pid=" + std::to_string(pid) + ", main thread=" << tid << "]";
         server.join();
 
-        SILK_LOG << "BackEndKvServer exiting [pid=" << pid << ", main thread=" << tid << "]";
+        SILK_LOG << "BackEndKvServer exiting [pid=" + std::to_string(pid) + ", main thread=" << tid << "]";
         return 0;
     } catch (const CLI::ParseError& pe) {
         return app.exit(pe);

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -27,76 +27,59 @@
 
 namespace silkworm::cmd {
 
-struct HumanSizeParserValidator : public CLI::Validator {
-    template <typename T>
-    explicit HumanSizeParserValidator(T min, std::optional<T> max = std::nullopt) {
-        std::stringstream out;
-        out << " in [" << min << " - " << (max.has_value() ? max.value() : "inf") << "]";
-        description(out.str());
-
-        func_ = [min, max](const std::string& value) -> std::string {
-            auto parsed_size{parse_size(value)};
-            if (!parsed_size.has_value()) {
-                return std::string("Value " + value + " is not a parseable size");
-            }
-            auto min_size{parse_size(min).value()};
-            auto max_size{max.has_value() ? parse_size(max.value()).value() : UINT64_MAX};
-            if (parsed_size.value() < min_size || parsed_size.value() > max_size) {
-                return "Value " + value + " not in range " + min + " to " + (max.has_value() ? max.value() : "∞");
-            }
-            return {};
-        };
-    }
-};
-
-struct PruneModeValidator : public CLI::Validator {
-    PruneModeValidator() {
-        func_ = [](const std::string& value) -> std::string {
-            if (value.find_first_not_of("hrtc") != std::string::npos) {
-                return "Value " + value + " contains other characters other than h r t c";
-            }
-            return {};
-        };
-    }
-};
+PruneModeValidator::PruneModeValidator() {
+    func_ = [](const std::string& value) -> std::string {
+        if (value.find_first_not_of("hrtc") != std::string::npos) {
+            return "Value " + value + " contains other characters other than h r t c";
+        }
+        return {};
+    };
+}
 
 IPEndPointValidator::IPEndPointValidator(bool allow_empty) {
-    {
-        func_ = [&allow_empty](const std::string& value) -> std::string {
-            if (value.empty() && allow_empty) {
-                return {};
-            }
-
-            const std::regex pattern(R"(([\da-fA-F\.\:]*)\:([\d]*))");
-            std::smatch matches;
-            if (!std::regex_match(value, matches, pattern)) {
-                return "Value " + value + " is not a valid endpoint";
-            }
-
-            // Validate IP address
-            boost::system::error_code err;
-            std::string ip_address{boost::asio::ip::address::from_string(matches[1], err).to_string()};
-            if (err) {
-                return "Value " + std::string(matches[1]) + " is not a valid ip address";
-            }
-
-            // Validate port
-            int port{std::stoi(matches[2])};
-            if (port < 1 || port > 65535) {
-                return "Value " + std::string(matches[2]) + " is not a valid listening port";
-            }
-
+    func_ = [&allow_empty](const std::string& value) -> std::string {
+        if (value.empty() && allow_empty) {
             return {};
-        };
-    }
+        }
+
+        const std::regex pattern(R"(([\da-fA-F\.\:]*)\:([\d]*))");
+        std::smatch matches;
+        if (!std::regex_match(value, matches, pattern)) {
+            return "Value " + value + " is not a valid endpoint";
+        }
+
+        // Validate IP address
+        boost::system::error_code err;
+        boost::asio::ip::address::from_string(matches[1], err);
+        if (err) {
+            return "Value " + std::string(matches[1]) + " is not a valid ip address";
+        }
+
+        // Validate port
+        int port{std::stoi(matches[2])};
+        if (port < 1 || port > 65535) {
+            return "Value " + std::string(matches[2]) + " is not a valid listening port";
+        }
+
+        return {};
+    };
 }
 
 void add_logging_options(CLI::App& cli, log::Settings& log_settings) {
+    std::map<std::string, log::Level> level_mapping{
+        {"critical", log::Level::kCritical},
+        {"error", log::Level::kError},
+        {"warning", log::Level::kWarning},
+        {"info", log::Level::kInfo},
+        {"debug", log::Level::kDebug},
+        {"trace", log::Level::kTrace},
+    };
     auto& log_opts = *cli.add_option_group("Log", "Logging options");
     log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
         ->capture_default_str()
-        ->check(CLI::Range(static_cast<uint32_t>(log::Level::kCritical), static_cast<uint32_t>(log::Level::kTrace)))
-        ->default_val(std::to_string(static_cast<uint32_t>(log_settings.log_verbosity)));
+        ->check(CLI::Range(log::Level::kCritical, log::Level::kTrace))
+        ->transform(CLI::Transformer(level_mapping, CLI::ignore_case))
+        ->default_val(log_settings.log_verbosity);
     log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
     log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines");
     log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");
@@ -104,25 +87,69 @@ void add_logging_options(CLI::App& cli, log::Settings& log_settings) {
     log_opts.add_option("--log.file", log_settings.log_file, "Tee all log lines to given file name");
 }
 
+void add_option_chain(CLI::App& cli, uint64_t& network_id) {
+    cli.add_option("--chain", network_id,"Name or ID of the network to join (default: \"mainnet\")")
+        ->transform(CLI::Transformer(get_known_chains_map(), CLI::ignore_case));
+}
+
 void add_option_data_dir(CLI::App& cli, std::filesystem::path& data_dir) {
-    data_dir = DataDirectory::get_default_storage_path();
-    cli.add_option("--datadir", data_dir, "Path to the data directory")->capture_default_str();
+    cli.add_option("--datadir", data_dir, "The path to the blockchain data directory")
+        ->default_val(DataDirectory::get_default_storage_path());
+}
+
+void add_option_etherbase(CLI::App& cli, std::string& etherbase_address) {
+    cli.add_option("--etherbase", etherbase_address, "The coinbase address as hex string")
+        ->default_val("");
+}
+
+void add_option_db_max_readers(CLI::App& cli, uint32_t& max_readers) {
+    cli.add_option("--mdbx.max.readers", max_readers, "The maximum number of MDBX readers")
+        ->default_val(silkworm::db::EnvConfig{}.max_readers)
+        ->check(CLI::Range(1, 32767));
+}
+
+void add_option_private_api_address(CLI::App& cli, std::string& private_api_address) {
+    add_option_ip_address(cli, "--private.api.addr", private_api_address,
+                          "Private API network address to serve remote database interface\n"
+                          "An empty string means to not start the listener\n"
+                          "Use the endpoint form i.e. ip-address:port\n"
+                          "DO NOT EXPOSE TO THE INTERNET");
+}
+
+void add_option_sentry_api_address(CLI::App& cli, std::string& sentry_api_address) {
+    add_option_ip_address(cli, "--sentry.api.addr", sentry_api_address, "Sentry api endpoint");
+}
+
+void add_option_ip_address(CLI::App& cli, const std::string& name, std::string& address, const std::string& description) {
+    cli.add_option(name, address, description)
+        ->capture_default_str()
+        ->check(IPEndPointValidator(/*allow_empty=*/true));
 }
 
 void add_option_num_contexts(CLI::App& cli, uint32_t& num_contexts) {
-    cli.add_option("--contexts", num_contexts, "The number of running contexts")->capture_default_str();
+    cli.add_option("--contexts", num_contexts, "The number of execution contexts")
+        ->default_val(std::thread::hardware_concurrency() / 2);
 }
 
 void add_option_wait_mode(CLI::App& cli, silkworm::rpc::WaitMode& wait_mode) {
+    std::map<std::string, silkworm::rpc::WaitMode> wait_mode_mapping{
+        {"blocking", silkworm::rpc::WaitMode::blocking},
+        {"busy_spin", silkworm::rpc::WaitMode::busy_spin},
+        {"sleeping", silkworm::rpc::WaitMode::sleeping},
+        {"yielding", silkworm::rpc::WaitMode::yielding},
+    };
     cli.add_option("--wait.mode", wait_mode, "The waiting mode for execution loops during idle cycles")
         ->capture_default_str()
-        ->check(CLI::Range(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking),
-                           static_cast<uint32_t>(silkworm::rpc::WaitMode::busy_spin)))
-        ->default_val(std::to_string(static_cast<uint32_t>(silkworm::rpc::WaitMode::blocking)));
+        ->check(CLI::Range(silkworm::rpc::WaitMode::blocking,silkworm::rpc::WaitMode::busy_spin))
+        ->transform(CLI::Transformer(wait_mode_mapping, CLI::ignore_case))
+        ->default_val(silkworm::rpc::WaitMode::blocking);
 }
 
-void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Settings& log_settings,
-                                 NodeSettings& node_settings) {
+void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], SilkwormCoreSettings& settings) {
+    using namespace silkworm::cmd;
+
+    auto& node_settings = settings.node_settings;
+
     // Node settings
     std::filesystem::path data_dir_path;
     std::string chaindata_max_size_str{human_size(node_settings.chaindata_env_config.max_size)};
@@ -155,22 +182,15 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     cli.add_option("--etl.buffersize", etl_buffer_size_str, "Buffer size for ETL operations")
         ->capture_default_str()
         ->check(HumanSizeParserValidator("64MB", {"1GB"}));
-    cli.add_option("--private.api.addr", node_settings.private_api_addr,
-                   "Private API network address to serve remote database interface\n"
-                   "An empty string means to not start the listener\n"
-                   "Use the endpoint form i.e. ip-address:port\n"
-                   "DO NOT EXPOSE TO THE INTERNET")
-        ->capture_default_str()
-        ->check(IPEndPointValidator(/*allow_empty=*/false));
+
+    add_option_private_api_address(cli, node_settings.private_api_addr);
 
     // Sentry settings
     cli.add_option("--sentry.remote.addr", node_settings.external_sentry_addr, "External sentry endpoint")
         ->capture_default_str()
         ->check(IPEndPointValidator(/*allow_empty=*/true));
 
-    cli.add_option("--sentry.api.addr", node_settings.sentry_api_addr, "Sentry api endpoint")
-        ->capture_default_str()
-        ->check(IPEndPointValidator(/*allow_empty=*/true));
+    add_option_sentry_api_address(cli, node_settings.sentry_api_addr);
 
     cli.add_option("--sync.loop.throttle", node_settings.sync_loop_throttle_seconds,
                    "Sets the minimum delay between sync loop starts (in seconds)")
@@ -185,16 +205,7 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     cli.add_flag("--fakepow", node_settings.fake_pow, "Disables proof-of-work verification");
 
     // Chain options
-    auto chains_map{get_known_chains_map()};
-    auto& chain_opts = *cli.add_option_group("Chain", "Chain selection options");
-    auto chain_opts_chain_name = chain_opts.add_option("--chain", "Name of the network to join (default: \"mainnet\")")
-                                     ->transform(CLI::Transformer(chains_map, CLI::ignore_case));
-    chain_opts
-        .add_option("--networkid", node_settings.network_id,
-                    "Explicitly set network id\n"
-                    "For known networks: use --chain <testnet_name> instead")
-        ->capture_default_str()
-        ->excludes(chain_opts_chain_name);
+    add_option_chain(cli, node_settings.network_id);
 
     // Prune options
     std::string prune_mode;
@@ -234,7 +245,18 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
     prune_opts.add_option("--prune.c.before", "Prune call traces data before this block")
         ->check(CLI::Range(0u, UINT32_MAX));
 
+    // Logging options
+    auto& log_settings = settings.log_settings;
     add_logging_options(cli, log_settings);
+
+    // RPC server options
+    auto& server_settings = settings.server_settings;
+
+    uint32_t num_contexts;
+    add_option_num_contexts(cli, num_contexts);
+
+    silkworm::rpc::WaitMode wait_mode;
+    add_option_wait_mode(cli, wait_mode);
 
     cli.parse(argc, argv);
 
@@ -282,13 +304,12 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Set
                              olderHistory, olderReceipts, olderSenders, olderTxIndex, olderCallTraces, beforeHistory,
                              beforeReceipts, beforeSenders, beforeTxIndex, beforeCallTraces);
 
-    // Set chain
-    if (chain_opts_chain_name->count()) {
-        node_settings.network_id = chain_opts_chain_name->as<uint32_t>();
-    }
+    server_settings.set_address_uri(node_settings.private_api_addr);
+    server_settings.set_num_contexts(num_contexts);
+    server_settings.set_wait_mode(wait_mode);
 }
 
-void run_preflight_checklist(NodeSettings& node_settings) {
+void run_preflight_checklist(NodeSettings& node_settings, bool init_if_empty) {
     node_settings.data_directory->deploy();                                  // Ensures all subdirs are present
     bool chaindata_exclusive{node_settings.chaindata_env_config.exclusive};  // Save setting
     {
@@ -315,7 +336,7 @@ void run_preflight_checklist(NodeSettings& node_settings) {
     // Check db is initialized with chain config
     {
         node_settings.chain_config = db::read_chain_config(*tx);
-        if (!node_settings.chain_config.has_value()) {
+        if (!node_settings.chain_config.has_value() && init_if_empty) {
             auto source_data{read_genesis_data(node_settings.network_id)};
             auto genesis_json = nlohmann::json::parse(source_data, nullptr, /* allow_exceptions = */ false);
             if (genesis_json.is_discarded()) {
@@ -449,6 +470,23 @@ void run_preflight_checklist(NodeSettings& node_settings) {
     chaindata_env.close();
     node_settings.chaindata_env_config.exclusive = chaindata_exclusive;
     node_settings.chaindata_env_config.create = false;  // Has already been created
+}
+
+std::string get_node_name_from_build_info(const buildinfo* build_info) {
+    std::string node_name{"silkworm/"};
+    node_name.append(build_info->git_branch);
+    node_name.append(build_info->project_version);
+    node_name.append("/");
+    node_name.append(build_info->system_name);
+    node_name.append("-");
+    node_name.append(build_info->system_processor);
+    node_name.append("_");
+    node_name.append(build_info->build_type);
+    node_name.append("/");
+    node_name.append(build_info->compiler_id);
+    node_name.append("-");
+    node_name.append(build_info->compiler_version);
+    return node_name;
 }
 
 }  // namespace silkworm::cmd

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -94,7 +94,7 @@ void add_option_chain(CLI::App& cli, uint64_t& network_id) {
 
 void add_option_data_dir(CLI::App& cli, std::filesystem::path& data_dir) {
     cli.add_option("--datadir", data_dir, "The path to the blockchain data directory")
-        ->default_val(DataDirectory::get_default_storage_path());
+        ->default_val(DataDirectory::get_default_storage_path().string());
 }
 
 void add_option_etherbase(CLI::App& cli, std::string& etherbase_address) {

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -88,7 +88,7 @@ void add_logging_options(CLI::App& cli, log::Settings& log_settings) {
 }
 
 void add_option_chain(CLI::App& cli, uint64_t& network_id) {
-    cli.add_option("--chain", network_id,"Name or ID of the network to join (default: \"mainnet\")")
+    cli.add_option("--chain", network_id, "Name or ID of the network to join (default: \"mainnet\")")
         ->transform(CLI::Transformer(get_known_chains_map(), CLI::ignore_case));
 }
 
@@ -140,7 +140,7 @@ void add_option_wait_mode(CLI::App& cli, silkworm::rpc::WaitMode& wait_mode) {
     };
     cli.add_option("--wait.mode", wait_mode, "The waiting mode for execution loops during idle cycles")
         ->capture_default_str()
-        ->check(CLI::Range(silkworm::rpc::WaitMode::blocking,silkworm::rpc::WaitMode::busy_spin))
+        ->check(CLI::Range(silkworm::rpc::WaitMode::blocking, silkworm::rpc::WaitMode::busy_spin))
         ->transform(CLI::Transformer(wait_mode_mapping, CLI::ignore_case))
         ->default_val(silkworm::rpc::WaitMode::blocking);
 }

--- a/cmd/common.hpp
+++ b/cmd/common.hpp
@@ -20,34 +20,88 @@
 
 #include <CLI/CLI.hpp>
 
+#include <silkworm/buildinfo.h>
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/settings.hpp>
+#include <silkworm/rpc/server/server_config.hpp>
 #include <silkworm/rpc/server/wait_strategy.hpp>
 
 namespace silkworm::cmd {
 
-//! \brief Parses command line arguments for silkworm executable
-//! \remark This implements the set of CLI args for silkworm executable ONLY !
-void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], log::Settings& log_settings,
-                                 NodeSettings& node_settings);
+//! \brief Ensure database is ready to take off and consistent with command line arguments
+void run_preflight_checklist(NodeSettings& node_settings, bool init_if_empty = true);
 
-//! \brief Ensures database is ready for take off and consistent with command line arguments
-void run_preflight_checklist(NodeSettings& node_settings);
+//! The overall settings for Silkworm Core component
+struct SilkwormCoreSettings {
+    silkworm::log::Settings log_settings;
+    silkworm::NodeSettings node_settings;
+    silkworm::rpc::ServerConfig server_settings;
+};
+
+//! \brief Parses command line arguments for Silkworm executables
+void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], SilkwormCoreSettings& settings);
+
+//! Assemble the full node name using the Cable build information
+std::string get_node_name_from_build_info(const buildinfo* build_info);
+
+struct HumanSizeParserValidator : public CLI::Validator {
+    template <typename T>
+    explicit HumanSizeParserValidator(T min, std::optional<T> max = std::nullopt) {
+        std::stringstream out;
+        out << " in [" << min << " - " << (max.has_value() ? max.value() : "inf") << "]";
+        description(out.str());
+
+        func_ = [min, max](const std::string& value) -> std::string {
+            auto parsed_size{parse_size(value)};
+            if (!parsed_size.has_value()) {
+                return std::string("Value " + value + " is not a parseable size");
+            }
+            auto min_size{parse_size(min).value()};
+            auto max_size{max.has_value() ? parse_size(max.value()).value() : UINT64_MAX};
+            if (parsed_size.value() < min_size || parsed_size.value() > max_size) {
+                return "Value " + value + " not in range " + min + " to " + (max.has_value() ? max.value() : "∞");
+            }
+            return {};
+        };
+    }
+};
 
 struct IPEndPointValidator : public CLI::Validator {
     explicit IPEndPointValidator(bool allow_empty = false);
 };
 
-//! \brief Sets up logging options to populate log_settings after cli.parse()
+struct PruneModeValidator : public CLI::Validator {
+    explicit PruneModeValidator();
+};
+
+//! \brief Set up options to populate log settings after cli.parse()
 void add_logging_options(CLI::App& cli, log::Settings& log_settings);
 
-//! \brief Sets up parsing of the DataDirectory path
+//! \brief Set up option for the network to join
+void add_option_chain(CLI::App& cli, uint64_t & network_id);
+
+//! \brief Set up option for the data directory path
 void add_option_data_dir(CLI::App& cli, std::filesystem::path& data_dir);
 
-//! \brief Sets up parsing of num_contexts
+//! \brief Set up option for the node Etherbase address
+void add_option_etherbase(CLI::App& cli, std::string& etherbase_address);
+
+//! \brief Set up option for maximum number of database readers
+void add_option_db_max_readers(CLI::App& cli, uint32_t& max_readers);
+
+//! \brief Set up option for the IP address of Core private gRPC API
+void add_option_private_api_address(CLI::App& cli, std::string& private_api_address);
+
+//! \brief Set up option for the IP address of Sentry gRPC API
+void add_option_sentry_api_address(CLI::App& cli, std::string& sentry_api_address);
+
+//! \brief Set up parsing of the specified IP address
+void add_option_ip_address(CLI::App& cli, const std::string& name, std::string& address, const std::string& description);
+
+//! \brief Set up parsing of num_contexts
 void add_option_num_contexts(CLI::App& cli, uint32_t& num_contexts);
 
-//! \brief Sets up parsing of wait_mode
+//! \brief Set up parsing of wait_mode
 void add_option_wait_mode(CLI::App& cli, silkworm::rpc::WaitMode& wait_mode);
 
 }  // namespace silkworm::cmd

--- a/cmd/common.hpp
+++ b/cmd/common.hpp
@@ -28,9 +28,6 @@
 
 namespace silkworm::cmd {
 
-//! \brief Ensure database is ready to take off and consistent with command line arguments
-void run_preflight_checklist(NodeSettings& node_settings, bool init_if_empty = true);
-
 //! The overall settings for Silkworm Core component
 struct SilkwormCoreSettings {
     silkworm::log::Settings log_settings;
@@ -40,6 +37,9 @@ struct SilkwormCoreSettings {
 
 //! \brief Parses command line arguments for Silkworm executables
 void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], SilkwormCoreSettings& settings);
+
+//! \brief Ensure database is ready to take off and consistent with command line arguments
+void run_preflight_checklist(NodeSettings& node_settings, bool init_if_empty = true);
 
 //! Assemble the full node name using the Cable build information
 std::string get_node_name_from_build_info(const buildinfo* build_info);

--- a/cmd/common.hpp
+++ b/cmd/common.hpp
@@ -78,7 +78,7 @@ struct PruneModeValidator : public CLI::Validator {
 void add_logging_options(CLI::App& cli, log::Settings& log_settings);
 
 //! \brief Set up option for the network to join
-void add_option_chain(CLI::App& cli, uint64_t & network_id);
+void add_option_chain(CLI::App& cli, uint64_t& network_id);
 
 //! \brief Set up option for the data directory path
 void add_option_data_dir(CLI::App& cli, std::filesystem::path& data_dir);

--- a/cmd/downloader.cpp
+++ b/cmd/downloader.cpp
@@ -100,9 +100,10 @@ int main(int argc, char* argv[]) {
     int return_value = 0;
 
     try {
-        NodeSettings node_settings{};
+        cmd::SilkwormCoreSettings settings;
+        auto& log_settings = settings.log_settings;
+        auto& node_settings = settings.node_settings;
 
-        log::Settings log_settings{};
         log_settings.log_threads = true;
         log_settings.log_file = "downloader.log";
         log_settings.log_verbosity = log::Level::kInfo;
@@ -131,7 +132,7 @@ int main(int argc, char* argv[]) {
         // test & measurement only parameters end
 
         // Command line parsing
-        cmd::parse_silkworm_command_line(app, argc, argv, log_settings, node_settings);
+        cmd::parse_silkworm_command_line(app, argc, argv, settings);
 
         log::init(log_settings);
         log::set_thread_name("stage-loop    ");

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -170,12 +170,10 @@ int main(int argc, char* argv[]) {
                 t1 = std::chrono::steady_clock::now();
                 auto total_duration{t1 - start_time};
                 log::Info("Resource usage",
-                          {
-                              "mem", human_size(get_mem_usage()),
-                              "chain", human_size(node_settings.data_directory->chaindata().size()),
-                              "etl-tmp", human_size(node_settings.data_directory->etl().size()),
-                              "uptime", StopWatch::format(total_duration)
-                          });
+                          {"mem", human_size(get_mem_usage()),
+                           "chain", human_size(node_settings.data_directory->chaindata().size()),
+                           "etl-tmp", human_size(node_settings.data_directory->etl().size()),
+                           "uptime", StopWatch::format(total_duration)});
             }
         }
 
@@ -203,13 +201,16 @@ int main(int argc, char* argv[]) {
         log::Error() << ex.what();
         return -1;
     } catch (const std::invalid_argument& ex) {
-        std::cerr << "\tInvalid argument :" << ex.what() << "\n" << std::endl;
+        std::cerr << "\tInvalid argument :" << ex.what() << "\n"
+                  << std::endl;
         return -3;
     } catch (const std::exception& ex) {
-        std::cerr << "\tUnexpected error : " << ex.what() << "\n" << std::endl;
+        std::cerr << "\tUnexpected error : " << ex.what() << "\n"
+                  << std::endl;
         return -4;
     } catch (...) {
-        std::cerr << "\tUnexpected undefined error\n" << std::endl;
+        std::cerr << "\tUnexpected undefined error\n"
+                  << std::endl;
         return -99;
     }
 }

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -14,7 +14,6 @@
    limitations under the License.
 */
 
-#include <optional>
 #include <regex>
 
 #include <CLI/CLI.hpp>
@@ -27,6 +26,7 @@
 #include <silkworm/db/stages.hpp>
 #include <silkworm/downloader/block_exchange.hpp>
 #include <silkworm/downloader/sentry_client.hpp>
+#include <silkworm/rpc/server/backend_kv_server.hpp>
 #include <silkworm/stagedsync/sync_loop.hpp>
 
 #include "common.hpp"
@@ -79,17 +79,17 @@ int main(int argc, char* argv[]) {
     cli.get_formatter()->column_width(50);
 
     try {
-        log::Settings log_settings{};  // Holds logging settings
-        NodeSettings node_settings{};  // Holds node settings
+        cmd::SilkwormCoreSettings settings;
+        cmd::parse_silkworm_command_line(cli, argc, argv, settings);
 
-        cmd::parse_silkworm_command_line(cli, argc, argv, log_settings, node_settings);
+        auto& node_settings = settings.node_settings;
 
         SignalHandler::init();    // Trap OS signals
-        log::init(log_settings);  // Initialize logging with cli settings
+        log::init(settings.log_settings);  // Initialize logging with cli settings
         log::set_thread_name("main");
 
         // Output BuildInfo
-        auto build_info{silkworm_get_buildinfo()};
+        const auto build_info{silkworm_get_buildinfo()};
         node_settings.build_info =
             "version=" + std::string(build_info->git_branch) + std::string(build_info->project_version) +
             "build=" + std::string(build_info->system_name) + "-" + std::string(build_info->system_processor) +
@@ -127,6 +127,14 @@ int main(int argc, char* argv[]) {
             log::Trace("Boost Asio", {"state", "stopped"});
         }};
 
+        // BackEnd & KV server
+        const auto node_name{silkworm::cmd::get_node_name_from_build_info(build_info)};
+        silkworm::EthereumBackEnd backend{node_settings, &chaindata_db};
+        backend.set_node_name(node_name);
+
+        silkworm::rpc::BackEndKvServer rpc_server{settings.server_settings, backend};
+        rpc_server.build_and_start();
+
         // Sentry client - connects to sentry
         SentryClient sentry{node_settings.external_sentry_addr, db::ROAccess{chaindata_db},
                             node_settings.chain_config.value()};
@@ -160,13 +168,17 @@ int main(int argc, char* argv[]) {
                 auto total_duration{t1 - start_time};
                 log::Info("Resource usage",
                           {
-                              "mem", human_size(get_mem_usage()),                                     //
-                              "chain", human_size(node_settings.data_directory->chaindata().size()),  //
-                              "etl-tmp", human_size(node_settings.data_directory->etl().size()),      //
-                              "uptime", StopWatch::format(total_duration)                             //
+                              "mem", human_size(get_mem_usage()),
+                              "chain", human_size(node_settings.data_directory->chaindata().size()),
+                              "etl-tmp", human_size(node_settings.data_directory->etl().size()),
+                              "uptime", StopWatch::format(total_duration)
                           });
             }
         }
+
+        backend.close();
+        rpc_server.shutdown();
+        rpc_server.join();
 
         block_exchange.stop();
         sentry.stop();
@@ -188,16 +200,13 @@ int main(int argc, char* argv[]) {
         log::Error() << ex.what();
         return -1;
     } catch (const std::invalid_argument& ex) {
-        std::cerr << "\tInvalid argument :" << ex.what() << "\n"
-                  << std::endl;
+        std::cerr << "\tInvalid argument :" << ex.what() << "\n" << std::endl;
         return -3;
     } catch (const std::exception& ex) {
-        std::cerr << "\tUnexpected error : " << ex.what() << "\n"
-                  << std::endl;
+        std::cerr << "\tUnexpected error : " << ex.what() << "\n" << std::endl;
         return -4;
     } catch (...) {
-        std::cerr << "\tUnexpected undefined error\n"
-                  << std::endl;
+        std::cerr << "\tUnexpected undefined error\n" << std::endl;
         return -99;
     }
 }

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -84,8 +84,11 @@ int main(int argc, char* argv[]) {
 
         auto& node_settings = settings.node_settings;
 
-        SignalHandler::init();    // Trap OS signals
-        log::init(settings.log_settings);  // Initialize logging with cli settings
+        // Trap OS signals
+        SignalHandler::init();
+
+        // Initialize logging with cli settings
+        log::init(settings.log_settings);
         log::set_thread_name("main");
 
         // Output BuildInfo

--- a/node/silkworm/rpc/server/call.hpp
+++ b/node/silkworm/rpc/server/call.hpp
@@ -45,15 +45,15 @@ class BaseRpc {
     //! Returns the number of total RPC instances.
     static uint64_t total_count() { return total_count_; }
 
-    BaseRpc(boost::asio::io_context& scheduler) : scheduler_(scheduler) {
+    explicit BaseRpc(boost::asio::io_context& scheduler) : scheduler_(scheduler) {
         ++instance_count_;
         ++total_count_;
-        SILK_TRACE << "BaseRpc::BaseRpc [" << this << "] instances: " << instance_count_ << " total: " << total_count_;
+        SILK_TRACE << "BaseRpc::BaseRpc [" << this << "] instances: " << instance_count() << " total: " << total_count();
     }
 
     virtual ~BaseRpc() {
         --instance_count_;
-        SILK_TRACE << "BaseRpc::~BaseRpc [" << this << "] instances: " << instance_count_ << " total: " << total_count_;
+        SILK_TRACE << "BaseRpc::~BaseRpc [" << this << "] instances: " << instance_count() << " total: " << total_count();
     }
 
     //! Returns a unique identifier of the RPC client for this call.
@@ -127,7 +127,7 @@ class BaseRpc {
     //! Used to access the options and current status of the RPC.
     grpc::ServerContext context_;
 
-    //! Keep track of the total outstanding RPC calls (intentionally signed to spot underflows).
+    //! Keep track of the total outstanding RPC calls (intentionally signed to spot underflow).
     inline static std::atomic_int64_t instance_count_ = 0;
 
     //! Keep track of the total RPC calls.

--- a/node/silkworm/rpc/server/kv_calls.cpp
+++ b/node/silkworm/rpc/server/kv_calls.cpp
@@ -108,7 +108,7 @@ void TxCall::start() {
 
         // Create a new read-only transaction.
         read_only_txn_ = chaindata_env_->start_read();
-        SILK_INFO << "Tx peer: " << peer() << " started tx: " << read_only_txn_.id();
+        SILK_DEBUG << "Tx peer: " << peer() << " started tx: " << read_only_txn_.id();
 
         // Send an unsolicited message containing the transaction ID.
         remote::Pair kv_pair;
@@ -192,7 +192,7 @@ void TxCall::handle_cursor_open(const remote::Cursor* request) {
     // Send the assigned cursor ID back to the client.
     remote::Pair kv_pair;
     kv_pair.set_cursorid(cursor_it->first);
-    SILK_INFO << "Tx peer: " << peer() << " opened cursor: " << kv_pair.cursorid();
+    SILK_DEBUG << "Tx peer: " << peer() << " opened cursor: " << kv_pair.cursorid();
     const bool sent = send_response(kv_pair);
     SILK_TRACE << "TxCall::handle_cursor_open " << this << " sent: " << sent;
 }
@@ -223,13 +223,13 @@ void TxCall::handle_cursor_close(const remote::Cursor* request) {
         return;
     }
     cursors_.erase(cursor_it);
-    SILK_INFO << "Tx peer: " << peer() << " closed cursor: " << request->cursor();
+    SILK_DEBUG << "Tx peer: " << peer() << " closed cursor: " << request->cursor();
     const bool sent = send_response(remote::Pair{});
     SILK_TRACE << "TxCall::handle_cursor_close " << this << " close cursor: " << request->cursor() << " sent: " << sent;
 }
 
 void TxCall::handle_operation(const remote::Cursor* request, db::Cursor& cursor) {
-    SILK_INFO << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " cursor=" << request->cursor();
+    SILK_DEBUG << "Tx peer: " << peer() << " op=" << remote::Op_Name(request->op()) << " cursor=" << request->cursor();
 
     switch (request->op()) {
         case remote::Op::FIRST: {


### PR DESCRIPTION
This PR integrates the BackEnd & KV gRPC server into Silkworm core component, also refactoring how some common options are handled. In particular:
- introduce some functions to add a single command-line option (e.g. `add_option_private_api_address `)
- support both tag and number values for enumerated options (e.g. `--log.verbosity 4` or `--log.verbosity info`)
- move function to build the node name in common place
- add BackEndKvServer startup to Silkworm main
- refactor command-line parsing in standalone Downloader executable