### PR TITLE
Change --channels parameter default value

### DIFF
--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -940,7 +940,7 @@ int main(int argc, char* argv[]) {
     CLI::App app{"ETHBACKEND & KV interface test"};
 
     std::string target_uri{"localhost:9090"};
-    int num_channels{0};
+    int num_channels{1};
     BatchOptions batch_options;
     silkworm::log::Level log_level{silkworm::log::Level::kCritical};
     app.add_option("--target", target_uri, "The address to connect to the ETHBACKEND & KV services")


### PR DESCRIPTION
This PR change the default value for the `channels` parameter of the BackEnd&KV test client because at least one channel is necessary.