### PR TITLE
Add indexes generation for Transaction snapshot

### DIFF
--- a/core/silkworm/types/transaction.cpp
+++ b/core/silkworm/types/transaction.cpp
@@ -387,7 +387,7 @@ namespace rlp {
         return DecodingResult::kOk;
     }
 
-    DecodingResult decode_header_and_transaction_type(ByteView& from, Header& header, Transaction::Type& type) noexcept {
+    DecodingResult decode_transaction_header_and_type(ByteView& from, Header& header, Transaction::Type& type) noexcept {
         if (from.empty()) {
             return DecodingResult::kInputTooShort;
         }

--- a/core/silkworm/types/transaction.hpp
+++ b/core/silkworm/types/transaction.hpp
@@ -113,6 +113,7 @@ namespace rlp {
         return decode_transaction(from, to, Eip2718Wrapping::kString);
     }
 
+    DecodingResult decode_header_and_transaction_type(ByteView& from, Header& header, Transaction::Type& type) noexcept;
 }  // namespace rlp
 
 }  // namespace silkworm

--- a/core/silkworm/types/transaction.hpp
+++ b/core/silkworm/types/transaction.hpp
@@ -113,7 +113,7 @@ namespace rlp {
         return decode_transaction(from, to, Eip2718Wrapping::kString);
     }
 
-    DecodingResult decode_header_and_transaction_type(ByteView& from, Header& header, Transaction::Type& type) noexcept;
+    DecodingResult decode_transaction_header_and_type(ByteView& from, Header& header, Transaction::Type& type) noexcept;
 }  // namespace rlp
 
 }  // namespace silkworm

