### PR TITLE
Shanghai fork is based on time rather than block number

### DIFF
--- a/cmd/test/consensus.cpp
+++ b/cmd/test/consensus.cpp
@@ -77,122 +77,94 @@ static const std::map<std::string, ChainConfig> kNetworkConfig{
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-             },
+         .homestead_block = 0,
      }},
     {"EIP150",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
      }},
     {"EIP158",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
      }},
     {"Byzantium",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
      }},
     {"Constantinople",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
      }},
     {"ConstantinopleFix",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
      }},
     {"Istanbul",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
      }},
     {"Berlin",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-                 0,  // Berlin
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
          .muir_glacier_block = 0,
+         .berlin_block = 0,
      }},
     {"London", test::kLondonConfig},
     {"Merge",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-                 0,  // Berlin
-                 0,  // London
-                 0,  // Merge Netsplit (FORK_NEXT_VALUE)
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
          .muir_glacier_block = 0,
+         .berlin_block = 0,
+         .london_block = 0,
          .arrow_glacier_block = 0,
          .gray_glacier_block = 0,
          .terminal_total_difficulty = 0,
@@ -203,19 +175,16 @@ static const std::map<std::string, ChainConfig> kNetworkConfig{
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-                 0,  // Berlin
-                 0,  // London
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
          .muir_glacier_block = 0,
+         .berlin_block = 0,
+         .london_block = 0,
          .arrow_glacier_block = 0,
          .terminal_total_difficulty = 0xC0000,
      }},
@@ -223,126 +192,100 @@ static const std::map<std::string, ChainConfig> kNetworkConfig{
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 5,  // Homestead
-             },
+         .homestead_block = 5,
      }},
     {"HomesteadToEIP150At5",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 5,  // Tangerine Whistle
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 5,
      }},
     {"HomesteadToDaoAt5",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-             },
+         .homestead_block = 0,
          .dao_block = 5,
      }},
     {"EIP158ToByzantiumAt5",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 5,  // Byzantium
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 5,
      }},
     {"ByzantiumToConstantinopleFixAt5",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 5,  // Constantinople
-                 5,  // Petersburg
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 5,
+         .petersburg_block = 5,
      }},
     {"BerlinToLondonAt5",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-                 0,  // Berlin
-                 5,  // London
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
+         .muir_glacier_block = 0,
+         .berlin_block = 0,
+         .london_block = 5,
      }},
     {"EIP2384",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
          .muir_glacier_block = 0,
      }},
     {"ArrowGlacier",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-                 0,  // Berlin
-                 0,  // London
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
          .muir_glacier_block = 0,
+         .berlin_block = 0,
+         .london_block = 0,
          .arrow_glacier_block = 0,
      }},
     {"GrayGlacier",
      {
          .chain_id = 1,
          .seal_engine = SealEngineType::kNoProof,
-         .evmc_fork_blocks =
-             {
-                 0,  // Homestead
-                 0,  // Tangerine Whistle
-                 0,  // Spurious Dragon
-                 0,  // Byzantium
-                 0,  // Constantinople
-                 0,  // Petersburg
-                 0,  // Istanbul
-                 0,  // Berlin
-                 0,  // London
-             },
+         .homestead_block = 0,
+         .tangerine_whistle_block = 0,
+         .spurious_dragon_block = 0,
+         .byzantium_block = 0,
+         .constantinople_block = 0,
+         .petersburg_block = 0,
+         .istanbul_block = 0,
          .muir_glacier_block = 0,
+         .berlin_block = 0,
+         .london_block = 0,
          .arrow_glacier_block = 0,
          .gray_glacier_block = 0,
      }},
@@ -647,6 +590,7 @@ RunResults transaction_test(const nlohmann::json& j) {
         }
 
         const ChainConfig& config{kNetworkConfig.at(entry.key())};
