### PR TITLE
add missing include stdexcept for std::runtime_error

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <filesystem>
+#include <stdexcept>
 #include <string>
 
 #include <CLI/CLI.hpp>

--- a/cmd/check_changes.cpp
+++ b/cmd/check_changes.cpp
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+#include <stdexcept>
+
 #include <CLI/CLI.hpp>
 #include <absl/container/flat_hash_set.h>
 

--- a/cmd/check_pow.cpp
+++ b/cmd/check_pow.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <filesystem>
+#include <stdexcept>
 #include <string>
 
 #include <CLI/CLI.hpp>

--- a/cmd/common.cpp
+++ b/cmd/common.cpp
@@ -17,6 +17,7 @@
 #include "common.hpp"
 
 #include <regex>
+#include <stdexcept>
 
 #include <boost/asio/ip/address.hpp>
 

--- a/cmd/scan_txs.cpp
+++ b/cmd/scan_txs.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <iostream>
+#include <stdexcept>
 
 #include <CLI/CLI.hpp>
 

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+#include <stdexcept>
+
 #include <CLI/CLI.hpp>
 
 #include <silkworm/backend/backend_kv_server.hpp>

--- a/cmd/toolbox.cpp
+++ b/cmd/toolbox.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <iostream>
 #include <regex>
+#include <stdexcept>
 #include <string>
 
 #include <CLI/CLI.hpp>

