### PR TITLE
Add memory-mapped file implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,14 @@ endif()
 
 # Compiler enforcements on Silkworm
 if(NOT MSVC)
-  add_compile_options(-Werror -Wall -Wextra -pedantic)
+  if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION STREQUAL "12.1.0"))
+    # Avoid -Werror to overcome GCC 12.1.0 bug breaking Google Benchmark build
+    # https://github.com/google/benchmark/issues/1398
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+    add_compile_options(-Wall -Wextra -pedantic)
+  else()
+    add_compile_options(-Werror -Wall -Wextra -pedantic)
+  endif()
   add_compile_options(-Wshadow -Wimplicit-fallthrough -Wsign-conversion)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
   add_compile_options(-Wno-missing-field-initializers -Wnon-virtual-dtor)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,14 +195,7 @@ endif()
 
 # Compiler enforcements on Silkworm
 if(NOT MSVC)
-  if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION STREQUAL "12.1.0"))
-    # Avoid -Werror to overcome GCC 12.1.0 bug breaking Google Benchmark build
-    # https://github.com/google/benchmark/issues/1398
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-    add_compile_options(-Wall -Wextra -pedantic)
-  else()
-    add_compile_options(-Werror -Wall -Wextra -pedantic)
-  endif()
+  add_compile_options(-Werror -Wall -Wextra -pedantic)
   add_compile_options(-Wshadow -Wimplicit-fallthrough -Wsign-conversion)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>)
   add_compile_options(-Wno-missing-field-initializers -Wnon-virtual-dtor)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -24,6 +24,14 @@ hunter_cmake_args(
         ABSL_RUN_TESTS=OFF
 )
 