+        const evmc_revision rev{config.revision(/*block_number=*/0, /*block_time=*/0)};
 
         /* pre_validate_transaction checks for invalid signature only if from is empty, which means sender recovery
          * phase (which btw also verifies signature) was not triggered yet. In the context of tests, instead, from is
@@ -657,7 +601,7 @@ RunResults transaction_test(const nlohmann::json& j) {
         txn.from.reset();
 
         if (ValidationResult err{
-                pre_validate_transaction(txn, /*block_number=*/0, config, /*base_fee_per_gas=*/std::nullopt)};
+                pre_validate_transaction(txn, rev, config.chain_id, /*base_fee_per_gas=*/std::nullopt)};
             err != ValidationResult::kOk) {
             if (should_be_valid) {
                 std::cout << "Validation error " << magic_enum::enum_name<ValidationResult>(err) << std::endl;
@@ -703,7 +647,6 @@ RunResults transaction_test(const nlohmann::json& j) {
         }
 
         const auto expected_intrinsic_gas{intx::from_string<intx::uint256>(test["intrinsicGas"].get<std::string>())};
-        const evmc_revision rev{config.revision(/*block_number=*/0)};
         const auto calculated_intrinsic_gas{intrinsic_gas(txn, rev)};
         if (calculated_intrinsic_gas != expected_intrinsic_gas) {
             std::cout << "Intrinsic gas mismatch for " << entry.key() << ":\n"

--- a/core/silkworm/chain/config.hpp
+++ b/core/silkworm/chain/config.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <map>
 #include <optional>
@@ -38,26 +37,6 @@ enum class SealEngineType {
 };
 
 struct ChainConfig {
-    static constexpr const char* kJsonForkNames[]{
-        "homesteadBlock",  // EVMC_HOMESTEAD
-        // there's no evmc_revision for daoForkBlock
-        "eip150Block",          // EVMC_TANGERINE_WHISTLE
-        "eip155Block",          // EVMC_SPURIOUS_DRAGON
-        "byzantiumBlock",       // EVMC_BYZANTIUM
-        "constantinopleBlock",  // EVMC_CONSTANTINOPLE
-        "petersburgBlock",      // EVMC_PETERSBURG
-        "istanbulBlock",        // EVMC_ISTANBUL
-        // there's no evmc_revision for muirGlacierBlock
-        "berlinBlock",  // EVMC_BERLIN
-        "londonBlock",  // EVMC_LONDON
-        // there's no evmc_revision for arrowGlacierBlock, nor for grayGlacierBlock
-        "mergeNetsplitBlock",  // EVMC_PARIS, corresponds to FORK_NEXT_VALUE of EIP-3675
-        "shanghaiBlock",       // EVMC_SHANGHAI
-        "cancunBlock",         // EVMC_CANCUN
-    };
-
-    static_assert(std::size(kJsonForkNames) == EVMC_MAX_REVISION);
-
     //! \brief Returns the chain identifier
     //! \see https://eips.ethereum.org/EIPS/eip-155
     uint64_t chain_id{0};
@@ -68,45 +47,34 @@ struct ChainConfig {
     //! \brief Returns the type of seal engine
     SealEngineType seal_engine{SealEngineType::kNoProof};
 
-    //! \brief Block numbers of forks that have an evmc_revision value
-    std::array<std::optional<uint64_t>, EVMC_MAX_REVISION> evmc_fork_blocks{};
-
-    //! \see https://eips.ethereum.org/EIPS/eip-779
-    std::optional<uint64_t> dao_block{std::nullopt};
-
-    //! \see https://eips.ethereum.org/EIPS/eip-2387
-    std::optional<uint64_t> muir_glacier_block{std::nullopt};
-
-    //! \see https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md
-    std::optional<uint64_t> arrow_glacier_block{std::nullopt};
-
-    //! \see https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md
-    std::optional<uint64_t> gray_glacier_block{std::nullopt};
+    // https://github.com/ethereum/execution-specs/tree/master/network-upgrades/mainnet-upgrades
+    std::optional<BlockNum> homestead_block{std::nullopt};
+    std::optional<BlockNum> dao_block{std::nullopt};
+    std::optional<BlockNum> tangerine_whistle_block{std::nullopt};
+    std::optional<BlockNum> spurious_dragon_block{std::nullopt};
+    std::optional<BlockNum> byzantium_block{std::nullopt};
+    std::optional<BlockNum> constantinople_block{std::nullopt};
+    std::optional<BlockNum> petersburg_block{std::nullopt};
+    std::optional<BlockNum> istanbul_block{std::nullopt};
+    std::optional<BlockNum> muir_glacier_block{std::nullopt};
+    std::optional<BlockNum> berlin_block{std::nullopt};
+    std::optional<BlockNum> london_block{std::nullopt};
+    std::optional<BlockNum> arrow_glacier_block{std::nullopt};
+    std::optional<BlockNum> gray_glacier_block{std::nullopt};
 
     //! \brief PoW to PoS switch
-    //! \see EIP-3675
+    //! \see EIP-3675: Upgrade consensus to Proof-of-Stake
     std::optional<intx::uint256> terminal_total_difficulty{std::nullopt};
-    std::optional<uint64_t> terminal_block_number{std::nullopt};
-    std::optional<evmc::bytes32> terminal_block_hash{std::nullopt};
+    std::optional<BlockNum> merge_netsplit_block{std::nullopt};  // FORK_NEXT_VALUE in EIP-3675
+
+    // Starting from Shanghai, forks are triggered by block time rather than number
+    std::optional<uint64_t> shanghai_time{std::nullopt};
+    std::optional<uint64_t> cancun_time{std::nullopt};
 
     //! \brief Returns the revision level at given block number
     //! \details In other words, on behalf of Json chain config data
     //! returns whether specific HF have occurred
-    [[nodiscard]] constexpr evmc_revision revision(uint64_t block_number) const noexcept {
-        for (size_t i{EVMC_MAX_REVISION}; i > 0; --i) {
-            if (evmc_fork_blocks[i - 1].has_value() && block_number >= evmc_fork_blocks[i - 1].value()) {
-                return static_cast<evmc_revision>(i);
-            }
-        }
-        return EVMC_FRONTIER;
-    }
-
-    //! \details As ancillary to revision this returns at which block
-    //! a specific revision has occurred. If return value is std::nullopt
-    //! it means the actual chain either does not support such revision
-    [[nodiscard]] std::optional<uint64_t> revision_block(evmc_revision rev) const noexcept;
-
-    void set_revision_block(evmc_revision rev, std::optional<uint64_t> block);
+    [[nodiscard]] evmc_revision revision(uint64_t block_number, uint64_t block_time) const noexcept;
 
     std::vector<BlockNum> distinct_fork_numbers() const;
 
@@ -141,20 +109,17 @@ inline constexpr evmc::bytes32 kMainnetGenesisHash{0xd4e56740f876aef8c010b86a40d
 inline constexpr ChainConfig kMainnetConfig{
     .chain_id = 1,
     .seal_engine = SealEngineType::kEthash,
-    .evmc_fork_blocks =
-        {
-            1'150'000,   // Homestead
-            2'463'000,   // Tangerine Whistle
-            2'675'000,   // Spurious Dragon
-            4'370'000,   // Byzantium
-            7'280'000,   // Constantinople
-            7'280'000,   // Petersburg
-            9'069'000,   // Istanbul
-            12'244'000,  // Berlin
-            12'965'000,  // London
-        },
+    .homestead_block = 1'150'000,
     .dao_block = 1'920'000,
+    .tangerine_whistle_block = 2'463'000,
+    .spurious_dragon_block = 2'675'000,
+    .byzantium_block = 4'370'000,
+    .constantinople_block = 7'280'000,
+    .petersburg_block = 7'280'000,
+    .istanbul_block = 9'069'000,
     .muir_glacier_block = 9'200'000,
+    .berlin_block = 12'244'000,
+    .london_block = 12'965'000,
     .arrow_glacier_block = 13'773'000,
     .gray_glacier_block = 15'050'000,
     .terminal_total_difficulty = intx::from_string<intx::uint256>("58750000000000000000000"),
@@ -164,36 +129,30 @@ inline constexpr evmc::bytes32 kRinkebyGenesisHash{0x6341fd3daf94b748c72ced5a5b2
 inline constexpr ChainConfig kRinkebyConfig{
     .chain_id = 4,
     .seal_engine = SealEngineType::kClique,
-    .evmc_fork_blocks =
-        {
-            1,          // Homestead
-            2,          // Tangerine Whistle
-            3,          // Spurious Dragon
-            1'035'301,  // Byzantium
-            3'660'663,  // Constantinople
-            4'321'234,  // Petersburg
-            5'435'345,  // Istanbul
-            8'290'928,  // Berlin
-            8'897'988,  // London
-        },
+    .homestead_block = 1,
+    .tangerine_whistle_block = 2,
+    .spurious_dragon_block = 3,
+    .byzantium_block = 1'035'301,
+    .constantinople_block = 3'660'663,
+    .petersburg_block = 4'321'234,
+    .istanbul_block = 5'435'345,
+    .berlin_block = 8'290'928,
+    .london_block = 8'897'988,
 };
 
 inline constexpr evmc::bytes32 kGoerliGenesisHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
 inline constexpr ChainConfig kGoerliConfig{
     .chain_id = 5,
     .seal_engine = SealEngineType::kClique,
-    .evmc_fork_blocks =
-        {
-            0,          // Homestead
-            0,          // Tangerine Whistle
-            0,          // Spurious Dragon
-            0,          // Byzantium
-            0,          // Constantinople
-            0,          // Petersburg
-            1'561'651,  // Istanbul
-            4'460'644,  // Berlin
-            5'062'605,  // London
-        },
+    .homestead_block = 0,
+    .tangerine_whistle_block = 0,
+    .spurious_dragon_block = 0,
+    .byzantium_block = 0,
+    .constantinople_block = 0,
+    .petersburg_block = 0,
+    .istanbul_block = 1'561'651,
+    .berlin_block = 4'460'644,
+    .london_block = 5'062'605,
     .terminal_total_difficulty = 10790000,
 };
 
@@ -201,21 +160,18 @@ inline constexpr evmc::bytes32 kSepoliaGenesisHash{0x25a5cc106eea7138acab33231d7
 inline constexpr ChainConfig kSepoliaConfig{
     .chain_id = 11155111,
     .seal_engine = SealEngineType::kEthash,
-    .evmc_fork_blocks =
-        {
-            0,        // Homestead
-            0,        // Tangerine Whistle
-            0,        // Spurious Dragon
-            0,        // Byzantium
-            0,        // Constantinople
-            0,        // Petersburg
-            0,        // Istanbul
-            0,        // Berlin
-            0,        // London
-            1735371,  // Merge Netsplit
-        },
+    .homestead_block = 0,
+    .tangerine_whistle_block = 0,
+    .spurious_dragon_block = 0,
+    .byzantium_block = 0,
+    .constantinople_block = 0,
+    .petersburg_block = 0,
+    .istanbul_block = 0,
     .muir_glacier_block = 0,
+    .berlin_block = 0,
+    .london_block = 0,
     .terminal_total_difficulty = 17000000000000000,
+    .merge_netsplit_block = 1735371,
 };
 
 //! \brief Looks up a known chain config provided its chain ID

--- a/core/silkworm/chain/config_test.cpp
+++ b/core/silkworm/chain/config_test.cpp
@@ -18,6 +18,8 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/common/test_util.hpp>
+
 using namespace evmc::literals;
 
 namespace silkworm {
@@ -44,61 +46,52 @@ TEST_CASE("Config lookup") {
 }
 
 TEST_CASE("Config revision") {
-    CHECK(kMainnetConfig.revision_block(EVMC_FRONTIER) == 0);
-    CHECK(kMainnetConfig.revision_block(EVMC_HOMESTEAD) == 1'150'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_TANGERINE_WHISTLE) == 2'463'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_SPURIOUS_DRAGON) == 2'675'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_BYZANTIUM) == 4'370'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_CONSTANTINOPLE) == 7'280'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_PETERSBURG) == 7'280'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_ISTANBUL) == 9'069'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_BERLIN) == 12'244'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_LONDON) == 12'965'000);
-    CHECK(kMainnetConfig.revision_block(EVMC_SHANGHAI) == std::nullopt);
+    CHECK(kMainnetConfig.revision(0, 0) == EVMC_FRONTIER);
+    CHECK(kMainnetConfig.revision(1, 0) == EVMC_FRONTIER);
+    CHECK(kMainnetConfig.revision(200'000, 0) == EVMC_FRONTIER);
+    CHECK(kMainnetConfig.revision(1'000'000, 0) == EVMC_FRONTIER);
+    CHECK(kMainnetConfig.revision(1'149'999, 0) == EVMC_FRONTIER);
+    CHECK(kMainnetConfig.revision(1'150'000, 0) == EVMC_HOMESTEAD);
+    CHECK(kMainnetConfig.revision(1'150'001, 0) == EVMC_HOMESTEAD);
+    CHECK(kMainnetConfig.revision(2'000'000, 0) == EVMC_HOMESTEAD);
+    CHECK(kMainnetConfig.revision(2'462'999, 0) == EVMC_HOMESTEAD);
+    CHECK(kMainnetConfig.revision(2'463'000, 0) == EVMC_TANGERINE_WHISTLE);
+    CHECK(kMainnetConfig.revision(2'463'001, 0) == EVMC_TANGERINE_WHISTLE);
+    CHECK(kMainnetConfig.revision(2'674'999, 0) == EVMC_TANGERINE_WHISTLE);
+    CHECK(kMainnetConfig.revision(2'675'000, 0) == EVMC_SPURIOUS_DRAGON);
+    CHECK(kMainnetConfig.revision(2'675'001, 0) == EVMC_SPURIOUS_DRAGON);
+    CHECK(kMainnetConfig.revision(3'000'000, 0) == EVMC_SPURIOUS_DRAGON);
+    CHECK(kMainnetConfig.revision(4'000'000, 0) == EVMC_SPURIOUS_DRAGON);
+    CHECK(kMainnetConfig.revision(4'369'999, 0) == EVMC_SPURIOUS_DRAGON);
+    CHECK(kMainnetConfig.revision(4'370'000, 0) == EVMC_BYZANTIUM);
+    CHECK(kMainnetConfig.revision(4'370'001, 0) == EVMC_BYZANTIUM);
+    CHECK(kMainnetConfig.revision(5'000'000, 0) == EVMC_BYZANTIUM);
+    CHECK(kMainnetConfig.revision(6'000'000, 0) == EVMC_BYZANTIUM);
+    CHECK(kMainnetConfig.revision(7'000'000, 0) == EVMC_BYZANTIUM);
+    CHECK(kMainnetConfig.revision(7'279'999, 0) == EVMC_BYZANTIUM);
+    CHECK(kMainnetConfig.revision(7'280'000, 0) == EVMC_PETERSBURG);
+    CHECK(kMainnetConfig.revision(7'280'001, 0) == EVMC_PETERSBURG);
+    CHECK(kMainnetConfig.revision(8'000'000, 0) == EVMC_PETERSBURG);
+    CHECK(kMainnetConfig.revision(9'000'000, 0) == EVMC_PETERSBURG);
+    CHECK(kMainnetConfig.revision(9'068'999, 0) == EVMC_PETERSBURG);
+    CHECK(kMainnetConfig.revision(9'069'000, 0) == EVMC_ISTANBUL);
+    CHECK(kMainnetConfig.revision(9'069'001, 0) == EVMC_ISTANBUL);
+    CHECK(kMainnetConfig.revision(9'200'000, 0) == EVMC_ISTANBUL);  // Muir Glacier doesn't have an evmc_revision
+    CHECK(kMainnetConfig.revision(10'000'000, 0) == EVMC_ISTANBUL);
+    CHECK(kMainnetConfig.revision(11'000'000, 0) == EVMC_ISTANBUL);
+    CHECK(kMainnetConfig.revision(12'000'000, 0) == EVMC_ISTANBUL);
+    CHECK(kMainnetConfig.revision(12'243'999, 0) == EVMC_ISTANBUL);
+    CHECK(kMainnetConfig.revision(12'244'000, 0) == EVMC_BERLIN);
+    CHECK(kMainnetConfig.revision(12'244'001, 0) == EVMC_BERLIN);
+    CHECK(kMainnetConfig.revision(12'964'999, 0) == EVMC_BERLIN);
+    CHECK(kMainnetConfig.revision(12'965'000, 0) == EVMC_LONDON);
+    CHECK(kMainnetConfig.revision(12'965'001, 0) == EVMC_LONDON);
+    CHECK(kMainnetConfig.revision(13'000'000, 0) == EVMC_LONDON);
+    CHECK(kMainnetConfig.revision(13'773'000, 0) == EVMC_LONDON);  // Arrow Glacier doesn't have an evmc_revision
+    CHECK(kMainnetConfig.revision(14'000'000, 0) == EVMC_LONDON);
 
-    CHECK(kMainnetConfig.revision(0) == EVMC_FRONTIER);
-    CHECK(kMainnetConfig.revision(1) == EVMC_FRONTIER);
-    CHECK(kMainnetConfig.revision(200'000) == EVMC_FRONTIER);
-    CHECK(kMainnetConfig.revision(1'000'000) == EVMC_FRONTIER);
-    CHECK(kMainnetConfig.revision(1'149'999) == EVMC_FRONTIER);
-    CHECK(kMainnetConfig.revision(1'150'000) == EVMC_HOMESTEAD);
-    CHECK(kMainnetConfig.revision(1'150'001) == EVMC_HOMESTEAD);
-    CHECK(kMainnetConfig.revision(2'000'000) == EVMC_HOMESTEAD);
-    CHECK(kMainnetConfig.revision(2'462'999) == EVMC_HOMESTEAD);
-    CHECK(kMainnetConfig.revision(2'463'000) == EVMC_TANGERINE_WHISTLE);
-    CHECK(kMainnetConfig.revision(2'463'001) == EVMC_TANGERINE_WHISTLE);
-    CHECK(kMainnetConfig.revision(2'674'999) == EVMC_TANGERINE_WHISTLE);
-    CHECK(kMainnetConfig.revision(2'675'000) == EVMC_SPURIOUS_DRAGON);
-    CHECK(kMainnetConfig.revision(2'675'001) == EVMC_SPURIOUS_DRAGON);
-    CHECK(kMainnetConfig.revision(3'000'000) == EVMC_SPURIOUS_DRAGON);
-    CHECK(kMainnetConfig.revision(4'000'000) == EVMC_SPURIOUS_DRAGON);
-    CHECK(kMainnetConfig.revision(4'369'999) == EVMC_SPURIOUS_DRAGON);
-    CHECK(kMainnetConfig.revision(4'370'000) == EVMC_BYZANTIUM);
-    CHECK(kMainnetConfig.revision(4'370'001) == EVMC_BYZANTIUM);
-    CHECK(kMainnetConfig.revision(5'000'000) == EVMC_BYZANTIUM);
-    CHECK(kMainnetConfig.revision(6'000'000) == EVMC_BYZANTIUM);
-    CHECK(kMainnetConfig.revision(7'000'000) == EVMC_BYZANTIUM);
-    CHECK(kMainnetConfig.revision(7'279'999) == EVMC_BYZANTIUM);
-    CHECK(kMainnetConfig.revision(7'280'000) == EVMC_PETERSBURG);
-    CHECK(kMainnetConfig.revision(7'280'001) == EVMC_PETERSBURG);
-    CHECK(kMainnetConfig.revision(8'000'000) == EVMC_PETERSBURG);
-    CHECK(kMainnetConfig.revision(9'000'000) == EVMC_PETERSBURG);
-    CHECK(kMainnetConfig.revision(9'068'999) == EVMC_PETERSBURG);
-    CHECK(kMainnetConfig.revision(9'069'000) == EVMC_ISTANBUL);
-    CHECK(kMainnetConfig.revision(9'069'001) == EVMC_ISTANBUL);
-    CHECK(kMainnetConfig.revision(9'200'000) == EVMC_ISTANBUL);  // Muir Glacier doesn't have an evmc_revision
-    CHECK(kMainnetConfig.revision(10'000'000) == EVMC_ISTANBUL);
-    CHECK(kMainnetConfig.revision(11'000'000) == EVMC_ISTANBUL);
-    CHECK(kMainnetConfig.revision(12'000'000) == EVMC_ISTANBUL);
-    CHECK(kMainnetConfig.revision(12'243'999) == EVMC_ISTANBUL);
-    CHECK(kMainnetConfig.revision(12'244'000) == EVMC_BERLIN);
-    CHECK(kMainnetConfig.revision(12'244'001) == EVMC_BERLIN);
-    CHECK(kMainnetConfig.revision(12'964'999) == EVMC_BERLIN);
-    CHECK(kMainnetConfig.revision(12'965'000) == EVMC_LONDON);
-    CHECK(kMainnetConfig.revision(12'965'001) == EVMC_LONDON);
-    CHECK(kMainnetConfig.revision(13'000'000) == EVMC_LONDON);
-    CHECK(kMainnetConfig.revision(13'773'000) == EVMC_LONDON);  // Arrow Glacier doesn't have an evmc_revision
-    CHECK(kMainnetConfig.revision(14'000'000) == EVMC_LONDON);
+    CHECK(test::kLondonConfig.revision(0, 0) == EVMC_LONDON);
+    CHECK(test::kShanghaiConfig.revision(0, 0) == EVMC_SHANGHAI);
 }
 
 TEST_CASE("distinct_fork_numbers") {
@@ -175,8 +168,6 @@ TEST_CASE("JSON serialization") {
             "berlinBlock":0,
             "londonBlock":0,
             "terminalTotalDifficulty":"39387012740608862000000",
-            "terminalBlockNumber":10000,
-            "terminalBlockHash":"0x6dc57fd586f41ee340124c3a005642af7731a9ca7a7b70d989a7e2833e4ab740",
             "mergeNetsplitBlock":10000
         })");
 
@@ -184,9 +175,7 @@ TEST_CASE("JSON serialization") {
 
     REQUIRE(config2);
     CHECK(config2->terminal_total_difficulty == intx::from_string<intx::uint256>("39387012740608862000000"));
-    CHECK(config2->terminal_block_number == 10000);
-    CHECK(config2->terminal_block_hash == 0x6dc57fd586f41ee340124c3a005642af7731a9ca7a7b70d989a7e2833e4ab740_bytes32);
-    CHECK(config2->revision_block(EVMC_PARIS) == 10000);
+    CHECK(config2->merge_netsplit_block == 10000);
 
     CHECK(config2->to_json() == merge_test_json);
 }

--- a/core/silkworm/chain/difficulty.cpp
+++ b/core/silkworm/chain/difficulty.cpp
@@ -21,7 +21,7 @@ namespace silkworm {
 intx::uint256 canonical_difficulty(uint64_t block_number, const uint64_t block_timestamp,
                                    const intx::uint256& parent_difficulty, const uint64_t parent_timestamp,
                                    const bool parent_has_uncles, const ChainConfig& config) {
-    const evmc_revision rev{config.revision(block_number)};
+    const evmc_revision rev{config.revision(block_number, block_timestamp)};
 
     intx::uint256 difficulty{parent_difficulty};
 

--- a/core/silkworm/chain/genesis.cpp
+++ b/core/silkworm/chain/genesis.cpp
@@ -94,7 +94,7 @@ BlockHeader read_genesis_header(const nlohmann::json& genesis_json, const evmc::
 
     const std::optional<ChainConfig> chain_config{ChainConfig::from_json(genesis_json["config"])};
     SILKWORM_ASSERT(chain_config.has_value());
-    if (chain_config->revision(0) >= EVMC_LONDON) {
+    if (chain_config->revision(0, header.timestamp) >= EVMC_LONDON) {
         header.base_fee_per_gas = param::kInitialBaseFee;
     }
 

--- a/core/silkworm/common/test_util.hpp
+++ b/core/silkworm/common/test_util.hpp
@@ -31,24 +31,37 @@ inline constexpr ChainConfig kFrontierConfig{
 inline constexpr ChainConfig kLondonConfig{
     .chain_id = 1,
     .seal_engine = SealEngineType::kNoProof,
-    .evmc_fork_blocks = {0, 0, 0, 0, 0, 0, 0, 0, 0},
+    .homestead_block = 0,
+    .tangerine_whistle_block = 0,
+    .spurious_dragon_block = 0,
+    .byzantium_block = 0,
+    .constantinople_block = 0,
+    .petersburg_block = 0,
+    .istanbul_block = 0,
     .muir_glacier_block = 0,
+    .berlin_block = 0,
+    .london_block = 0,
 };
-
-static_assert(kLondonConfig.revision(0) == EVMC_LONDON);
 
 /// Enables Shanghai from genesis.
 inline constexpr ChainConfig kShanghaiConfig{
     .chain_id = 1,
     .seal_engine = SealEngineType::kNoProof,
-    .evmc_fork_blocks = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    .homestead_block = 0,
+    .tangerine_whistle_block = 0,
+    .spurious_dragon_block = 0,
+    .byzantium_block = 0,
+    .constantinople_block = 0,
+    .petersburg_block = 0,
+    .istanbul_block = 0,
     .muir_glacier_block = 0,
+    .berlin_block = 0,
+    .london_block = 0,
     .arrow_glacier_block = 0,
     .gray_glacier_block = 0,
     .terminal_total_difficulty = 0,
+    .shanghai_time = 0,
 };
-
-static_assert(kShanghaiConfig.revision(0) == EVMC_SHANGHAI);
 
 std::vector<Transaction> sample_transactions();
 std::vector<Receipt> sample_receipts();

--- a/core/silkworm/consensus/base/engine.cpp
+++ b/core/silkworm/consensus/base/engine.cpp
@@ -33,8 +33,9 @@ ValidationResult EngineBase::pre_validate_block_body(const Block& block, const B
         return ValidationResult::kWrongTransactionsRoot;
     }
 
+    const evmc_revision rev{chain_config_.revision(header.number, header.timestamp)};
     for (const Transaction& txn : block.transactions) {
-        if (ValidationResult err{pre_validate_transaction(txn, header.number, chain_config_, header.base_fee_per_gas)};
+        if (ValidationResult err{pre_validate_transaction(txn, rev, chain_config_.chain_id, header.base_fee_per_gas)};
             err != ValidationResult::kOk) {
             return err;
         }
@@ -126,7 +127,7 @@ ValidationResult EngineBase::validate_block_header(const BlockHeader& header, co
     }
 
     uint64_t parent_gas_limit{parent->gas_limit};
-    if (header.number == chain_config_.revision_block(EVMC_LONDON)) {
+    if (header.number == chain_config_.london_block) {
         parent_gas_limit = parent->gas_limit * param::kElasticityMultiplier;  // EIP-1559
     }
 
@@ -194,11 +195,11 @@ evmc::address EngineBase::get_beneficiary(const BlockHeader& header) { return he
 
 std::optional<intx::uint256> EngineBase::expected_base_fee_per_gas(const BlockHeader& header,
                                                                    const BlockHeader& parent) {
-    if (chain_config_.revision(header.number) < EVMC_LONDON) {
+    if (chain_config_.revision(header.number, header.timestamp) < EVMC_LONDON) {
         return std::nullopt;
     }
 
-    if (header.number == chain_config_.revision_block(EVMC_LONDON)) {
+    if (header.number == chain_config_.london_block) {
         return param::kInitialBaseFee;
     }
 

--- a/core/silkworm/consensus/engine.cpp
+++ b/core/silkworm/consensus/engine.cpp
@@ -30,12 +30,10 @@ namespace silkworm::consensus {
 
 void IEngine::finalize(IntraBlockState&, const Block&, evmc_revision) {}
 
-ValidationResult pre_validate_transaction(const Transaction& txn, uint64_t block_number, const ChainConfig& config,
+ValidationResult pre_validate_transaction(const Transaction& txn, const evmc_revision rev, const uint64_t chain_id,
                                           const std::optional<intx::uint256>& base_fee_per_gas) {
-    const evmc_revision rev{config.revision(block_number)};
-
     if (txn.chain_id.has_value()) {
-        if (rev < EVMC_SPURIOUS_DRAGON || txn.chain_id.value() != config.chain_id) {
+        if (rev < EVMC_SPURIOUS_DRAGON || txn.chain_id.value() != chain_id) {
             return ValidationResult::kWrongChainId;
         }
     }

--- a/core/silkworm/consensus/engine.hpp
+++ b/core/silkworm/consensus/engine.hpp
@@ -68,7 +68,7 @@ class IEngine {
 //! \return Any of kIntrinsicGas, kInvalidSignature, kWrongChainId, kUnsupportedTransactionType, or kOk.
 //! \remarks Should sender of transaction not yet recovered a check on signature's validity is performed
 //! \remarks These function is agnostic to whole block validity
-ValidationResult pre_validate_transaction(const Transaction& txn, uint64_t block_number, const ChainConfig& config,
+ValidationResult pre_validate_transaction(const Transaction& txn, evmc_revision revision, uint64_t chain_id,
                                           const std::optional<intx::uint256>& base_fee_per_gas);
 
 //! \brief Creates an instance of proper Consensus Engine on behalf of chain configuration

--- a/core/silkworm/consensus/engine_test.cpp
+++ b/core/silkworm/consensus/engine_test.cpp
@@ -22,23 +22,6 @@
 
 namespace silkworm::consensus {
 
-static const ChainConfig kTestConfig{
-    1,             // chain_id
-    std::nullopt,  // genesis_hash
-    SealEngineType::kNoProof,
-    {
-        EVMC_HOMESTEAD,
-        EVMC_TANGERINE_WHISTLE,
-        EVMC_SPURIOUS_DRAGON,
-        EVMC_BYZANTIUM,
-        EVMC_CONSTANTINOPLE,
-        EVMC_PETERSBURG,
-        EVMC_ISTANBUL,
-        EVMC_BERLIN,
-        EVMC_LONDON,
-    },
-};
-
 TEST_CASE("Consensus Engine factory") {
     std::unique_ptr<IEngine> consensus_engine;
     consensus_engine = engine_factory(kMainnetConfig);  // Ethash consensus engine
@@ -66,35 +49,35 @@ TEST_CASE("Validate transaction types") {
 
     Transaction txn;
     txn.type = Transaction::Type::kLegacy;
-    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, 1, base_fee_per_gas) !=
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, 1, base_fee_per_gas) !=
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) !=
           ValidationResult::kUnsupportedTransactionType);
 
     txn.type = static_cast<Transaction::Type>(0x03);  // unsupported transaction type
-    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, 1, base_fee_per_gas) ==
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, 1, base_fee_per_gas) ==
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) ==
           ValidationResult::kUnsupportedTransactionType);
 
     txn.type = Transaction::Type::kEip2930;
-    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, 1, base_fee_per_gas) ==
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, 1, base_fee_per_gas) !=
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) !=
           ValidationResult::kUnsupportedTransactionType);
 
     txn.type = Transaction::Type::kEip1559;
-    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, 1, base_fee_per_gas) ==
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_BERLIN, 1, base_fee_per_gas) ==
           ValidationResult::kUnsupportedTransactionType);
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) !=
           ValidationResult::kUnsupportedTransactionType);
 }
 
@@ -106,22 +89,22 @@ TEST_CASE("Validate max_fee_per_gas") {
 
     txn.max_priority_fee_per_gas = 500'000'000;
     txn.max_fee_per_gas = 700'000'000;
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) ==
           ValidationResult::kMaxFeeLessThanBase);
 
     txn.max_priority_fee_per_gas = 3'000'000'000;
     txn.max_fee_per_gas = 2'000'000'000;
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) ==
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) ==
           ValidationResult::kMaxPriorityFeeGreaterThanMax);
 
     txn.max_priority_fee_per_gas = 2'000'000'000;
     txn.max_fee_per_gas = 2'000'000'000;
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) !=
           ValidationResult::kMaxPriorityFeeGreaterThanMax);
 
     txn.max_priority_fee_per_gas = 1'000'000'000;
     txn.max_fee_per_gas = 2'000'000'000;
-    CHECK(pre_validate_transaction(txn, EVMC_LONDON, kTestConfig, base_fee_per_gas) !=
+    CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas) !=
           ValidationResult::kMaxPriorityFeeGreaterThanMax);
 }
 

--- a/core/silkworm/execution/evm.cpp
+++ b/core/silkworm/execution/evm.cpp
@@ -337,7 +337,9 @@ evmc_result EVM::execute_with_advanced_interpreter(evmc_revision rev, const evmc
     return res;
 }
 
-evmc_revision EVM::revision() const noexcept { return config().revision(block_.header.number); }
+evmc_revision EVM::revision() const noexcept {
+    return config().revision(block_.header.number, block_.header.timestamp);
+}
 
 void EVM::add_tracer(EvmTracer& tracer) noexcept {
     assert(advanced_analysis_cache == nullptr);

--- a/core/silkworm/execution/evm_test.cpp
+++ b/core/silkworm/execution/evm_test.cpp
@@ -337,11 +337,11 @@ TEST_CASE("Contract overwrite") {
 }
 
 TEST_CASE("EIP-3541: Reject new contracts starting with the 0xEF byte") {
-    ChainConfig config{kMainnetConfig};
-    config.set_revision_block(EVMC_LONDON, 13'000'000);
+    const ChainConfig& config{kMainnetConfig};
 
     Block block;
     block.header.number = 13'500'000;
+    REQUIRE(config.revision(block.header.number, block.header.timestamp) == EVMC_LONDON);
 
     InMemoryState db;
     IntraBlockState state{db};

--- a/core/silkworm/execution/processor.cpp
+++ b/core/silkworm/execution/processor.cpp
@@ -32,9 +32,6 @@ ExecutionProcessor::ExecutionProcessor(const Block& block, consensus::IEngine& c
 }
 
 ValidationResult ExecutionProcessor::validate_transaction(const Transaction& txn) const noexcept {
-    assert(consensus::pre_validate_transaction(txn, evm_.block().header.number, evm_.config(),
-                                               evm_.block().header.base_fee_per_gas) == ValidationResult::kOk);
-
     if (!txn.from.has_value()) {
         return ValidationResult::kMissingSender;
     }

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -444,7 +444,8 @@ Stage::Result Senders::add_to_batch(BlockNum block_num, std::vector<Transaction>
         return Stage::Result::kAborted;
     }
 
-    const evmc_revision rev{node_settings_->chain_config->revision(block_num)};
+    // We're only interested in revisions up to London, so it's OK to not detect time-based forks.
+    const evmc_revision rev{node_settings_->chain_config->revision(block_num, /*block_time=*/0)};
     const bool has_homestead{rev >= EVMC_HOMESTEAD};
     const bool has_spurious_dragon{rev >= EVMC_SPURIOUS_DRAGON};
     const bool has_berlin{rev >= EVMC_BERLIN};

--- a/wasm/silkworm_wasm_api.cpp
+++ b/wasm/silkworm_wasm_api.cpp
@@ -65,10 +65,6 @@ ChainConfig* new_config(uint64_t chain_id) {
 
 void delete_config(ChainConfig* x) { delete x; }
 
-void config_set_fork_block(ChainConfig* config, evmc_revision fork, uint64_t block) {
-    config->set_revision_block(fork, block);
-}
-
 void config_set_muir_glacier_block(ChainConfig* config, uint64_t block) { config->muir_glacier_block = block; }
 
 void config_set_dao_block(ChainConfig* config, uint64_t block) { config->dao_block = block; }

--- a/wasm/silkworm_wasm_api.hpp
+++ b/wasm/silkworm_wasm_api.hpp
@@ -56,8 +56,6 @@ SILKWORM_EXPORT const silkworm::ChainConfig* lookup_config(uint64_t chain_id);
 SILKWORM_EXPORT silkworm::ChainConfig* new_config(uint64_t chain_id);
 SILKWORM_EXPORT void delete_config(silkworm::ChainConfig* x);
 
-SILKWORM_EXPORT void config_set_fork_block(silkworm::ChainConfig* config, evmc_revision fork, uint64_t block);
-
 SILKWORM_EXPORT void config_set_muir_glacier_block(silkworm::ChainConfig* config, uint64_t block);
 
 SILKWORM_EXPORT void config_set_dao_block(silkworm::ChainConfig* config, uint64_t block);


### PR DESCRIPTION
Starting from [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md), forks are triggered by block time rather than number. The old generic `evmc_fork_blocks` logic wasn't a good fit anymore, so I reverted to more hand-crafted code.