--- a/node/silkworm/common/directories.hpp
+++ b/node/silkworm/common/directories.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <filesystem>
+#include <stdexcept>
 
 namespace silkworm {
 

--- a/node/silkworm/common/log.cpp
+++ b/node/silkworm/common/log.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <ostream>
 #include <regex>
+#include <stdexcept>
 #include <thread>
 
 #include <absl/time/clock.h>

--- a/node/silkworm/concurrency/_test.cpp
+++ b/node/silkworm/concurrency/_test.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <csignal>
+#include <stdexcept>
 
 #include <catch2/catch.hpp>
 

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -16,6 +16,8 @@
 
 #include "access_layer.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/assert.hpp>
 #include <silkworm/common/cast.hpp>
 #include <silkworm/common/endian.hpp>

--- a/node/silkworm/db/access_layer_test.cpp
+++ b/node/silkworm/db/access_layer_test.cpp
@@ -16,6 +16,8 @@
 
 #include "access_layer.hpp"
 
+#include <stdexcept>
+
 #include <catch2/catch.hpp>
 
 #include <silkworm/chain/genesis.hpp>

--- a/node/silkworm/db/bitmap.cpp
+++ b/node/silkworm/db/bitmap.cpp
@@ -16,6 +16,8 @@
 
 #include "bitmap.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/binary_search.hpp>
 #include <silkworm/common/cast.hpp>
 #include <silkworm/concurrency/signal_handler.hpp>

--- a/node/silkworm/db/buffer.cpp
+++ b/node/silkworm/db/buffer.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <stdexcept>
 
 #include <absl/container/btree_set.h>
 

--- a/node/silkworm/db/genesis.cpp
+++ b/node/silkworm/db/genesis.cpp
@@ -16,6 +16,8 @@
 
 #include "genesis.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/chain/genesis.hpp>
 #include <silkworm/state/in_memory_state.hpp>
 #include <silkworm/trie/hash_builder.hpp>

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -16,6 +16,8 @@
 
 #include "mdbx.hpp"
 
+#include <stdexcept>
+
 namespace silkworm::db {
 
 //! \brief Returns data of current cursor position or moves it to the beginning or the end of the table based on

--- a/node/silkworm/db/prune_mode.cpp
+++ b/node/silkworm/db/prune_mode.cpp
@@ -16,6 +16,8 @@
 
 #include "prune_mode.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/endian.hpp>
 
 namespace silkworm::db {

--- a/node/silkworm/db/stages.cpp
+++ b/node/silkworm/db/stages.cpp
@@ -16,6 +16,8 @@
 
 #include "stages.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/endian.hpp>
 
 namespace silkworm::db::stages {

--- a/node/silkworm/db/tables.cpp
+++ b/node/silkworm/db/tables.cpp
@@ -16,6 +16,8 @@
 
 #include "tables.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/db/access_layer.hpp>
 
 namespace silkworm::db::table {

--- a/node/silkworm/db/util.cpp
+++ b/node/silkworm/db/util.cpp
@@ -17,6 +17,7 @@
 #include "util.hpp"
 
 #include <cstring>
+#include <stdexcept>
 
 #include <silkworm/common/assert.hpp>
 #include <silkworm/common/endian.hpp>

--- a/node/silkworm/downloader/sentry_client.hpp
+++ b/node/silkworm/downloader/sentry_client.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <stdexcept>
 
 #include <boost/signals2.hpp>
 #include <p2psentry/sentry.grpc.pb.h>

--- a/node/silkworm/etl/collector.cpp
+++ b/node/silkworm/etl/collector.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <queue>
+#include <stdexcept>
 
 #include <silkworm/common/directories.hpp>
 #include <silkworm/common/log.hpp>

--- a/node/silkworm/recsplit/rec_split.hpp
+++ b/node/silkworm/recsplit/rec_split.hpp
@@ -52,6 +52,7 @@
 #include <fstream>
 #include <limits>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>

--- a/node/silkworm/rpc/client/call.hpp
+++ b/node/silkworm/rpc/client/call.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <stdexcept>
 #include <utility>  // for std::exchange in Boost 1.78, fixed in Boost 1.79
 
 #include <agrpc/detail/rpc.hpp>

--- a/node/silkworm/rpc/server/call.hpp
+++ b/node/silkworm/rpc/server/call.hpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <functional>
 #include <list>
+#include <stdexcept>
 #include <utility>
 
 #include <agrpc/repeatedly_request.hpp>

--- a/node/silkworm/rpc/server/server.hpp
+++ b/node/silkworm/rpc/server/server.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include <grpcpp/grpcpp.h>

--- a/node/silkworm/rpc/server/server_test.cpp
+++ b/node/silkworm/rpc/server/server_test.cpp
@@ -16,6 +16,7 @@
 
 #include "server.hpp"
 
+#include <stdexcept>
 #include <thread>
 
 #include <catch2/catch.hpp>

--- a/node/silkworm/snapshot/index.cpp
+++ b/node/silkworm/snapshot/index.cpp
@@ -16,6 +16,8 @@
 
 #include "index.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/log.hpp>
 #include <silkworm/common/util.hpp>
 #include <silkworm/test/snapshot_files.hpp>

--- a/node/silkworm/stagedsync/stage_execution.cpp
+++ b/node/silkworm/stagedsync/stage_execution.cpp
@@ -17,6 +17,7 @@
 #include "stage_execution.hpp"
 
 #include <span>
+#include <stdexcept>
 
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/stopwatch.hpp>

--- a/node/silkworm/stagedsync/stage_hashstate.cpp
+++ b/node/silkworm/stagedsync/stage_hashstate.cpp
@@ -16,6 +16,8 @@
 
 #include "stage_hashstate.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/endian.hpp>
 #include <silkworm/db/access_layer.hpp>
 

--- a/node/silkworm/stagedsync/stage_interhashes.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes.cpp
@@ -16,6 +16,7 @@
 
 #include "stage_interhashes.hpp"
 
+#include <stdexcept>
 #include <utility>
 
 #include <absl/container/btree_set.h>

--- a/node/silkworm/stagedsync/stage_interhashes/trie_loader.cpp
+++ b/node/silkworm/stagedsync/stage_interhashes/trie_loader.cpp
@@ -16,6 +16,8 @@
 
 #include "trie_loader.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/rlp_err.hpp>
 #include <silkworm/concurrency/signal_handler.hpp>
 #include <silkworm/db/tables.hpp>

--- a/node/silkworm/stagedsync/stage_log_index.hpp
+++ b/node/silkworm/stagedsync/stage_log_index.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <stdexcept>
+
 #include <cbor/cbor.h>
 
 #include <silkworm/db/bitmap.hpp>

--- a/node/silkworm/stagedsync/stage_senders.cpp
+++ b/node/silkworm/stagedsync/stage_senders.cpp
@@ -17,6 +17,7 @@
 #include "stage_senders.hpp"
 
 #include <algorithm>
+#include <stdexcept>
 #include <thread>
 
 #include <gsl/util>

--- a/node/silkworm/stagedsync/stage_tx_lookup.cpp
+++ b/node/silkworm/stagedsync/stage_tx_lookup.cpp
@@ -16,6 +16,8 @@
 
 #include "stage_tx_lookup.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/endian.hpp>
 #include <silkworm/db/access_layer.hpp>
 

--- a/node/silkworm/stagedsync/sync_loop.cpp
+++ b/node/silkworm/stagedsync/sync_loop.cpp
@@ -16,6 +16,8 @@
 
 #include "sync_loop.hpp"
 
+#include <stdexcept>
+
 #include <boost/format.hpp>
 
 #include <silkworm/stagedsync/stage_blockhashes.hpp>

--- a/sentry/silkworm/sentry/common/ecc_key_pair.cpp
+++ b/sentry/silkworm/sentry/common/ecc_key_pair.cpp
@@ -16,6 +16,8 @@
 
 #include "ecc_key_pair.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/secp256k1_context.hpp>
 #include <silkworm/common/util.hpp>
 #include <silkworm/sentry/common/random.hpp>

--- a/sentry/silkworm/sentry/common/ecc_public_key.cpp
+++ b/sentry/silkworm/sentry/common/ecc_public_key.cpp
@@ -16,6 +16,8 @@
 
 #include "ecc_public_key.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/secp256k1_context.hpp>
 #include <silkworm/common/util.hpp>
 

--- a/sentry/silkworm/sentry/common/timeout.hpp
+++ b/sentry/silkworm/sentry/common/timeout.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <stdexcept>
 
 #include <silkworm/concurrency/coroutine.hpp>
 

--- a/sentry/silkworm/sentry/common/timeout_test.cpp
+++ b/sentry/silkworm/sentry/common/timeout_test.cpp
@@ -17,6 +17,7 @@
 #include "timeout.hpp"
 
 #include <exception>
+#include <stdexcept>
 
 #include <silkworm/concurrency/coroutine.hpp>
 

--- a/sentry/silkworm/sentry/eth/fork_id.cpp
+++ b/sentry/silkworm/sentry/eth/fork_id.cpp
@@ -19,6 +19,7 @@
 #include <Crc32.h>
 
 #include <optional>
+#include <stdexcept>
 
 #include <silkworm/common/endian.hpp>
 #include <silkworm/rlp/decode.hpp>

--- a/sentry/silkworm/sentry/eth/protocol.cpp
+++ b/sentry/silkworm/sentry/eth/protocol.cpp
@@ -16,6 +16,8 @@
 
 #include "protocol.hpp"
 
+#include <stdexcept>
+
 namespace silkworm::sentry::eth {
 
 const uint8_t Protocol::kVersion = 67;

--- a/sentry/silkworm/sentry/eth/status_message.cpp
+++ b/sentry/silkworm/sentry/eth/status_message.cpp
@@ -16,6 +16,8 @@
 
 #include "status_message.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/rlp/encode_vector.hpp>
 

--- a/sentry/silkworm/sentry/node_key_config.cpp
+++ b/sentry/silkworm/sentry/node_key_config.cpp
@@ -17,6 +17,7 @@
 #include "node_key_config.hpp"
 
 #include <fstream>
+#include <stdexcept>
 
 #include <silkworm/common/util.hpp>
 

--- a/sentry/silkworm/sentry/rlpx/auth/auth_ack_message.cpp
+++ b/sentry/silkworm/sentry/rlpx/auth/auth_ack_message.cpp
@@ -16,6 +16,8 @@
 
 #include "auth_ack_message.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/rlp/decode.hpp>
 #include <silkworm/rlp/encode_vector.hpp>
 #include <silkworm/sentry/common/random.hpp>

--- a/sentry/silkworm/sentry/rlpx/auth/auth_message.cpp
+++ b/sentry/silkworm/sentry/rlpx/auth/auth_message.cpp
@@ -16,6 +16,8 @@
 
 #include "auth_message.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/secp256k1_context.hpp>
 #include <silkworm/rlp/decode.hpp>

--- a/sentry/silkworm/sentry/rlpx/auth/ecies_cipher.cpp
+++ b/sentry/silkworm/sentry/rlpx/auth/ecies_cipher.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <memory>
+#include <stdexcept>
 
 #include <silkworm/common/endian.hpp>
 #include <silkworm/common/secp256k1_context.hpp>

--- a/sentry/silkworm/sentry/rlpx/auth/handshake.hpp
+++ b/sentry/silkworm/sentry/rlpx/auth/handshake.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 

--- a/sentry/silkworm/sentry/rlpx/auth/hello_message.cpp
+++ b/sentry/silkworm/sentry/rlpx/auth/hello_message.cpp
@@ -17,6 +17,7 @@
 #include "hello_message.hpp"
 
 #include <sstream>
+#include <stdexcept>
 
 #include <silkworm/common/as_range.hpp>
 #include <silkworm/rlp/decode.hpp>

--- a/sentry/silkworm/sentry/rlpx/common/disconnect_message.cpp
+++ b/sentry/silkworm/sentry/rlpx/common/disconnect_message.cpp
@@ -16,6 +16,7 @@
 
 #include "disconnect_message.hpp"
 
+#include <stdexcept>
 #include <vector>
 
 #include <silkworm/rlp/decode.hpp>

--- a/sentry/silkworm/sentry/rlpx/crypto/aes.cpp
+++ b/sentry/silkworm/sentry/rlpx/crypto/aes.cpp
@@ -16,6 +16,8 @@
 
 #include "aes.hpp"
 
+#include <stdexcept>
+
 #include <gsl/util>
 #include <openssl/aes.h>
 #include <openssl/evp.h>

--- a/sentry/silkworm/sentry/rlpx/crypto/hmac.cpp
+++ b/sentry/silkworm/sentry/rlpx/crypto/hmac.cpp
@@ -16,6 +16,8 @@
 
 #include "hmac.hpp"
 
+#include <stdexcept>
+
 #include <gsl/util>
 #include <openssl/hmac.h>
 

--- a/sentry/silkworm/sentry/rlpx/framing/framing_cipher.cpp
+++ b/sentry/silkworm/sentry/rlpx/framing/framing_cipher.cpp
@@ -16,6 +16,8 @@
 
 #include "framing_cipher.hpp"
 
+#include <stdexcept>
+
 #include <silkworm/common/endian.hpp>
 #include <silkworm/rlp/encode_vector.hpp>
 #include <silkworm/sentry/rlpx/crypto/aes.hpp>

--- a/sentry/silkworm/sentry/rlpx/framing/message_frame_codec.cpp
+++ b/sentry/silkworm/sentry/rlpx/framing/message_frame_codec.cpp
@@ -18,6 +18,7 @@
 
 #include <snappy.h>
 
+#include <stdexcept>
 #include <string>
 
 #include <silkworm/rlp/decode.hpp>

--- a/sentry/silkworm/sentry/rlpx/framing/message_stream.cpp
+++ b/sentry/silkworm/sentry/rlpx/framing/message_stream.cpp
@@ -16,6 +16,8 @@
 
 #include "message_stream.hpp"
 
+#include <stdexcept>
+
 #include "message_frame_codec.hpp"
 
 namespace silkworm::sentry::rlpx::framing {

--- a/sentry/silkworm/sentry/rlpx/protocol.hpp
+++ b/sentry/silkworm/sentry/rlpx/protocol.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
Note: it works without it, but I'd like to follow a convention to include things we use directly.