### PR TITLE
Fix TOML embedding

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -29,18 +29,34 @@ add_executable(${SILKWORM_EMBED} ${SILKWORM_MAIN_DIR}/cmd/embed.cpp)
 target_link_libraries(${SILKWORM_EMBED} PRIVATE CLI11::CLI11)
 
 set(SILKWORM_TOML_SRC_DIR "${SILKWORM_MAIN_DIR}/third_party/erigon-snapshot")
-set(SILKWORM_TOML_SRC "${SILKWORM_TOML_SRC_DIR}/mainnet.toml")
+set(SILKWORM_TOML_SRC
+        ${SILKWORM_TOML_SRC_DIR}/bor-mainnet.toml
+        ${SILKWORM_TOML_SRC_DIR}/bsc.toml
+        ${SILKWORM_TOML_SRC_DIR}/gnosis.toml
+        ${SILKWORM_TOML_SRC_DIR}/goerli.toml
+        ${SILKWORM_TOML_SRC_DIR}/mainnet.toml
+        ${SILKWORM_TOML_SRC_DIR}/mumbai.toml
+        ${SILKWORM_TOML_SRC_DIR}/ropsten.toml
+        ${SILKWORM_TOML_SRC_DIR}/sepolia.toml)
 set(SILKWORM_TOML_CPP_SRC_DIR "${SILKWORM_MAIN_DIR}/node/silkworm/snapshot/config")
-set(SILKWORM_TOML_CPP_SOURCES "${SILKWORM_TOML_CPP_SRC_DIR}/mainnet.cpp")
+set(SILKWORM_TOML_CPP_SRC
+        ${SILKWORM_TOML_CPP_SRC_DIR}/bor_mainnet.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/bsc.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/gnosis.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/goerli.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/mainnet.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/mumbai.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/ropsten.cpp
+        ${SILKWORM_TOML_CPP_SRC_DIR}/sepolia.cpp)
 
 add_custom_command(
-        OUTPUT "${SILKWORM_TOML_CPP_SOURCES}"
+        OUTPUT "${SILKWORM_TOML_CPP_SRC}"
         COMMAND "${SILKWORM_EMBED}"
         ARGS -i "${SILKWORM_TOML_SRC_DIR}" -o "${SILKWORM_TOML_CPP_SRC_DIR}" -e ".toml" -s "toml"
         DEPENDS "${SILKWORM_EMBED}"
 )
 
-add_custom_target(generate_toml DEPENDS "${SILKWORM_TOML_CPP_SOURCES}")
+add_custom_target(generate_toml DEPENDS "${SILKWORM_TOML_SRC}" "${SILKWORM_EMBED}")
 
 file(GLOB_RECURSE SILKWORM_NODE_SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp" "*.c" "*.h" "*.cc")
 list(FILTER SILKWORM_NODE_SRC EXCLUDE REGEX "_test\\.cpp$")
@@ -60,16 +76,6 @@ set(SILKWORM_INTERFACE_SRC
         ${SILKWORM_MAIN_DIR}/interfaces/remote/kv.pb.h
         ${SILKWORM_MAIN_DIR}/interfaces/types/types.pb.cc
         ${SILKWORM_MAIN_DIR}/interfaces/types/types.pb.h)
-
-set(SILKWORM_TOML_CPP_SRC
-        ${SILKWORM_TOML_CPP_SRC_DIR}/bor_mainnet.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/bsc.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/gnosis.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/goerli.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/mainnet.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/mumbai.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/ropsten.cpp
-        ${SILKWORM_TOML_CPP_SRC_DIR}/sepolia.cpp)
 
 add_library(silkworm_node ${SILKWORM_NODE_SRC} ${SILKWORM_INTERFACE_SRC} ${SILKWORM_TOML_CPP_SRC})
 


### PR DESCRIPTION
This PR should fix the issues w/ TOML generated files during build by:
- listing all input/output files in TOML embedding
- fixing dependencies in `embed_toml` command and `generate_toml` target