--- a/node/silkworm/common/memory_mapped_file.cpp
+++ b/node/silkworm/common/memory_mapped_file.cpp
@@ -158,10 +158,6 @@ void MemoryMappedFile::advise_sequential() {
 void* MemoryMappedFile::mmap(FileDescriptor fd, bool read_only) {
     int flags = MAP_SHARED;
 
-#ifdef __linux__
-    flags = flags | MAP_POPULATE;
-#endif
-
     const auto address = ::mmap(nullptr, length_, read_only ? PROT_READ : (PROT_READ | PROT_WRITE), flags, fd, 0);
     if (address == MAP_FAILED) {
         throw std::runtime_error{"mmap failed for: " + std::string{path_} + " error: " + strerror(errno)};

--- a/node/silkworm/recsplit/rec_split.hpp
+++ b/node/silkworm/recsplit/rec_split.hpp
@@ -151,7 +151,7 @@ class SplittingStrategy {
 };
 
 //! Parameters for modified Recursive splitting (RecSplit) algorithm.
-struct RecSplitSettings{
+struct RecSplitSettings {
     std::size_t keys_count;                                 // The total number of keys in the RecSplit
     std::size_t bucket_size;                                // The number of keys in each bucket (except probably last one)
     std::filesystem::path index_path;                       // The path of the generated RecSplit index file

--- a/node/silkworm/recsplit/rec_split_test.cpp
+++ b/node/silkworm/recsplit/rec_split_test.cpp
@@ -33,15 +33,15 @@ constexpr int kTestSalt{1};
 TEST_CASE("RecSplit8", "[silkworm][recsplit]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
     test::TemporaryFile index_file;
+    RecSplitSettings settings{
+        .keys_count = 2,
+        .bucket_size = 10,
+        .index_path =  index_file.path(),
+        .base_data_id = 0
+    };
+    RecSplit8 rs{settings, /*.salt=*/kTestSalt};
 
     SECTION("keys") {
-        RecSplit8 rs{
-            /*.keys_count=*/2,
-            /*.bucket_size=*/10,
-            /*.index_path=*/index_file.path(),
-            /*.base_data_id=*/0,
-            /*.salt=*/kTestSalt,
-        };
         CHECK_NOTHROW(rs.add_key("first_key", 0));
         CHECK_THROWS_AS(rs.build(), std::logic_error);
         CHECK_NOTHROW(rs.add_key("second_key", 0));
@@ -49,13 +49,6 @@ TEST_CASE("RecSplit8", "[silkworm][recsplit]") {
     }
 
     SECTION("duplicated keys") {
-        RecSplit8 rs{
-            /*.keys_count=*/2,
-            /*.bucket_size=*/10,
-            /*.index_path=*/index_file.path(),
-            /*.base_data_id=*/0,
-            /*.salt=*/kTestSalt,
-        };
         CHECK_NOTHROW(rs.add_key("first_key", 0));
         CHECK_NOTHROW(rs.add_key("first_key", 0));
         CHECK(rs.build() == true /*collision_detected*/);
@@ -106,13 +99,13 @@ TEST_CASE("RecSplit4: keys=1000 buckets=128", "[silkworm][recsplit]") {
         hashed_keys.push_back({test::next_pseudo_random(), test::next_pseudo_random()});
     }
 
-    RecSplit4 rs{
-        /*.keys_count=*/hashed_keys.size(),
-        /*.bucket_size=*/kTestBucketSize,
-        /*.index_path=*/index_file.path(),
-        /*.base_data_id=*/0,
-        /*.salt=*/kTestSalt,
+    RecSplitSettings settings{
+        .keys_count = hashed_keys.size(),
+        .bucket_size = kTestBucketSize,
+        .index_path =  index_file.path(),
+        .base_data_id = 0
     };
+    RecSplit4 rs{settings, /*.salt=*/kTestSalt};
 
     SECTION("random_hash128 KO: not built") {
         for (const auto& hk : hashed_keys) {
@@ -155,13 +148,13 @@ TEST_CASE("RecSplit4: multiple keys-buckets", "[silkworm][recsplit]") {
                 hashed_keys.push_back({test::next_pseudo_random(), test::next_pseudo_random()});
             }
 
-            RecSplit4 rs{
-                /*.keys_count=*/hashed_keys.size(),
-                /*.bucket_size=*/bucket_size,
-                /*.index_path=*/index_file.path(),
-                /*.base_data_id=*/0,
-                /*.salt=*/kTestSalt,
+            RecSplitSettings settings{
+                .keys_count = key_count,
+                .bucket_size = bucket_size,
+                .index_path =  index_file.path(),
+                .base_data_id = 0
             };
+            RecSplit4 rs{settings, /*.salt=*/kTestSalt};
 
             for (const auto& hk : hashed_keys) {
                 rs.add_key(hk, 0);

--- a/node/silkworm/recsplit/rec_split_test.cpp
+++ b/node/silkworm/recsplit/rec_split_test.cpp
@@ -36,9 +36,8 @@ TEST_CASE("RecSplit8", "[silkworm][recsplit]") {
     RecSplitSettings settings{
         .keys_count = 2,
         .bucket_size = 10,
-        .index_path =  index_file.path(),
-        .base_data_id = 0
-    };
+        .index_path = index_file.path(),
+        .base_data_id = 0};
     RecSplit8 rs{settings, /*.salt=*/kTestSalt};
 
     SECTION("keys") {
@@ -102,9 +101,8 @@ TEST_CASE("RecSplit4: keys=1000 buckets=128", "[silkworm][recsplit]") {
     RecSplitSettings settings{
         .keys_count = hashed_keys.size(),
         .bucket_size = kTestBucketSize,
-        .index_path =  index_file.path(),
-        .base_data_id = 0
-    };
+        .index_path = index_file.path(),
+        .base_data_id = 0};
     RecSplit4 rs{settings, /*.salt=*/kTestSalt};
 
     SECTION("random_hash128 KO: not built") {
@@ -151,9 +149,8 @@ TEST_CASE("RecSplit4: multiple keys-buckets", "[silkworm][recsplit]") {
             RecSplitSettings settings{
                 .keys_count = key_count,
                 .bucket_size = bucket_size,
-                .index_path =  index_file.path(),
-                .base_data_id = 0
-            };
+                .index_path = index_file.path(),
+                .base_data_id = 0};
             RecSplit4 rs{settings, /*.salt=*/kTestSalt};
 
             for (const auto& hk : hashed_keys) {

--- a/node/silkworm/snapshot/decompressor.hpp
+++ b/node/silkworm/snapshot/decompressor.hpp
@@ -172,7 +172,7 @@ class Decompressor {
     constexpr static std::size_t kMaxTablePatterns = (1 << DecodingTable::kMaxTableBitLength) * 100;
 
     //! The max number of positions in decoding tables
-    constexpr static std::size_t kMaxTablePositions = (1 << DecodingTable::kMaxTableBitLength) * 4;
+    constexpr static std::size_t kMaxTablePositions = (1 << DecodingTable::kMaxTableBitLength) * 100;
 
     //! Read-only access to the file data stream
     class Iterator {

--- a/node/silkworm/snapshot/decompressor.hpp
+++ b/node/silkworm/snapshot/decompressor.hpp
@@ -172,7 +172,7 @@ class Decompressor {
     constexpr static std::size_t kMaxTablePatterns = (1 << DecodingTable::kMaxTableBitLength) * 100;
 
     //! The max number of positions in decoding tables
-    constexpr static std::size_t kMaxTablePositions = 1 << DecodingTable::kMaxTableBitLength;
+    constexpr static std::size_t kMaxTablePositions = (1 << DecodingTable::kMaxTableBitLength) * 4;
 
     //! Read-only access to the file data stream
     class Iterator {

--- a/node/silkworm/snapshot/index.cpp
+++ b/node/silkworm/snapshot/index.cpp
@@ -207,7 +207,7 @@ void TransactionIndex::build() {
 
                         rlp::Header tx_header;
                         Transaction::Type tx_type;
-                        decode_result = rlp::decode_header_and_transaction_type(tx_envelope_view, tx_header, tx_type);
+                        decode_result = rlp::decode_transaction_header_and_type(tx_envelope_view, tx_header, tx_type);
                         if (decode_result != DecodingResult::kOk) {
                             SILK_ERROR << "cannot decode tx envelope: " << to_hex(tx_envelope) << " i: " << i << " result: " << int(decode_result);
                             return false;

--- a/node/silkworm/snapshot/index.cpp
+++ b/node/silkworm/snapshot/index.cpp
@@ -18,8 +18,6 @@
 
 #include <stdexcept>
 
-#include <magic_enum.hpp>
-
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/util.hpp>

--- a/node/silkworm/snapshot/index.cpp
+++ b/node/silkworm/snapshot/index.cpp
@@ -208,7 +208,7 @@ void TransactionIndex::build() {
                         ByteView encoded_tx{tx_payload};
                         decode_result = rlp::decode(encoded_tx, tx);
                         if (decode_result != DecodingResult::kOk) {
-                            SILK_ERROR << "cannot decode tx in block: " << block_number << " payload: "<< to_hex(tx_payload)
+                            SILK_ERROR << "cannot decode tx in block: " << block_number << " payload: " << to_hex(tx_payload)
                                        << " i: " << i << " result: " << magic_enum::enum_name<>(decode_result);
                             return false;
                         }

--- a/node/silkworm/snapshot/index.cpp
+++ b/node/silkworm/snapshot/index.cpp
@@ -16,6 +16,8 @@
 
 #include "index.hpp"
 
+#include <stdexcept>
+
 #include <magic_enum.hpp>
 
 #include <silkworm/common/endian.hpp>

--- a/node/silkworm/snapshot/index.cpp
+++ b/node/silkworm/snapshot/index.cpp
@@ -16,12 +16,18 @@
 
 #include "index.hpp"
 
+#include <magic_enum.hpp>
+
+#include <silkworm/common/decoding_result.hpp>
+#include <silkworm/common/endian.hpp>
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/util.hpp>
 #include <silkworm/test/snapshot_files.hpp>
+#include <silkworm/types/hash.hpp>
 
 namespace silkworm {
 
+using RecSplitSettings = succinct::RecSplitSettings;
 using RecSplit8 = succinct::RecSplit8;
 
 void Index::build() {
@@ -78,6 +84,150 @@ bool BodyIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView
     rec_split.add_key(uint64_buffer_.data(), size, offset);
     uint64_buffer_.clear();
     return true;
+}
+
+void TransactionIndex::build() {
+    SILK_INFO << "TransactionIndex::build path: " << segment_path_.path().string() << " start";
+
+    const SnapshotFile bodies_segment = SnapshotFile::from(segment_path_.path().parent_path(),
+                                                           segment_path_.version(),
+                                                           segment_path_.block_from(),
+                                                           segment_path_.block_to(),
+                                                           SnapshotType::bodies);
+    SILK_INFO << "TransactionIndex::build bodies_segment path: " << bodies_segment.path().string();
+
+    BodySnapshot bodies_snapshot{bodies_segment.path(), bodies_segment.block_from(), bodies_segment.block_to()};
+    bodies_snapshot.reopen_segment();
+    const auto [first_tx_id, expected_tx_count] = bodies_snapshot.compute_txs_amount();
+    SILK_INFO << "TransactionIndex::build first_tx_id: " << first_tx_id << " expected_tx_count: " << expected_tx_count;
+
+    Decompressor txs_decoder{segment_path_.path()};
+    txs_decoder.open();
+
+    const auto tx_count = txs_decoder.words_count();
+    if (tx_count != expected_tx_count) {
+        throw std::runtime_error{"tx count mismatch: expected=" + std::to_string(expected_tx_count) +
+                                 " got=" + std::to_string(tx_count)};
+    }
+
+    const BlockNum first_block_num{segment_path_.block_from()};
+
+    const SnapshotFile tx_idx_file = segment_path_.index_file();
+    SILK_INFO << "TransactionIndex::build tx_idx_file path: " << tx_idx_file.path().string();
+    RecSplit8 tx_hash_rs{RecSplitSettings{
+        .keys_count = txs_decoder.words_count(),
+        .bucket_size = kBucketSize,
+        .index_path =  tx_idx_file.path(),
+        .base_data_id = first_tx_id,
+        .double_enum_index = true,
+        .etl_optimal_size = etl::kOptimalBufferSize / 2
+    }, 1};
+
+    const SnapshotFile tx2block_idx_file = segment_path_.index_file_for_type(SnapshotType::transactions2block);
+    SILK_INFO << "TransactionIndex::build tx2block_idx_file path: " << tx2block_idx_file.path().string();
+    RecSplit8 tx_hash_2_block_number_rs{RecSplitSettings{
+        .keys_count = txs_decoder.words_count(),
+        .bucket_size = kBucketSize,
+        .index_path =  tx2block_idx_file.path(),
+        .base_data_id = first_block_num,
+        .double_enum_index = false,
+        .etl_optimal_size = etl::kOptimalBufferSize / 2
+    }, 1};
+
+    Decompressor bodies_decoder{bodies_segment.path()};
+    bodies_decoder.open();
+
+    using DoubleReadAheadFunc = std::function<bool(Decompressor::Iterator, Decompressor::Iterator)>;
+    auto double_read_ahead = [&txs_decoder, &bodies_decoder](const DoubleReadAheadFunc& fn) -> bool {
+        return txs_decoder.read_ahead([fn, &bodies_decoder](Decompressor::Iterator tx_it) -> bool {
+            return bodies_decoder.read_ahead([fn, &tx_it](Decompressor::Iterator body_it) {
+                return fn(tx_it, body_it);
+            });
+        });
+    };
+
+    SILK_INFO << "Build index for: " << segment_path_.path().string() << " start";
+    uint64_t iterations{0};
+    bool collision_detected{false};
+    do {
+        iterations++;
+        SILK_INFO << "Process snapshot items to prepare index build for: " << segment_path_.path().string();
+        const bool read_ok = double_read_ahead([&](Decompressor::Iterator tx_it, Decompressor::Iterator body_it) -> bool {
+            BlockNum block_number = first_block_num;
+
+            db::detail::BlockBodyForStorage body;
+
+            Bytes tx_buffer{}, body_buffer{};
+            tx_buffer.reserve(kPageSize);
+            body_buffer.reserve(kPageSize);
+
+            body_it.next(body_buffer);
+            ByteView body_rlp{body_buffer.data(), body_buffer.length()};
+            SILK_DEBUG << "double_read_ahead block_number: " << block_number << " body_rlp: " << to_hex(body_rlp);
+            auto decode_result = db::detail::decode_stored_block_body(body_rlp, body);
+            SILK_DEBUG << "double_read_ahead decode_result: " << magic_enum::enum_name<>(decode_result);
+            body_buffer.clear();
+
+            uint64_t i{0}, offset{0};
+            while (tx_it.has_next()) {
+                uint64_t next_position = tx_it.next(tx_buffer);
+                while (body.base_txn_id + body.txn_count <= first_tx_id + i) {
+                    if (!body_it.has_next()) return false;
+                    body_it.next(body_buffer);
+                    body_rlp = ByteView{body_buffer.data(), body_buffer.length()};
+                    SILK_DEBUG << "double_read_ahead block_number: " << block_number << " body_rlp: " << to_hex(body_rlp);
+                    decode_result = db::detail::decode_stored_block_body(body_rlp, body);
+                    SILK_DEBUG << "double_read_ahead decode_result: " << magic_enum::enum_name<>(decode_result);
+                    body_buffer.clear();
+                    ++block_number;
+                }
+                const bool is_system_tx{tx_buffer.empty()};
+                if (is_system_tx) {
+                    // system-txs: hash:pad32(txnID)
+                    Hash tx_hash;
+                    endian::store_big_u64(tx_hash.bytes, first_tx_id + i);
+
+                    tx_hash_rs.add_key(tx_hash.bytes, kHashLength, offset);
+                    tx_hash_2_block_number_rs.add_key(tx_hash.bytes, kHashLength, block_number);
+                } else {
+                    // Skip first byte plus address length in transaction encoding
+                    constexpr int kTxFirstByteAndAddressLength{1 + kAddressLength};
+                    const auto tx_hash{keccak256(tx_buffer.substr(kTxFirstByteAndAddressLength))};
+
+                    tx_hash_rs.add_key(tx_hash.bytes, kHashLength, offset);
+                    tx_hash_2_block_number_rs.add_key(tx_hash.bytes, kHashLength, block_number);
+                }
+
+                ++i;
+                offset = next_position;
+                tx_buffer.clear();
+            }
+
+            if (i != expected_tx_count) {
+                throw std::runtime_error{"tx count mismatch: expected=" + std::to_string(expected_tx_count) +
+                                         " got=" + std::to_string(i)};
+            }
+
+            return true;
+        });
+        if (!read_ok) throw std::runtime_error{"cannot build index for: " + segment_path_.path().string()};
+
+        SILK_INFO << "Build tx_hash RecSplit index for: " << segment_path_.path().string() << " [" << iterations << "]";
+        collision_detected = tx_hash_rs.build();
+        SILK_DEBUG << "Build tx_hash RecSplit index collision_detected: " << collision_detected << " [" << iterations << "]";
+
+        SILK_INFO << "Build tx_hash_2_bn RecSplit index for: " << segment_path_.path().string() << " [" << iterations << "]";
+        collision_detected = tx_hash_2_block_number_rs.build();
+        SILK_DEBUG << "Build tx_hash_2_bn RecSplit index collision_detected: " << collision_detected << " [" << iterations << "]";
+
+        if (collision_detected) {
+            tx_hash_rs.reset_new_salt();
+            tx_hash_2_block_number_rs.reset_new_salt();
+        }
+    } while (collision_detected);
+    SILK_INFO << "Build index for: " << segment_path_.path().string() << " end [iterations=" << iterations << "]";
+
+    SILK_INFO << "TransactionIndex::build path: " << segment_path_.path().string() << " end";
 }
 
 bool TransactionIndex::walk(RecSplit8& /*rec_split*/, uint64_t /*i*/, uint64_t /*offset*/, ByteView /*word*/) {

--- a/node/silkworm/snapshot/index.hpp
+++ b/node/silkworm/snapshot/index.hpp
@@ -33,7 +33,7 @@ class Index {
     explicit Index(SnapshotFile segment_path) : segment_path_(std::move(segment_path)) {}
     virtual ~Index() = default;
 
-    void build();
+    virtual void build();
 
   protected:
     virtual bool walk(succinct::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) = 0;
@@ -43,7 +43,7 @@ class Index {
 
 class HeaderIndex : public Index {
   public:
-    explicit HeaderIndex(SnapshotFile path) : Index(std::move(path)) {}
+    explicit HeaderIndex(SnapshotFile segment_path) : Index(std::move(segment_path)) {}
 
   protected:
     bool walk(succinct::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) override;
@@ -62,7 +62,9 @@ class BodyIndex : public Index {
 
 class TransactionIndex : public Index {
   public:
-    explicit TransactionIndex(SnapshotFile path) : Index(std::move(path)) {}
+    explicit TransactionIndex(SnapshotFile segment_path) : Index(std::move(segment_path)) {}
+
+    void build() override;
 
   protected:
     bool walk(succinct::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) override;

--- a/node/silkworm/snapshot/index_test.cpp
+++ b/node/silkworm/snapshot/index_test.cpp
@@ -33,16 +33,16 @@ TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
     CHECK_THROWS_AS(header_index.build(), std::logic_error);
 }
 
-TEST_CASE("TransactionIndex::build KO: empty body snapshot", "[silkworm][snapshot][index]") {
+TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][index]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
     constexpr const char* kBodiesSnapshotFileName{"v1-014500-015000-bodies.seg"};
     constexpr const char* kTransactionsSnapshotFileName{"v1-014500-015000-transactions.seg"};
 
-    SECTION("KO: empty snapshots", "[.]") {
+    SECTION("KO: empty body snapshot", "[.]") {
         test::TemporarySnapshotFile bodies_snapshot_file{kBodiesSnapshotFileName};
         test::TemporarySnapshotFile txs_snapshot_file{kTransactionsSnapshotFileName};
         TransactionIndex tx_index{*SnapshotFile::parse(txs_snapshot_file.path().string())};
-        CHECK_THROWS_AS(tx_index.build(), std::logic_error);
+        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
     }
 }
 

--- a/node/silkworm/snapshot/index_test.cpp
+++ b/node/silkworm/snapshot/index_test.cpp
@@ -20,6 +20,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/common/rlp_err.hpp>
 #include <silkworm/test/log.hpp>
 #include <silkworm/test/snapshot_files.hpp>
 
@@ -41,9 +42,50 @@ TEST_CASE("TransactionIndex::build KO: empty body snapshot", "[silkworm][snapsho
         test::TemporarySnapshotFile bodies_snapshot_file{kBodiesSnapshotFileName};
         test::TemporarySnapshotFile txs_snapshot_file{kTransactionsSnapshotFileName};
         TransactionIndex tx_index{*SnapshotFile::parse(txs_snapshot_file.path().string())};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+        CHECK_THROWS_AS(tx_index.build(), std::logic_error);
     }
 }
+
+//! Sample Bodies snapshot file: it contains body for block 1'500'013 on mainnet
+class SampleBodySnapshotFile : public test::TemporarySnapshotFile {
+  public:
+    inline static constexpr const char* kBodiesSnapshotFileName{"v1-001500-001500-bodies.seg"};
+    explicit SampleBodySnapshotFile(std::string_view hex)
+        : TemporarySnapshotFile{kBodiesSnapshotFileName, *from_hex(hex)} {}
+};
+
+//! Sample Transactions snapshot file: it contains transactions for block 1'500'013 on mainnet (a block with 1 tx)
+class SampleTransactionSnapshotFile : public test::TemporarySnapshotFile {
+  public:
+    inline static constexpr const char* kTransactionsSnapshotFileName{"v1-001500-001500-transactions.seg"};
+
+    explicit SampleTransactionSnapshotFile()
+        : TemporarySnapshotFile{
+              kTransactionsSnapshotFileName,
+              test::SnapshotHeader{
+                  .words_count = 1,  // number of non-empty words
+                  .empty_words_count = 0,
+                  .patterns = std::vector<test::SnapshotPattern>{},
+                  .positions = std::vector<test::SnapshotPosition>{
+                      {1, 0},   // 1: position 0: zero encoded data (no pattern)
+                      {1, 114}  // 1: position 114: unencoded data length (including position encoding)
+                  }},
+              test::SnapshotBody{
+                  *from_hex(
+                      "01"  // 0x01: position
+                      "f86f828f938504a817c80083015f9094e9ae6ec1117bbfeb89302ce7e632597b"
+                      "c595efae880e61a774f297bb80801ca031131812a9b210cf6033e9420478b72f"
+                      "08251d8c7323dd88bd3a180679fa90b5a028a6d676d77923b19506c7aaae5f1d"
+                      "c2f2244855aabb6672401c1b55b0d844ff")  // 0xf86f...44ff: RLP encoding for transaction
+              }} {}
+};
+
+//! Sample Transaction snapshot path injecting custom from/to blocks to override 500'000 block range
+class SampleTransactionSnapshotPath : public test::TransactionSnapshotPath {
+  public:
+    explicit SampleTransactionSnapshotPath(std::filesystem::path path)
+        : test::TransactionSnapshotPath(std::move(path), 1'500'000, 1'500'014) {}
+};
 
 TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][index]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
@@ -56,13 +98,87 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
                 .words_count = 0,
                 .empty_words_count = 0,
                 .patterns = {},
-                .positions = {}},
+                .positions = {}
+            },
             test::SnapshotBody{
-                *from_hex("0000000000000000")}};
+                *from_hex("0000000000000000")
+            }
+        };
         test::TemporarySnapshotFile txs_snapshot_file{kTransactionsSnapshotFileName};
         TransactionIndex tx_index{*SnapshotFile::parse(txs_snapshot_file.path().string())};
         CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
     }
+
+    SECTION("KO: invalid position depth") {
+        SampleBodySnapshotFile bodies_snapshot_file{
+            "000000000000000e000000000000000000000000000000000000000000000004"
+            "c100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {c1, 00} <-
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d901c0"
+        };
+        SampleTransactionSnapshotFile txs_snapshot_file{};
+        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        TransactionIndex tx_index{txs_snapshot_path};
+        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+    }
+
+    SECTION("KO: invalid position value") {
+        SampleBodySnapshotFile bodies_snapshot_file{
+            "000000000000000e000000000000000000000000000000000000000000000004"
+            "01ff010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, ff} <-
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d901c0"
+        };
+        SampleTransactionSnapshotFile txs_snapshot_file{};
+        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        TransactionIndex tx_index{txs_snapshot_path};
+        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+    }
+
+    SECTION("KO: invalid positions count") {
+        SampleBodySnapshotFile bodies_snapshot_file{
+            "000000000000000e000000000000000000000000000000000000000000000005"  // POSITIONS=5 <-
+            "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d901c0"
+        };
+        SampleTransactionSnapshotFile txs_snapshot_file{};
+        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        TransactionIndex tx_index{txs_snapshot_path};
+        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+    }
+
+    SECTION("KO: invalid RLP") {
+        SampleBodySnapshotFile bodies_snapshot_file{
+            "000000000000000e000000000000000000000000000000000000000000000004"
+            "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c78370"  // {01, c7837004d980c0}
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c6837004d901c0"
+        };
+        SampleTransactionSnapshotFile txs_snapshot_file{};
+        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        TransactionIndex tx_index{txs_snapshot_path};
+        CHECK_THROWS_AS(tx_index.build(), rlp::DecodingError);
+    }
+}
+
+TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+    SampleBodySnapshotFile bodies_snapshot_file{
+        "000000000000000e000000000000000000000000000000000000000000000004"  // WC=14 EWC=0 PATTERNS=0 POSITIONS=4
+        "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, 00}, {01, 08}
+        "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, c6837004d980c0}
+        "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // ...
+        "04d980c001c6837004d980c001c6837004d901c0"                          // {01, c6837004d901c0}
+    };
+    SampleTransactionSnapshotFile txs_snapshot_file{};
+    SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+    TransactionIndex tx_index{txs_snapshot_path};
+    CHECK_NOTHROW(tx_index.build());
 }
 
 }  // namespace silkworm

--- a/node/silkworm/snapshot/index_test.cpp
+++ b/node/silkworm/snapshot/index_test.cpp
@@ -71,12 +71,11 @@ class SampleTransactionSnapshotFile : public test::TemporarySnapshotFile {
                       {1, 114}  // 1: position 114: unencoded data length (including position encoding)
                   }},
               test::SnapshotBody{
-                  *from_hex(
-                      "01"  // 0x01: position
-                      "f86f828f938504a817c80083015f9094e9ae6ec1117bbfeb89302ce7e632597b"
-                      "c595efae880e61a774f297bb80801ca031131812a9b210cf6033e9420478b72f"
-                      "08251d8c7323dd88bd3a180679fa90b5a028a6d676d77923b19506c7aaae5f1d"
-                      "c2f2244855aabb6672401c1b55b0d844ff")  // 0xf86f...44ff: RLP encoding for transaction
+                  *from_hex("01"  // 0x01: position
+                            "f86f828f938504a817c80083015f9094e9ae6ec1117bbfeb89302ce7e632597b"
+                            "c595efae880e61a774f297bb80801ca031131812a9b210cf6033e9420478b72f"
+                            "08251d8c7323dd88bd3a180679fa90b5a028a6d676d77923b19506c7aaae5f1d"
+                            "c2f2244855aabb6672401c1b55b0d844ff")  // 0xf86f...44ff: RLP encoding for transaction
               }} {}
 };
 
@@ -98,12 +97,9 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
                 .words_count = 0,
                 .empty_words_count = 0,
                 .patterns = {},
-                .positions = {}
-            },
+                .positions = {}},
             test::SnapshotBody{
-                *from_hex("0000000000000000")
-            }
-        };
+                *from_hex("0000000000000000")}};
         test::TemporarySnapshotFile txs_snapshot_file{kTransactionsSnapshotFileName};
         TransactionIndex tx_index{*SnapshotFile::parse(txs_snapshot_file.path().string())};
         CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
@@ -115,8 +111,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "c100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {c1, 00} <-
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d901c0"
-        };
+            "04d980c001c6837004d980c001c6837004d901c0"};
         SampleTransactionSnapshotFile txs_snapshot_file{};
         SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
@@ -129,8 +124,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "01ff010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, ff} <-
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d901c0"
-        };
+            "04d980c001c6837004d980c001c6837004d901c0"};
         SampleTransactionSnapshotFile txs_snapshot_file{};
         SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
@@ -143,8 +137,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d901c0"
-        };
+            "04d980c001c6837004d980c001c6837004d901c0"};
         SampleTransactionSnapshotFile txs_snapshot_file{};
         SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
@@ -157,8 +150,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c78370"  // {01, c7837004d980c0}
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d901c0"
-        };
+            "04d980c001c6837004d980c001c6837004d901c0"};
         SampleTransactionSnapshotFile txs_snapshot_file{};
         SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};

--- a/node/silkworm/snapshot/index_test.cpp
+++ b/node/silkworm/snapshot/index_test.cpp
@@ -50,8 +50,20 @@ TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][in
 class SampleBodySnapshotFile : public test::TemporarySnapshotFile {
   public:
     inline static constexpr const char* kBodiesSnapshotFileName{"v1-001500-001500-bodies.seg"};
+
+    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     explicit SampleBodySnapshotFile(std::string_view hex)
         : TemporarySnapshotFile{kBodiesSnapshotFileName, *from_hex(hex)} {}
+
+    //! This empty ctor captures the correct sample snapshot content once for all
+    explicit SampleBodySnapshotFile()
+        : SampleBodySnapshotFile(
+              "000000000000000e000000000000000000000000000000000000000000000004"  // WC=14 EWC=0 PATTERNS=0 POSITIONS=4
+              "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, 00}, {01, 08}
+              "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, c6837004d980c0}
+              "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // ...
+              "04d980c001c6837004d980c001c6837004d901c0"                          // {01, c6837004d901c0}
+          ) {}
 };
 
 //! Sample Transactions snapshot file: it contains transactions for block 1'500'013 on mainnet (a block with 1 tx)
@@ -59,24 +71,19 @@ class SampleTransactionSnapshotFile : public test::TemporarySnapshotFile {
   public:
     inline static constexpr const char* kTransactionsSnapshotFileName{"v1-001500-001500-transactions.seg"};
 
+    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
+    explicit SampleTransactionSnapshotFile(std::string_view hex)
+        : TemporarySnapshotFile{kTransactionsSnapshotFileName, *from_hex(hex)} {}
+
+    //! This empty ctor captures the correct sample snapshot content once for all
     explicit SampleTransactionSnapshotFile()
-        : TemporarySnapshotFile{
-              kTransactionsSnapshotFileName,
-              test::SnapshotHeader{
-                  .words_count = 1,  // number of non-empty words
-                  .empty_words_count = 0,
-                  .patterns = std::vector<test::SnapshotPattern>{},
-                  .positions = std::vector<test::SnapshotPosition>{
-                      {1, 0},   // 1: position 0: zero encoded data (no pattern)
-                      {1, 114}  // 1: position 114: unencoded data length (including position encoding)
-                  }},
-              test::SnapshotBody{
-                  *from_hex("01"  // 0x01: position
-                            "f86f828f938504a817c80083015f9094e9ae6ec1117bbfeb89302ce7e632597b"
-                            "c595efae880e61a774f297bb80801ca031131812a9b210cf6033e9420478b72f"
-                            "08251d8c7323dd88bd3a180679fa90b5a028a6d676d77923b19506c7aaae5f1d"
-                            "c2f2244855aabb6672401c1b55b0d844ff")  // 0xf86f...44ff: RLP encoding for transaction
-              }} {}
+        : SampleTransactionSnapshotFile(
+              "0000000000000001000000000000000000000000000000000000000000000004"  // WC=1 EWC=0 PATTERNS=0 POSITIONS=4
+              "0100017201f86f828f938504a817c80083015f9094e9ae6ec1117bbfeb89302c"  // {01, 00}, {01, 72}, {01, f86f...
+              "e7e632597bc595efae880e61a774f297bb80801ca031131812a9b210cf6033e9"  // ...
+              "420478b72f08251d8c7323dd88bd3a180679fa90b5a028a6d676d77923b19506"  // ...
+              "c7aaae5f1dc2f2244855aabb6672401c1b55b0d844ff"                      // ...44ff}
+          ) {}
 };
 
 //! Sample Transaction snapshot path injecting custom from/to blocks to override 500'000 block range
@@ -106,53 +113,53 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
     }
 
     SECTION("KO: invalid position depth") {
-        SampleBodySnapshotFile bodies_snapshot_file{
+        SampleBodySnapshotFile invalid_bodies_snapshot{
             "000000000000000e000000000000000000000000000000000000000000000004"
-            "c100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {c1, 00} <-
+            "c100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {c1, 00} <- c1 instead of 01
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
-        SampleTransactionSnapshotFile txs_snapshot_file{};
-        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        SampleTransactionSnapshotFile valid_txs_snapshot{};
+        SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
         CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
     }
 
     SECTION("KO: invalid position value") {
-        SampleBodySnapshotFile bodies_snapshot_file{
+        SampleBodySnapshotFile invalid_bodies_snapshot{
             "000000000000000e000000000000000000000000000000000000000000000004"
-            "01ff010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, ff} <-
+            "01ff010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, ff} <- ff instead of 00
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
-        SampleTransactionSnapshotFile txs_snapshot_file{};
-        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        SampleTransactionSnapshotFile valid_txs_snapshot{};
+        SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
         CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
     }
 
     SECTION("KO: invalid positions count") {
-        SampleBodySnapshotFile bodies_snapshot_file{
-            "000000000000000e000000000000000000000000000000000000000000000005"  // POSITIONS=5 <-
+        SampleBodySnapshotFile invalid_bodies_snapshot{
+            "000000000000000e000000000000000000000000000000000000000000000005"  // POSITIONS=5 <- 5 instead of 4
             "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
-        SampleTransactionSnapshotFile txs_snapshot_file{};
-        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        SampleTransactionSnapshotFile valid_txs_snapshot{};
+        SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
         CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
     }
 
     SECTION("KO: invalid RLP") {
-        SampleBodySnapshotFile bodies_snapshot_file{
+        SampleBodySnapshotFile invalid_bodies_snapshot{
             "000000000000000e000000000000000000000000000000000000000000000004"
             "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c78370"  // {01, c7837004d980c0}
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c78370"  // {01, c7837004d980c0} <- c7 instead of c6
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
-        SampleTransactionSnapshotFile txs_snapshot_file{};
-        SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+        SampleTransactionSnapshotFile valid_txs_snapshot{};
+        SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
         CHECK_THROWS_AS(tx_index.build(), rlp::DecodingError);
     }
@@ -160,15 +167,9 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
 
 TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
-    SampleBodySnapshotFile bodies_snapshot_file{
-        "000000000000000e000000000000000000000000000000000000000000000004"  // WC=14 EWC=0 PATTERNS=0 POSITIONS=4
-        "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, 00}, {01, 08}
-        "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // {01, c6837004d980c0}
-        "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"  // ...
-        "04d980c001c6837004d980c001c6837004d901c0"                          // {01, c6837004d901c0}
-    };
-    SampleTransactionSnapshotFile txs_snapshot_file{};
-    SampleTransactionSnapshotPath txs_snapshot_path{txs_snapshot_file.path()};  // necessary to tweak the block numbers
+    SampleBodySnapshotFile valid_bodies_snapshot{};
+    SampleTransactionSnapshotFile valid_txs_snapshot{};
+    SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
     TransactionIndex tx_index{txs_snapshot_path};
     CHECK_NOTHROW(tx_index.build());
 }

--- a/node/silkworm/snapshot/repository.cpp
+++ b/node/silkworm/snapshot/repository.cpp
@@ -35,9 +35,6 @@ namespace silkworm {
 //! The scale factor to convert the block numbers to/from the values in snapshot file names
 constexpr int kFileNameBlockScaleFactor{1'000};
 
-//! The number of digits to represent the to/from block numbers in snapshot file names
-constexpr int kFileNameBlockDigits{6};
-
 namespace fs = std::filesystem;
 
 std::optional<SnapshotFile> SnapshotFile::parse(fs::path path) {

--- a/node/silkworm/snapshot/repository.hpp
+++ b/node/silkworm/snapshot/repository.hpp
@@ -99,7 +99,7 @@ class SnapshotFile {
 
     friend bool operator<(const SnapshotFile& lhs, const SnapshotFile& rhs);
 
-  private:
+  protected:
     static std::filesystem::path build_filename(uint8_t version, BlockNum block_from, BlockNum block_to, SnapshotType type);
 
     explicit SnapshotFile(std::filesystem::path path, uint8_t version, BlockNum block_from, BlockNum block_to, SnapshotType type);

--- a/node/silkworm/snapshot/repository.hpp
+++ b/node/silkworm/snapshot/repository.hpp
@@ -52,11 +52,18 @@ enum SnapshotType {
     headers = 0,
     bodies = 1,
     transactions = 2,
+    transactions2block = 3,
 };
 
 class SnapshotFile {
   public:
     [[nodiscard]] static std::optional<SnapshotFile> parse(std::filesystem::path path);
+
+    [[nodiscard]] static SnapshotFile from(const std::filesystem::path& dir,
+                                           uint8_t version,
+                                           BlockNum block_from,
+                                           BlockNum block_to,
+                                           SnapshotType type);
 
     [[nodiscard]] std::filesystem::path path() const { return path_; }
 
@@ -84,9 +91,17 @@ class SnapshotFile {
         return SnapshotFile(std::filesystem::path{path_}.replace_extension(kIdxExtension), version_, block_from_, block_to_, type_);
     }
 
+    [[nodiscard]] SnapshotFile index_file_for_type(SnapshotType type) const {
+        std::filesystem::path index_path{path_};
+        index_path.replace_filename(build_filename(version_, block_from_, block_to_, type));
+        return SnapshotFile(index_path.replace_extension(kIdxExtension), version_, block_from_, block_to_, type);
+    }
+
     friend bool operator<(const SnapshotFile& lhs, const SnapshotFile& rhs);
 
   private:
+    static std::filesystem::path build_filename(uint8_t version, BlockNum block_from, BlockNum block_to, SnapshotType type);
+
     explicit SnapshotFile(std::filesystem::path path, uint8_t version, BlockNum block_from, BlockNum block_to, SnapshotType type);
 
     std::filesystem::path path_;

--- a/node/silkworm/snapshot/repository_test.cpp
+++ b/node/silkworm/snapshot/repository_test.cpp
@@ -94,9 +94,11 @@ TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][snapshot][snapsh
 TEST_CASE("SnapshotRepository::reopen_folder", "[silkworm][snapshot][snapshot]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
 
-    test::TemporarySnapshotFile tmp_snapshot_1{"v1-014500-015000-headers.seg"};
-    test::TemporarySnapshotFile tmp_snapshot_2{"v1-011500-012000-bodies.seg"};
-    test::TemporarySnapshotFile tmp_snapshot_3{"v1-015000-015500-transactions.seg"};
+    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
+    std::filesystem::create_directories(tmp_dir);
+    test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir, "v1-014500-015000-headers.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir, "v1-011500-012000-bodies.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir, "v1-015000-015500-transactions.seg"};
     SnapshotSettings settings{tmp_snapshot_1.path().parent_path()};
     SnapshotRepository repository{settings};
     CHECK_NOTHROW(repository.reopen_folder());
@@ -109,9 +111,11 @@ TEST_CASE("SnapshotRepository::reopen_folder", "[silkworm][snapshot][snapshot]")
 TEST_CASE("SnapshotRepository::view", "[silkworm][snapshot][snapshot]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
 
-    test::TemporarySnapshotFile tmp_snapshot_1{"v1-014500-015000-headers.seg"};
-    test::TemporarySnapshotFile tmp_snapshot_2{"v1-011500-012000-bodies.seg"};
-    test::TemporarySnapshotFile tmp_snapshot_3{"v1-015000-015500-transactions.seg"};
+    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
+    std::filesystem::create_directories(tmp_dir);
+    test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir, "v1-014500-015000-headers.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir, "v1-011500-012000-bodies.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir, "v1-015000-015500-transactions.seg"};
     SnapshotSettings settings{tmp_snapshot_1.path().parent_path()};
     SnapshotRepository repository{settings};
     repository.reopen_folder();

--- a/node/silkworm/snapshot/snapshot.hpp
+++ b/node/silkworm/snapshot/snapshot.hpp
@@ -100,6 +100,8 @@ class BodySnapshot : public Snapshot {
     using Walker = std::function<bool(BlockNum number, const db::detail::BlockBodyForStorage* body)>;
     bool for_each_body(const Walker& walker);
 
+    std::pair<uint64_t, uint64_t> compute_txs_amount();
+
     void reopen_index() override;
 
   protected:

--- a/node/silkworm/test/files.hpp
+++ b/node/silkworm/test/files.hpp
@@ -31,6 +31,8 @@ class TemporaryFile {
     explicit TemporaryFile() : path_{TemporaryDirectory::get_unique_temporary_path()}, stream_{path_} {}
     explicit TemporaryFile(const std::string& filename)
         : path_{TemporaryDirectory::get_os_temporary_path() / filename}, stream_{path_} {}
+    explicit TemporaryFile(const std::filesystem::path& tmp_dir, const std::string& filename)
+        : path_{tmp_dir / filename}, stream_{path_} {}
     ~TemporaryFile() { stream_.close(); }
 
     const std::filesystem::path& path() const noexcept { return path_; }

--- a/node/silkworm/test/snapshot_files.hpp
+++ b/node/silkworm/test/snapshot_files.hpp
@@ -21,6 +21,7 @@
 
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/util.hpp>
+#include <silkworm/snapshot/repository.hpp>
 #include <silkworm/test/files.hpp>
 
 namespace silkworm::test {
@@ -133,9 +134,13 @@ class TemporarySnapshotFile {
     }
     TemporarySnapshotFile(const std::filesystem::path& tmp_dir, const std::string& filename)
         : TemporarySnapshotFile(tmp_dir, filename, {}, {}) {}
+    TemporarySnapshotFile(const std::string& filename, ByteView data)
+        : file_(TemporaryDirectory::get_os_temporary_path(), filename) {
+        file_.write(data);
+    }
     TemporarySnapshotFile(const std::string& filename, const SnapshotHeader& header, const SnapshotBody& body = {})
         : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, header, body) {}
-    TemporarySnapshotFile(const std::string& filename)
+    explicit TemporarySnapshotFile(const std::string& filename)
         : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, {}, {}) {}
 
     const std::filesystem::path& path() const { return file_.path(); }
@@ -161,4 +166,23 @@ class HelloWorldSnapshotFile : public TemporarySnapshotFile {
                   *from_hex("0168656C6C6F2C20776F726C64")  // 0x01: position 0x68656C6C6F2C20776F726C64: "hello, world"
               }} {}
 };
+
+class HeaderSnapshotPath : public SnapshotFile {
+  public:
+    HeaderSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
+        : SnapshotFile(std::move(path), /*.version=*/ 1, from ,to, SnapshotType::headers) {}
+};
+
+class BodySnapshotPath : public SnapshotFile {
+  public:
+    BodySnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
+        : SnapshotFile(std::move(path), /*.version=*/ 1, from ,to, SnapshotType::bodies) {}
+};
+
+class TransactionSnapshotPath : public SnapshotFile {
+  public:
+    TransactionSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
+        : SnapshotFile(std::move(path), /*.version=*/ 1, from ,to, SnapshotType::transactions) {}
+};
+
 }  // namespace silkworm::test

--- a/node/silkworm/test/snapshot_files.hpp
+++ b/node/silkworm/test/snapshot_files.hpp
@@ -170,19 +170,19 @@ class HelloWorldSnapshotFile : public TemporarySnapshotFile {
 class HeaderSnapshotPath : public SnapshotFile {
   public:
     HeaderSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
-        : SnapshotFile(std::move(path), /*.version=*/ 1, from ,to, SnapshotType::headers) {}
+        : SnapshotFile(std::move(path), /*.version=*/1, from, to, SnapshotType::headers) {}
 };
 
 class BodySnapshotPath : public SnapshotFile {
   public:
     BodySnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
-        : SnapshotFile(std::move(path), /*.version=*/ 1, from ,to, SnapshotType::bodies) {}
+        : SnapshotFile(std::move(path), /*.version=*/1, from, to, SnapshotType::bodies) {}
 };
 
 class TransactionSnapshotPath : public SnapshotFile {
   public:
     TransactionSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
-        : SnapshotFile(std::move(path), /*.version=*/ 1, from ,to, SnapshotType::transactions) {}
+        : SnapshotFile(std::move(path), /*.version=*/1, from, to, SnapshotType::transactions) {}
 };
 
 }  // namespace silkworm::test

--- a/node/silkworm/test/snapshot_files.hpp
+++ b/node/silkworm/test/snapshot_files.hpp
@@ -116,19 +116,27 @@ struct SnapshotBody {
 class TemporarySnapshotFile {
   public:
     explicit TemporarySnapshotFile(const SnapshotHeader& header, const SnapshotBody& body = {}) {
-        silkworm::Bytes data{};
+        Bytes data{};
         header.encode(data);
         body.encode(data);
         file_.write(data);
     }
+    TemporarySnapshotFile(const std::filesystem::path& tmp_dir,
+                          const std::string& filename,
+                          const SnapshotHeader& header,
+                          const SnapshotBody& body = {})
+        : file_(tmp_dir, filename) {
+        Bytes data{};
+        header.encode(data);
+        body.encode(data);
+        file_.write(data);
+    }
+    TemporarySnapshotFile(const std::filesystem::path& tmp_dir, const std::string& filename)
+        : TemporarySnapshotFile(tmp_dir, filename, {}, {}) {}
     TemporarySnapshotFile(const std::string& filename, const SnapshotHeader& header, const SnapshotBody& body = {})
-        : file_(filename) {
-        silkworm::Bytes data{};
-        header.encode(data);
-        body.encode(data);
-        file_.write(data);
-    }
-    explicit TemporarySnapshotFile(const std::string& filename) : TemporarySnapshotFile(filename, {}, {}) {}
+        : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, header, body) {}
+    TemporarySnapshotFile(const std::string& filename)
+        : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, {}, {}) {}
 
     const std::filesystem::path& path() const { return file_.path(); }
 


### PR DESCRIPTION
This PR adds the generation of Transaction indexes for the Snapshot Sync feature:
- tx hash -> offset index
- tx hash -> block number index