### PR TITLE
Avoid CMake warning w/o breaking default build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,18 +23,13 @@ endif()
 
 get_directory_property(SILKWORM_HAS_PARENT PARENT_DIRECTORY)
 if(NOT SILKWORM_HAS_PARENT)
-  # Set default CMAKE_TOOLCHAIN_FILE *before* enable_language (otherwise default toolchain build breaks)
+  include(third_party/evmone/cmake/cable/bootstrap.cmake)
+  include(CableBuildType)
+  cable_set_build_type(DEFAULT Release CONFIGURATION_TYPES Release Debug)
+
   if(NOT CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain/cxx20.cmake CACHE FILEPATH "" FORCE)
   endif()
-
-  # Enable language *before* indirectly including GNUInstallDirs (see CableBuildInfo)
-  enable_language(CXX)
-
-  include(third_party/evmone/cmake/cable/bootstrap.cmake)
-  include(CableBuildType)
-  include(CableBuildInfo)
-  cable_set_build_type(DEFAULT Release CONFIGURATION_TYPES Release Debug)
 
   include(third_party/evmone/cmake/cable/HunterGate.cmake)
   HunterGate(
@@ -50,7 +45,6 @@ add the following lines before the project command of your root CMakeLists.txt:
 
 -----------------------------------------------------------------------------------------------------
 include(silkworm/third_party/evmone/cmake/cable/bootstrap.cmake)
-include(CableBuildInfo)
 include(silkworm/third_party/evmone/cmake/cable/HunterGate.cmake)
 HunterGate(
   URL "https://github.com/cpp-pm/hunter/archive/v0.24.3.tar.gz"
@@ -65,6 +59,8 @@ HunterGate(
 
 project(silkworm)
 set(PROJECT_VERSION 0.1.0-dev)
+
+include(CableBuildInfo)
 
 string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ ${PROJECT_VERSION})
 set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,18 @@ endif()
 
 get_directory_property(SILKWORM_HAS_PARENT PARENT_DIRECTORY)
 if(NOT SILKWORM_HAS_PARENT)
+  # Set default CMAKE_TOOLCHAIN_FILE *before* enable_language (otherwise default toolchain build breaks)
+  if(NOT CMAKE_TOOLCHAIN_FILE)
+    set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain/cxx20.cmake CACHE FILEPATH "" FORCE)
+  endif()
+
+  # Enable language *before* indirectly including GNUInstallDirs (see CableBuildInfo)
+  enable_language(CXX)
+
   include(third_party/evmone/cmake/cable/bootstrap.cmake)
   include(CableBuildType)
   include(CableBuildInfo)
   cable_set_build_type(DEFAULT Release CONFIGURATION_TYPES Release Debug)
-
-  if(NOT CMAKE_TOOLCHAIN_FILE)
-    set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain/cxx20.cmake CACHE FILEPATH "" FORCE)
-  endif()
 
   include(third_party/evmone/cmake/cable/HunterGate.cmake)
   HunterGate(


### PR DESCRIPTION
This PR moves the `CableBuildInfo` inclusion in CMake script to avoid this build warning:
```
CMake Warning (dev) at /usr/share/cmake-3.22/Modules/GNUInstallDirs.cmake:239 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  third_party/evmone/cmake/cable/CableBuildInfo.cmake:16 (include)
  CMakeLists.txt:28 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
