### PR TITLE
Require a number for --channels in backend_kv_test

### DIFF
--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -947,6 +947,8 @@ int main(int argc, char* argv[]) {
         ->capture_default_str();
     app.add_option("--channels", num_channels,
                    "The number of gRPC channels to use as integer")
+        ->required()
+        ->check(CLI::PositiveNumber)
         ->capture_default_str();
     app.add_option("--interval", batch_options.interval_between_calls,
                    "The interval to wait between successive call batches as milliseconds")


### PR DESCRIPTION
`backend_kv_test` executable debug asserts with a vector subscript out of bounds because `channels` is empty. This happens if `--channels` is not specified to be > 0 so require that it is set using the CLI library