### PR TITLE
Avoid sentry client consume cpu trying to connect to sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,20 +111,6 @@ jobs:
       - build
       - test
 
-  linux-gcc-10-debug:
-    environment:
-      TOOLCHAIN: cxx20
-      BUILD_TYPE: Debug
-      CLANG_COVERAGE: OFF
-      SANITIZE: OFF
-    docker:
-      - image: ethereum/cpp-build-env:18-gcc-10
-    resource_class: xlarge
-    steps:
-      - checkout_with_submodules
-      - build
-      - test
-
   linux-gcc-12-release:
     environment:
       TOOLCHAIN: cxx20
@@ -285,7 +271,6 @@ workflows:
   version: 2
   silkworm:
     jobs:
-      - linux-gcc-10-debug
       - linux-gcc-12-release
       - linux-gcc-11-thread-sanitizer
       - linux-clang-13-coverage

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git submodule update --init --recursive
 ## Building on Linux & macOS
 
 Building Silkworm requires:
-* C++20 compiler: [GCC](https://www.gnu.org/software/gcc/) >= 10.2.0 or [Clang](https://clang.llvm.org/) >= 12.0.0
+* C++20 compiler: [GCC](https://www.gnu.org/software/gcc/) >= 11.2.0 or [Clang](https://clang.llvm.org/) >= 12.0.0
 * [CMake]
 * Tools for [gmplib](https://gmplib.org/): `sudo apt-get install -y m4 texinfo bison`
 

--- a/node/silkworm/downloader/sentry_client.hpp
+++ b/node/silkworm/downloader/sentry_client.hpp
@@ -73,6 +73,7 @@ class SentryClient : public rpc::Client<sentry::Sentry>, public ActiveComponent 
     db::ROAccess db_access_;
     const ChainConfig& chain_config_;
 
+    std::atomic<bool> connected_{false};
     std::shared_ptr<rpc::HandShake> handshake_;
     std::shared_ptr<rpc::ReceiveMessages> receive_messages_;
     std::shared_ptr<rpc::ReceivePeerStats> receive_peer_stats_;


### PR DESCRIPTION
Sentry client has 2 threads: when the first is blocked waiting for connection to the sentry the second one spins. This PR avoid this.

Note that this PR uses std::atomic::wait, introduced in c++20,  that is not supported on gcc-10 so we removed the gcc-10 CI job.