### PR TITLE
Cancel GA execution on new commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,13 @@
 #   limitations under the License.
 
 name: Continuous integration
+
 on: [ push, pull_request ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux_x64:
     if: ${{ false }}  # disable for now


### PR DESCRIPTION
This PR changes the GitHub Actions workflow to cancel the running execution on new commits on the same PR or branch.
This is obtained by using the same concurrency group for the current workflow on the same PR number or commit.

The same can be obtained in CircleCI by changing the `Auto-cancel redundant workflows` setting in `Advanced` section of `Project Settings` (just done, it should have immediate effect).