### PR TITLE
sentry: refactor common RPC type conversions

### DIFF
--- a/node/silkworm/downloader/internals/sentry_type_casts.cpp
+++ b/node/silkworm/downloader/internals/sentry_type_casts.cpp
@@ -30,19 +30,11 @@ constexpr uint64_t& hi(intx::uint128& x) { return x[1]; }
 
 constexpr uint64_t hi(const intx::uint128& x) { return x[1]; }
 
-constexpr uint64_t& lo_lo(intx::uint256& x) { return x[0]; }
-
 constexpr uint64_t lo_lo(const intx::uint256& x) { return x[0]; }
-
-constexpr uint64_t& lo_hi(intx::uint256& x) { return x[1]; }
 
 constexpr uint64_t lo_hi(const intx::uint256& x) { return x[1]; }
 
-constexpr uint64_t& hi_lo(intx::uint256& x) { return x[2]; }
-
 constexpr uint64_t hi_lo(const intx::uint256& x) { return x[2]; }
-
-constexpr uint64_t& hi_hi(intx::uint256& x) { return x[3]; }
 
 constexpr uint64_t hi_hi(const intx::uint256& x) { return x[3]; }
 
@@ -66,18 +58,6 @@ std::unique_ptr<types::H256> to_H256(const intx::uint256& orig) {
     return dest;  // transfer ownership
 }
 