+# Avoid -Werror to overcome GCC 12.1.0 bug breaking Google Benchmark build
+# https://github.com/google/benchmark/issues/1398
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+hunter_cmake_args(
+  benchmark
+  CMAKE_ARGS BENCHMARK_ENABLE_WERROR=OFF
+)
+
 hunter_config(
   Microsoft.GSL
   VERSION 4.0.0

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -27,8 +27,9 @@ hunter_cmake_args(
 # Avoid -Werror to overcome GCC 12.1.0 bug breaking Google Benchmark build
 # https://github.com/google/benchmark/issues/1398
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-hunter_cmake_args(
+hunter_config(
   benchmark
+  VERSION 1.6.1
   CMAKE_ARGS BENCHMARK_ENABLE_WERROR=OFF
 )
 

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -22,13 +22,12 @@ else()
   add_link_options(-Wl,-z,stack-size=0x1000000)
 endif()
 
-# Benchmarks
-add_subdirectory(benchmark)
-
 # Tests
 add_subdirectory(test)
 
 if(NOT SILKWORM_CORE_ONLY)
+  # Benchmarks
+  add_subdirectory(benchmark)
 
   find_package(absl CONFIG REQUIRED)
   find_package(CLI11 CONFIG REQUIRED)

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -22,6 +22,9 @@ else()
   add_link_options(-Wl,-z,stack-size=0x1000000)
 endif()
 
+# Benchmarks
+add_subdirectory(benchmark)
+
 # Tests
 add_subdirectory(test)
 

--- a/cmd/benchmark/CMakeLists.txt
+++ b/cmd/benchmark/CMakeLists.txt
@@ -14,10 +14,8 @@
    limitations under the License.
 ]]
 
-hunter_add_package(abseil)
-hunter_add_package(benchmark)
-hunter_add_package(Boost COMPONENTS thread)
-hunter_add_package(CLI11)
-hunter_add_package(gRPC)
-hunter_add_package(OpenSSL)
-hunter_add_package(Protobuf)
+find_package(benchmark CONFIG REQUIRED)
+
+file(GLOB_RECURSE SILKWORM_BENCHMARK_TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/node/*_benchmark.cpp")
+add_executable(benchmark_test benchmark_test.cpp ${SILKWORM_BENCHMARK_TESTS})
+target_link_libraries(benchmark_test silkworm_node benchmark::benchmark)

--- a/cmd/benchmark/benchmark_test.cpp
+++ b/cmd/benchmark/benchmark_test.cpp
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();

--- a/cmd/benchmark/benchmark_test.cpp
+++ b/cmd/benchmark/benchmark_test.cpp
@@ -1,17 +1,17 @@
 /*
-Copyright 2022 The Silkworm Authors
+   Copyright 2022 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #include <benchmark/benchmark.h>

--- a/node/silkworm/common/memory_mapped_file.cpp
+++ b/node/silkworm/common/memory_mapped_file.cpp
@@ -19,12 +19,13 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
-#include <cstring>
-
 #include <fcntl.h>
 #include <ftw.h>
-#include <sys/mman.h>
 #include <unistd.h>
+
+#include <cstring>
+
+#include <sys/mman.h>
 #endif
 
 #include <stdexcept>
@@ -105,9 +106,9 @@ void* MemoryMappedFile::mmap(const char* path, FileDescriptor fd, std::size_t le
     }
 
     DWORD dwDesiredAccess = static_cast<DWORD>(read_only ? FILE_MAP_READ : FILE_MAP_ALL_ACCESS);
-    void *memory = (LPTSTR)::MapViewOfFile(mapping_, dwDesiredAccess, 0, static_cast<DWORD>(0), length);
+    void* memory = (LPTSTR)::MapViewOfFile(mapping_, dwDesiredAccess, 0, static_cast<DWORD>(0), length);
 
-    return static_cast<std::uint8_t *>(memory);
+    return static_cast<std::uint8_t*>(memory);
 }
 
 void MemoryMappedFile::unmap(const char* /*path*/, void* address, std::size_t /*length*/) {
@@ -139,13 +140,13 @@ std::pair<uint8_t*, std::size_t> MemoryMappedFile::map_existing(const char* path
     }
     auto _ = gsl::finally([fd]() { ::close(fd); });
 
-    struct stat stat_buffer{};
+    struct stat stat_buffer {};
     if (::fstat(fd, &stat_buffer) == -1) {
         throw std::runtime_error{"fstat failed for: " + std::string{path} + " error: " + strerror(errno)};
     }
     const auto length = static_cast<std::size_t>(stat_buffer.st_size);
 
-    const auto address= mmap(path, fd, length, read_only);
+    const auto address = mmap(path, fd, length, read_only);
 
     return {static_cast<uint8_t*>(address), length};
 }

--- a/node/silkworm/common/memory_mapped_file.cpp
+++ b/node/silkworm/common/memory_mapped_file.cpp
@@ -1,0 +1,192 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "memory_mapped_file.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <cstring>
+
+#include <fcntl.h>
+#include <ftw.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#include <stdexcept>
+#include <string>
+
+#include <gsl/util>
+
+namespace silkworm {
+
+const std::size_t MemoryMappedFile::kPageSize{MemoryMappedFile::get_page_size()};
+
+MemoryMappedFile::MemoryMappedFile(const std::filesystem::path& path, bool read_only)
+    : MemoryMappedFile(path.string().c_str(), read_only) {}
+
+MemoryMappedFile::MemoryMappedFile(const char* path, bool read_only) : path_(path) {
+    std::tie(address_, length_) = map_existing(path, read_only);
+}
+
+MemoryMappedFile::~MemoryMappedFile() {
+    unmap(path_, address_, length_);
+
+#ifdef _WIN32
+    cleanup();
+#endif
+}
+
+#ifdef _WIN32
+std::size_t MemoryMappedFile::get_page_size() noexcept {
+    SYSTEM_INFO system_info;
+    ::GetSystemInfo(&system_info);
+
+    return static_cast<std::size_t>(system_info.dwPageSize);
+}
+
+std::pair<uint8_t*, std::size_t> MemoryMappedFile::map_existing(const char* path, bool read_only) {
+    DWORD dwDesiredAccess = read_only ? GENERIC_READ : (GENERIC_READ | GENERIC_WRITE);
+    DWORD dwSharedMode = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    FileDescriptor fd = {};
+    fd = ::CreateFile(
+        path,
+        dwDesiredAccess,
+        dwSharedMode,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+
+    if (INVALID_HANDLE_VALUE == fd) {
+        throw std::runtime_error{"Failed to create existing file: " + std::string{path} + " error: " + std::to_string(GetLastError())};
+    }
+
+    auto _ = gsl::finally([fd]() { if (INVALID_HANDLE_VALUE != fd) ::CloseHandle(fd); });
+
+    LARGE_INTEGER fileSize;
+    if (!::GetFileSizeEx(fd, &fileSize)) {
+        throw std::runtime_error{"GetFileSizeEx failed for: " + std::string{path} + " error: " + std::to_string(GetLastError())};
+    }
+
+    const auto length = static_cast<std::size_t>(fileSize.QuadPart);
+
+    const auto address = mmap(path, fd, length, read_only);
+    fd = INVALID_HANDLE_VALUE;
+
+    return {static_cast<uint8_t*>(address), length};
+}
+
+void MemoryMappedFile::advise_random() {
+}
+
+void MemoryMappedFile::advise_sequential() {
+}
+
+void* MemoryMappedFile::mmap(const char* path, FileDescriptor fd, std::size_t length, bool read_only) {
+    DWORD flProtect = static_cast<DWORD>(read_only ? PAGE_READONLY : PAGE_READWRITE);
+    mapping_ = ::CreateFileMapping(fd, nullptr, flProtect, 0, static_cast<DWORD>(length), nullptr);
+    if (nullptr == mapping_) {
+        throw std::runtime_error{"CreateFileMapping failed for: " + std::string{path} + " error: " + std::to_string(GetLastError())};
+    }
+
+    DWORD dwDesiredAccess = static_cast<DWORD>(read_only ? FILE_MAP_READ : FILE_MAP_ALL_ACCESS);
+    void *memory = (LPTSTR)::MapViewOfFile(mapping_, dwDesiredAccess, 0, static_cast<DWORD>(0), length);
+
+    return static_cast<std::uint8_t *>(memory);
+}
+
+void MemoryMappedFile::unmap(const char* /*path*/, void* address, std::size_t /*length*/) {
+    if (address != nullptr) {
+        ::UnmapViewOfFile(address);
+    }
+}
+
+void MemoryMappedFile::cleanup() {
+    if (mapping_) {
+        ::CloseHandle(mapping_);
+        mapping_ = nullptr;
+    }
+
+    if (file_) {
+        ::CloseHandle(file_);
+        file_ = nullptr;
+    }
+}
+#else
+std::size_t MemoryMappedFile::get_page_size() noexcept {
+    return static_cast<std::size_t>(::getpagesize());
+}
+
+std::pair<uint8_t*, std::size_t> MemoryMappedFile::map_existing(const char* path, bool read_only) {
+    FileDescriptor fd = ::open(path, read_only ? O_RDONLY : O_RDWR);
+    if (fd == -1) {
+        throw std::runtime_error{"open failed for: " + std::string{path} + " error: " + strerror(errno)};
+    }
+    auto _ = gsl::finally([fd]() { ::close(fd); });
+
+    struct stat stat_buffer{};
+    if (::fstat(fd, &stat_buffer) == -1) {
+        throw std::runtime_error{"fstat failed for: " + std::string{path} + " error: " + strerror(errno)};
+    }
+    const auto length = static_cast<std::size_t>(stat_buffer.st_size);
+
+    const auto address= mmap(path, fd, length, read_only);
+
+    return {static_cast<uint8_t*>(address), length};
+}
+
+void MemoryMappedFile::advise_random() {
+    advise(MADV_RANDOM);
+}
+
+void MemoryMappedFile::advise_sequential() {
+    advise(MADV_SEQUENTIAL);
+}
+
+void* MemoryMappedFile::mmap(const char* path, FileDescriptor fd, std::size_t length, bool read_only) {
+    int flags = MAP_SHARED | MAP_POPULATE;
+
+    const auto address = ::mmap(nullptr, length, read_only ? PROT_READ : (PROT_READ | PROT_WRITE), flags, fd, 0);
+    if (address == MAP_FAILED) {
+        throw std::runtime_error{"mmap failed for: " + std::string{path} + " error: " + strerror(errno)};
+    }
+
+    return address;
+}
+
+void MemoryMappedFile::unmap(const char* path, void* address, std::size_t length) {
+    if (address != nullptr) {
+        const int result = ::munmap(address, length);
+        if (result == -1) {
+            throw std::runtime_error{"munmap failed for: " + std::string{path} + " error: " + strerror(errno)};
+        }
+    }
+}
+
+void MemoryMappedFile::advise(int advice) {
+    const int result = ::madvise(address_, length_, advice);
+    if (result == -1) {
+        // Ignore not implemented in kernel error because it still works (from Erigon)
+        if (errno != ENOSYS) {
+            throw std::runtime_error{"madvise failed for: " + std::string{path_} + " error: " + strerror(errno)};
+        }
+    }
+}
+#endif  // _WIN32
+
+}  // namespace silkworm

--- a/node/silkworm/common/memory_mapped_file.hpp
+++ b/node/silkworm/common/memory_mapped_file.hpp
@@ -94,19 +94,10 @@ class MemoryMappedFile {
   private:
     [[nodiscard]] static std::size_t get_page_size() noexcept;
 
-#ifndef _WIN32
-    [[nodiscard]] static std::pair<uint8_t*, std::size_t> map_existing(const char* path, bool read_only);
+    void map_existing(bool read_only);
 
-    static void* mmap(const char* path, FileDescriptor fd, std::size_t length, bool read_only);
-    static void unmap(const char* path, void* address, std::size_t length);
-
-    void advise(int advice);
-#else
-    [[nodiscard]] std::pair<uint8_t*, std::size_t> map_existing(const char* path, bool read_only);
-
-    void* mmap(const char* path, FileDescriptor fd, std::size_t length, bool read_only);
-    void unmap(const char* path, void* address, std::size_t length);
-#endif
+    void* mmap(FileDescriptor fd, bool read_only);
+    void unmap();
 
     //! The path to the file
     const char* path_;
@@ -122,6 +113,8 @@ class MemoryMappedFile {
 
     HANDLE file_ = nullptr;
     HANDLE mapping_ = nullptr;
+#else
+    void advise(int advice);
 #endif
 };
 

--- a/node/silkworm/common/memory_mapped_file.hpp
+++ b/node/silkworm/common/memory_mapped_file.hpp
@@ -35,10 +35,10 @@
 #pragma once
 
 #ifdef _WIN32
-#pragma warning(disable:4668)
-#pragma warning(disable:4710)
-#pragma warning(disable:4820)
-#pragma warning(disable:5039)
+#pragma warning(disable : 4668)
+#pragma warning(disable : 4710)
+#pragma warning(disable : 4820)
+#pragma warning(disable : 5039)
 #endif
 
 #include <cstddef>
@@ -51,9 +51,10 @@
 #include <fcntl.h>
 #include <ftw.h>
 #include <pwd.h>
+#include <unistd.h>
+
 #include <sys/mman.h>
 #include <sys/types.h>
-#include <unistd.h>
 #endif
 
 //! Raw memory mapped file structure in *nix

--- a/node/silkworm/common/memory_mapped_file.hpp
+++ b/node/silkworm/common/memory_mapped_file.hpp
@@ -1,0 +1,127 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Portions of the following code and inspiration are taken from Aeron [https://github.com/real-logic/aeron]
+
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef _WIN32
+#pragma warning(disable:4668)
+#pragma warning(disable:4710)
+#pragma warning(disable:4820)
+#pragma warning(disable:5039)
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <tuple>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <ftw.h>
+#include <pwd.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+//! Raw memory mapped file structure in *nix
+struct MappedFile {
+    void* address{nullptr};
+    size_t length{0};
+};
+
+namespace silkworm {
+
+#ifdef _WIN32
+typedef void* HANDLE;
+using FileDescriptor = HANDLE;
+#else
+using FileDescriptor = int;
+#endif
+
+class MemoryMappedFile {
+  public:
+    static const std::size_t kPageSize;
+
+    explicit MemoryMappedFile(const std::filesystem::path& path, bool read_only = true);
+    explicit MemoryMappedFile(const char* path, bool read_only = true);
+    ~MemoryMappedFile();
+
+    [[nodiscard]] uint8_t* address() const {
+        return address_;
+    }
+
+    [[nodiscard]] std::size_t length() const {
+        return length_;
+    }
+
+    void advise_random();
+    void advise_sequential();
+
+  private:
+    [[nodiscard]] static std::size_t get_page_size() noexcept;
+
+#ifndef _WIN32
+    [[nodiscard]] static std::pair<uint8_t*, std::size_t> map_existing(const char* path, bool read_only);
+
+    static void* mmap(const char* path, FileDescriptor fd, std::size_t length, bool read_only);
+    static void unmap(const char* path, void* address, std::size_t length);
+
+    void advise(int advice);
+#else
+    [[nodiscard]] std::pair<uint8_t*, std::size_t> map_existing(const char* path, bool read_only);
+
+    void* mmap(const char* path, FileDescriptor fd, std::size_t length, bool read_only);
+    void unmap(const char* path, void* address, std::size_t length);
+#endif
+
+    //! The path to the file
+    const char* path_;
+
+    //! The address of the mapped area
+    uint8_t* address_{nullptr};
+
+    //! The file size
+    std::size_t length_{0};
+
+#ifdef _WIN32
+    void cleanup();
+
+    HANDLE file_ = nullptr;
+    HANDLE mapping_ = nullptr;
+#endif
+};
+
+}  // namespace silkworm

--- a/node/silkworm/common/memory_mapped_file_benchmark.cpp
+++ b/node/silkworm/common/memory_mapped_file_benchmark.cpp
@@ -1,0 +1,82 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "memory_mapped_file.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+
+#include <benchmark/benchmark.h>
+
+#include <silkworm/common/base.hpp>
+#include <silkworm/common/directories.hpp>
+
+constexpr uint64_t k4MiBFileSize{4u * silkworm::kMebi};
+
+static inline std::filesystem::path create_random_temporary_file(int64_t file_size) {
+    auto tmp_file = silkworm::TemporaryDirectory::get_unique_temporary_path();
+    std::ofstream tmp_stream{tmp_file, std::ios_base::binary};
+    std::random_device random_dev;
+    std::mt19937 random_gen(random_dev());
+    std::uniform_int_distribution<> distribution{0, sizeof(char)};
+    for (int64_t i{0u}; i < file_size; ++i) {
+        const auto random_number = static_cast<char>(distribution(random_gen));
+        tmp_stream.write(&random_number, sizeof(char));
+    }
+    tmp_stream.close();
+    return tmp_file;
+}
+
+static void benchmark_checksum_ifstream(benchmark::State& state) {
+    constexpr int kPageSize{1024 * 4};
+    const auto tmp_file_path = create_random_temporary_file(state.range(0));
+
+    for ([[maybe_unused]] auto _ : state) {
+        std::unique_ptr<char[]> buffer{new char[static_cast<std::size_t>(kPageSize)]};
+        std::ifstream snapshot_stream{tmp_file_path, std::ifstream::binary};
+        int checksum{0};
+        std::size_t count{0};
+        while (snapshot_stream) {
+            snapshot_stream.read(buffer.get(), kPageSize);
+            for (uint64_t i{0}; i < static_cast<uint64_t>(snapshot_stream.gcount()); ++i, ++count) {
+                const auto byte{static_cast<unsigned char>(buffer[i])};
+                checksum += byte;
+            }
+        }
+        benchmark::DoNotOptimize(checksum);
+    }
+}
+
+BENCHMARK(benchmark_checksum_ifstream)->Arg(k4MiBFileSize);
+
+static void benchmark_checksum_memory_mapped_file(benchmark::State& state) {
+    const auto tmp_file_path = create_random_temporary_file(state.range(0));
+
+    for ([[maybe_unused]] auto _ : state) {
+        silkworm::MemoryMappedFile mapped_file{tmp_file_path};
+        mapped_file.advise_sequential();
+        int checksum{0};
+        std::size_t count{0};
+        for (auto it{mapped_file.address()}; count < mapped_file.length(); ++it, ++count) {
+            const auto byte{*it};
+            checksum += byte;
+        }
+        benchmark::DoNotOptimize(checksum);
+    }
+}
+
+BENCHMARK(benchmark_checksum_memory_mapped_file)->Arg(k4MiBFileSize);

--- a/node/silkworm/common/memory_mapped_file_benchmark.cpp
+++ b/node/silkworm/common/memory_mapped_file_benchmark.cpp
@@ -14,8 +14,6 @@
    limitations under the License.
 */
 
-#include "memory_mapped_file.hpp"
-
 #include <filesystem>
 #include <fstream>
 #include <random>
@@ -24,6 +22,8 @@
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/directories.hpp>
+
+#include "memory_mapped_file.hpp"
 
 constexpr uint64_t k4MiBFileSize{4u * silkworm::kMebi};
 

--- a/node/silkworm/common/memory_mapped_file_test.cpp
+++ b/node/silkworm/common/memory_mapped_file_test.cpp
@@ -1,0 +1,83 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "memory_mapped_file.hpp"
+
+#include <fstream>
+#include <stdexcept>
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/common/directories.hpp>
+
+namespace silkworm {
+
+TEST_CASE("MemoryMappedFile::kPageSize", "[silkworm][common][memory_mapped_file]") {
+    CHECK(MemoryMappedFile::kPageSize >= 4096);
+}
+
+TEST_CASE("MemoryMappedFile", "[silkworm][common][memory_mapped_file]") {
+    SECTION("constructor fails for nonexistent file") {
+        CHECK_THROWS_AS(MemoryMappedFile{"nonexistent.txt"}, std::runtime_error);
+    }
+
+    SECTION("constructor fails for existent empty file") {
+        const auto tmp_file = TemporaryDirectory::get_unique_temporary_path();
+        std::ofstream tmp_stream{tmp_file, std::ios_base::binary};
+        tmp_stream.close();
+        CHECK_THROWS_AS(MemoryMappedFile{tmp_file}, std::runtime_error);
+    }
+
+    SECTION("constructor succeeds for existent nonempty file") {
+        const auto tmp_file = TemporaryDirectory::get_unique_temporary_path();
+        std::ofstream tmp_stream{tmp_file, std::ios_base::binary};
+        tmp_stream.write("\x01", 1);
+        tmp_stream.close();
+        CHECK_NOTHROW(MemoryMappedFile{tmp_file});
+        CHECK_NOTHROW(MemoryMappedFile{tmp_file, false});
+        CHECK_NOTHROW(MemoryMappedFile{tmp_file.string()});
+        CHECK_NOTHROW(MemoryMappedFile{tmp_file.string(), false});
+    }
+
+    const std::string kFileContent{"\x01\x02\x03"};
+    const auto tmp_file = TemporaryDirectory::get_unique_temporary_path();
+    std::ofstream tmp_stream{tmp_file, std::ios_base::binary};
+    tmp_stream.write(kFileContent.data(), static_cast<std::streamsize>(kFileContent.size()));
+    tmp_stream.close();
+    MemoryMappedFile mmf{tmp_file};
+
+    SECTION("has expected memory address and size") {
+        CHECK(mmf.address() != nullptr);
+        CHECK(mmf.length() == 3);
+    }
+
+    SECTION("has expected content") {
+        const auto data{mmf.address()};
+        CHECK(data[0] == '\x01');
+        CHECK(data[1] == '\x02');
+        CHECK(data[2] == '\x03');
+    }
+
+    SECTION("advise_sequential") {
+        CHECK_NOTHROW(mmf.advise_sequential());
+    }
+
+    SECTION("advise_random") {
+        CHECK_NOTHROW(mmf.advise_random());
+    }
+}
+
+}  // namespace silkworm

--- a/node/silkworm/common/memory_mapped_file_test.cpp
+++ b/node/silkworm/common/memory_mapped_file_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("MemoryMappedFile", "[silkworm][common][memory_mapped_file]") {
 
     SECTION("has expected memory address and size") {
         CHECK(mmf.address() != nullptr);
-        CHECK(mmf.length() == 3);
+        CHECK(mmf.length() == kFileContent.size());
     }
 
     SECTION("has expected content") {


### PR DESCRIPTION
This PR adds a thin memory-mapped file implementation, based on [Aeron's one](https://github.com/real-logic/aeron/blob/master/aeron-client/src/main/cpp/util/MemoryMappedFile.h), as part of the Snapshot Sync functionality. The motivation for introducing this memory-mapped file lies on the performance numbers captured in [its benchmark file](https://github.com/torquem-ch/silkworm/blob/105735fe7512ffc5fa8ffca9eb1358e2458e54ea/node/silkworm/common/memory_mapped_file_benchmark.cpp).

Exactly for the purpose of adding performance benchmarks, this PR includes also the following changes:

- add Google Benchmark as project dependency
- add new `benchmark_test` target built collecting all the benchmark files (i.e. any source code file matching *_benchmark.cpp)

Minor customization in Hunter configuration: it is necessary not to treat warnings as errors in Google Benchmark build to avoid bug in GCC 12.1.0:

- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
