### PR TITLE
Add default build job to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,35 @@ jobs:
           working_directory: ~/build
           command: wasmer cmd/test/core_test
 
+  linux-default-build:
+    docker:
+      - image: ethereum/cpp-build-env:18-gcc-12
+    resource_class: xlarge
+    steps:
+      - checkout_with_submodules
+      - run:
+          name: "Install dependencies"
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y m4 texinfo bison
+      - restore_cache:
+          name: "Restore Hunter cache"
+          key: &cache-key hunter-{{ .Environment.CIRCLE_JOB }}-{{checksum "cmake/Hunter/config.cmake"}}-{{checksum "cmake/toolchain/base.cmake"}}-{{checksum "cmake/toolchain/cxx20.cmake"}}
+      - run:
+          name: "Cmake"
+          working_directory: ~/build
+          command: cmake ../project
+      - save_cache:
+          name: "Save Hunter cache"
+          key: *cache-key
+          paths:
+            - ~/.hunter
+      - run:
+          name: "Build"
+          working_directory: ~/build
+          command: make -j4 # each compiler job requires 4GB of RAM
+      - test
+
 workflows:
   version: 2
   silkworm:
@@ -262,3 +291,4 @@ workflows:
       - linux-clang-13-coverage
       - linux-clang-13-address-sanitizer
       - linux-wasm-build
+      - linux-default-build


### PR DESCRIPTION
This PR add a new job to our CI to prevent any error using the base build procedure as described in our README.

Requires #789 