-intx::uint256 uint256_from_H256(const types::H256& orig) {
-    using types::H128, types::H256;
-
-    intx::uint256 dest;
-    hi_hi(dest) = orig.hi().hi();
-    hi_lo(dest) = orig.hi().lo();
-    lo_hi(dest) = orig.lo().hi();
-    lo_lo(dest) = orig.lo().lo();
-
-    return dest;
-}
-
 std::unique_ptr<types::H256> to_H256(const Hash& orig) {
     using types::H128, types::H256, evmc::load64be;
 
@@ -94,21 +74,6 @@ std::unique_ptr<types::H256> to_H256(const Hash& orig) {
     dest->set_allocated_lo(lo);  // take ownership
 
     return dest;  // transfer ownership
-}
-
-Hash hash_from_H256(const types::H256& orig) {
-    uint64_t hi_hi = orig.hi().hi();
-    uint64_t hi_lo = orig.hi().lo();
-    uint64_t lo_hi = orig.lo().hi();
-    uint64_t lo_lo = orig.lo().lo();
-
-    Hash dest;
-    endian::store_big_u64(dest.bytes + 0, hi_hi);
-    endian::store_big_u64(dest.bytes + 8, hi_lo);
-    endian::store_big_u64(dest.bytes + 16, lo_hi);
-    endian::store_big_u64(dest.bytes + 24, lo_lo);
-
-    return dest;
 }
 
 std::unique_ptr<types::H512> to_H512(const Bytes& orig) {

--- a/node/silkworm/downloader/internals/types.hpp
+++ b/node/silkworm/downloader/internals/types.hpp
@@ -25,30 +25,10 @@
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/rlp/encode.hpp>
 #include <silkworm/types/block.hpp>
+#include <silkworm/types/hash.hpp>
 #include <silkworm/types/transaction.hpp>
 
 namespace silkworm {
-
-class Hash : public evmc::bytes32 {
-  public:
-    using evmc::bytes32::bytes32;
-
-    Hash() = default;
-    Hash(ByteView bv) {
-        std::memcpy(bytes, bv.data(), length());
-        SILKWORM_ASSERT(bv.length() == length());
-    }
-
-    static constexpr size_t length() { return sizeof(evmc::bytes32); }
-
-    std::string to_hex() { return silkworm::to_hex(*this); }
-    static Hash from_hex(const std::string& hex) { return {evmc::from_hex<Hash>(hex).value()}; }
-
-    // conversion to ByteView is handled in ByteView class,
-    // conversion operator Byte() { return {bytes, length()}; } is handled elsewhere
-
-    static_assert(sizeof(evmc::bytes32) == 32);
-};
 
 using BigInt = intx::uint256;  // use intx::to_string, from_string, ...
 

--- a/node/silkworm/rpc/interfaces/types.cpp
+++ b/node/silkworm/rpc/interfaces/types.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "types.hpp"
+
+#include <silkworm/common/endian.hpp>
+
+namespace silkworm {
+
+Hash hash_from_H256(const types::H256& orig) {
+    uint64_t hi_hi = orig.hi().hi();
+    uint64_t hi_lo = orig.hi().lo();
+    uint64_t lo_hi = orig.lo().hi();
+    uint64_t lo_lo = orig.lo().lo();
+
+    Hash dest;
+    endian::store_big_u64(dest.bytes + 0, hi_hi);
+    endian::store_big_u64(dest.bytes + 8, hi_lo);
+    endian::store_big_u64(dest.bytes + 16, lo_hi);
+    endian::store_big_u64(dest.bytes + 24, lo_lo);
+
+    return dest;
+}
+
+constexpr uint64_t& lo_lo(intx::uint256& x) { return x[0]; }
+constexpr uint64_t& lo_hi(intx::uint256& x) { return x[1]; }
+constexpr uint64_t& hi_lo(intx::uint256& x) { return x[2]; }
+constexpr uint64_t& hi_hi(intx::uint256& x) { return x[3]; }
+
+intx::uint256 uint256_from_H256(const types::H256& orig) {
+    using types::H128, types::H256;
+
+    intx::uint256 dest;
+    hi_hi(dest) = orig.hi().hi();
+    hi_lo(dest) = orig.hi().lo();
+    lo_hi(dest) = orig.lo().hi();
+    lo_lo(dest) = orig.lo().lo();
+
+    return dest;
+}
+
+}  // namespace silkworm

--- a/node/silkworm/rpc/interfaces/types.hpp
+++ b/node/silkworm/rpc/interfaces/types.hpp
@@ -16,20 +16,14 @@
 
 #pragma once
 
-#include <memory>
-
+#include <intx/intx.hpp>
 #include <types/types.pb.h>
 
-#include <silkworm/rpc/interfaces/types.hpp>
-
-#include "types.hpp"
+#include <silkworm/types/hash.hpp>
 
 namespace silkworm {
 
-std::unique_ptr<types::H256> to_H256(const intx::uint256& orig);
-std::unique_ptr<types::H256> to_H256(const Hash& orig);
-std::unique_ptr<types::H512> to_H512(const Bytes& orig);
-
-Bytes bytes_from_H512(const types::H512& orig);
+Hash hash_from_H256(const types::H256& orig);
+intx::uint256 uint256_from_H256(const types::H256& orig);
 
 }  // namespace silkworm

--- a/node/silkworm/types/hash.hpp
+++ b/node/silkworm/types/hash.hpp
@@ -1,0 +1,50 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include <evmc/evmc.hpp>
+
+#include <silkworm/common/assert.hpp>
+#include <silkworm/common/base.hpp>
+#include <silkworm/common/util.hpp>
+
+namespace silkworm {
+
+class Hash : public evmc::bytes32 {
+  public:
+    using evmc::bytes32::bytes32;
+
+    Hash() = default;
+    explicit Hash(ByteView bv) {
+        std::memcpy(bytes, bv.data(), length());
+        SILKWORM_ASSERT(bv.length() == length());
+    }
+
+    static constexpr size_t length() { return sizeof(evmc::bytes32); }
+
+    std::string to_hex() { return silkworm::to_hex(*this); }
+    static Hash from_hex(const std::string& hex) { return {evmc::from_hex<Hash>(hex).value()}; }
+
+    // conversion to ByteView is handled in ByteView class,
+    // conversion operator Byte() { return {bytes, length()}; } is handled elsewhere
+
+    static_assert(sizeof(evmc::bytes32) == 32);
+};
+
+}  // namespace silkworm

--- a/sentry/silkworm/sentry/rpc/service.cpp
+++ b/sentry/silkworm/sentry/rpc/service.cpp
@@ -24,7 +24,7 @@
 
 #include <silkworm/common/base.hpp>
 #include <silkworm/common/log.hpp>
-#include <silkworm/downloader/internals/sentry_type_casts.hpp>
+#include <silkworm/rpc/interfaces/types.hpp>
 #include <silkworm/rpc/server/call.hpp>
 #include <silkworm/sentry/eth/fork_id.hpp>
 


### PR DESCRIPTION
Sentry is using parts of downloader's sentry_type_casts.hpp which implements interfaces' types.proto helpers.
Those could be useful for other RPCs too.