### PR TITLE
Add max idle timeout in Tx RPC calls

### DIFF
--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -1016,10 +1016,7 @@ int main(int argc, char* argv[]) {
                     SILK_DEBUG << "Completion thread post operation: " << processor;
                     (*processor)(ok);
                 } else {
-                    SILK_DEBUG << "Got shutdown, draining queue...";
-                    while (queue.Next(&tag, &ok)) {
-                    }
-                    SILK_DEBUG << "Queue fully drained";
+                    SILK_DEBUG << "Got shutdown";
                     SILKWORM_ASSERT(completion_stop);
                 }
             }

--- a/node/silkworm/rpc/server/backend_kv_server_test.cpp
+++ b/node/silkworm/rpc/server/backend_kv_server_test.cpp
@@ -1071,7 +1071,7 @@ class TxIdleTimeoutGuard {
     ~TxIdleTimeoutGuard() { TxCall::set_max_idle_duration(server::kDefaultMaxIdleDuration); }
 };
 
-TEST_CASE("BackEndKvServer E2E: bidirectional idle timeout", "[.]") {
+TEST_CASE("BackEndKvServer E2E: bidirectional idle timeout", "[silkworm][node][rpc]") {
     TxIdleTimeoutGuard timeout_guard{100};
     BackEndKvE2eTest test{silkworm::log::Level::kNone, NodeSettings{}};
     test.fill_tables();
@@ -1090,7 +1090,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional idle timeout", "[.]") {
         CHECK(status.error_message().find("call idle, no incoming request") != std::string::npos);
     }*/
 
-    SECTION("Tx KO: finish after first read (w/o WritesDone)", "[.]") {
+    SECTION("Tx KO: finish after first read (w/o WritesDone)") {
         grpc::ClientContext context;
         const auto tx_reader_writer = kv_client.tx_start(&context);
         remote::Pair response;
@@ -1099,10 +1099,10 @@ TEST_CASE("BackEndKvServer E2E: bidirectional idle timeout", "[.]") {
         auto status = tx_reader_writer->Finish();
         CHECK(!status.ok());
         CHECK(status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED);
-        CHECK(status.error_message().find("call idle, no incoming request") != std::string::npos);
+        CHECK(status.error_message().find("no incoming request") != std::string::npos);
     }
 
-    SECTION("Tx KO: finish after first read and one write/read (w/o WritesDone)", "[.]") {
+    SECTION("Tx KO: finish after first read and one write/read (w/o WritesDone)") {
         grpc::ClientContext context;
         const auto tx_reader_writer = kv_client.tx_start(&context);
         remote::Pair response;
@@ -1118,7 +1118,7 @@ TEST_CASE("BackEndKvServer E2E: bidirectional idle timeout", "[.]") {
         auto status = tx_reader_writer->Finish();
         CHECK(!status.ok());
         CHECK(status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED);
-        CHECK(status.error_message().find("call idle, no incoming request") != std::string::npos);
+        CHECK(status.error_message().find("no incoming request") != std::string::npos);
     }
 }
 
@@ -2218,7 +2218,7 @@ class TxMaxTimeToLiveGuard {
 TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][node][rpc]") {
     constexpr uint8_t kCustomMaxTimeToLive{10};
     TxMaxTimeToLiveGuard ttl_guard{kCustomMaxTimeToLive};
-    BackEndKvE2eTest test{silkworm::log::Level::kTrace, NodeSettings{}};
+    BackEndKvE2eTest test{silkworm::log::Level::kNone, NodeSettings{}};
     test.fill_tables();
     auto kv_client = *test.kv_client;
 

--- a/node/silkworm/rpc/server/kv_calls.hpp
+++ b/node/silkworm/rpc/server/kv_calls.hpp
@@ -23,7 +23,6 @@
 #include <utility>
 #include <vector>
 
-#include <agrpc/asio_grpc.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <grpcpp/grpcpp.h>
 #include <remote/kv.grpc.pb.h>

--- a/node/silkworm/rpc/server/server_context_pool.cpp
+++ b/node/silkworm/rpc/server/server_context_pool.cpp
@@ -80,11 +80,13 @@ void ServerContext::execute_loop_single_threaded(WaitStrategy&& wait_strategy) {
 void ServerContext::execute_loop_multi_threaded() {
     SILK_DEBUG << "Multi-thread execution loop start [" << std::this_thread::get_id() << "]";
     std::thread server_grpc_context_thread{[&]() {
+        log::set_thread_name(build_thread_name("grpc_ctx_s", context_id_).c_str());
         SILK_DEBUG << "Server GrpcContext execution loop start [" << std::this_thread::get_id() << "]";
         server_grpc_context_->run();
         SILK_DEBUG << "Server GrpcContext execution loop end [" << std::this_thread::get_id() << "]";
     }};
     std::thread client_grpc_context_thread{[&]() {
+        log::set_thread_name(build_thread_name("grpc_ctx_c", context_id_).c_str());
         SILK_DEBUG << "Client GrpcContext execution loop start [" << std::this_thread::get_id() << "]";
         client_grpc_context_->run_completion_queue();
         SILK_DEBUG << "Client GrpcContext execution loop end [" << std::this_thread::get_id() << "]";
@@ -93,7 +95,6 @@ void ServerContext::execute_loop_multi_threaded() {
 
     server_grpc_context_work_.reset();
     client_grpc_context_work_.reset();
-    server_grpc_context_->stop();
     client_grpc_context_->stop();
     server_grpc_context_thread.join();
     client_grpc_context_thread.join();


### PR DESCRIPTION
This PR restores the max idle timeout handling in Tx RPC calls.

Moreover, it also introduces some related changes:
- switch back to `boost::asio` timers in Tx RPC calls
- use `boost::asio::dispatch` instead of `boost::asio::post` in StateChanges RPC notification handler
- avoid stopping `asio-grpc` server context on shutdown to make all handlers complete (this can slow down the shutdown in case of heavy load; ideally we could parameterise `rpc::Server::shutdown` and use `GrpcContext::stop` to have immediate shutdown, but let's keep it simple for now)
- restore temporarily disabled BackEndKV unit tests
- avoid completion queue drain in test client