### PR TITLE
sentry: fix exception in MessageReceiver::receive_messages when GRPC disconnects

### DIFF
--- a/sentry/silkworm/sentry/message_receiver.cpp
+++ b/sentry/silkworm/sentry/message_receiver.cpp
@@ -16,6 +16,7 @@
 
 #include "message_receiver.hpp"
 
+#include <algorithm>
 #include <memory>
 
 #include <boost/asio/co_spawn.hpp>
@@ -62,9 +63,13 @@ awaitable<void> MessageReceiver::unsubscribe_on_signal(std::shared_ptr<common::C
         co_await unsubscribe_signal_channel->receive();
     } catch (const boost::system::system_error& ex) {
         if (ex.code() == experimental::error::channel_closed) {
-            subscriptions_.remove_if([=](const Subscription& subscription) {
-                return subscription.unsubscribe_signal_channel == unsubscribe_signal_channel;
+            auto subscription = std::find_if(subscriptions_.begin(), subscriptions_.end(), [=](const Subscription& s) {
+                return s.unsubscribe_signal_channel == unsubscribe_signal_channel;
             });
+            if (subscription != subscriptions_.end()) {
+                subscription->messages_channel->close();
+                subscriptions_.erase(subscription);
+            }
             co_return;
         }
         log::Error() << "MessageReceiver::unsubscribe_on_signal system_error: " << ex.what();
@@ -84,9 +89,21 @@ awaitable<void> MessageReceiver::receive_messages(std::shared_ptr<rlpx::Peer> pe
             {peer->peer_public_key()},
         };
 
+        std::list<std::shared_ptr<common::Channel<rpc::common::MessagesCall::MessageFromPeer>>> messages_channels;
         for (auto& subscription : subscriptions_) {
             if (subscription.message_id_filter.empty() || subscription.message_id_filter.contains(message_from_peer.message.id)) {
-                co_await subscription.messages_channel->send(message_from_peer);
+                messages_channels.push_back(subscription.messages_channel);
+            }
+        }
+
+        for (auto& messages_channel : messages_channels) {
+            try {
+                co_await messages_channel->send(message_from_peer);
+            } catch (const boost::system::system_error& ex) {
+                if (ex.code() == experimental::error::channel_closed) {
+                    continue;
+                }
+                throw;
             }
         }
     }


### PR DESCRIPTION
Do not co_await during subscriptions_ iteration.
When GRPC client disconnects, subscription is removed and messages_channel is closed. If this happens during messages_channel->send, receive_messages handles it and keeps going.