### PR TITLE
Fix Tx RPC flaky test

### DIFF
--- a/node/silkworm/backend/backend_kv_server_test.cpp
+++ b/node/silkworm/backend/backend_kv_server_test.cpp
@@ -2216,7 +2216,7 @@ class TxMaxTimeToLiveGuard {
 };
 
 TEST_CASE("BackEndKvServer E2E: bidirectional max TTL duration", "[silkworm][node][rpc]") {
-    constexpr uint8_t kCustomMaxTimeToLive{10};
+    constexpr uint8_t kCustomMaxTimeToLive{100};
     TxMaxTimeToLiveGuard ttl_guard{kCustomMaxTimeToLive};
     BackEndKvE2eTest test{silkworm::log::Level::kNone, NodeSettings{}};
     test.fill_tables();

--- a/node/silkworm/backend/rpc/kv_calls.cpp
+++ b/node/silkworm/backend/rpc/kv_calls.cpp
@@ -132,13 +132,11 @@ awaitable<void> TxCall::operator()() {
         boost::asio::cancellation_signal signal;
         bool completed{false};
         while (!completed) {
-            SILK_INFO << "Tx peer: " << peer() << " BEFORE ||";
             const auto rv = co_await (
                 read_stream.next() ||
                 max_idle_alarm.async_wait(as_tuple(use_awaitable)) ||
                 max_ttl_alarm.async_wait(as_tuple(use_awaitable)) ||
                 write_stream.next());
-            SILK_INFO << "Tx peer: " << peer() << " AFTER ||";
             if (0 == rv.index()) {  // read request completed
                 if (const bool read_ok = std::get<0>(rv); read_ok) {
                     // Handle incoming request from client


### PR DESCRIPTION
This PR fixes a test failing intermittently due to too low timer granularity