### PR TITLE
Fix github actions on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory C:\build
 
     - name: Add VCPKG libs to environment
       run: |
@@ -174,16 +174,16 @@ jobs:
         Add-Content $env:GITHUB_ENV "INCLUDE=${{runner.workspace}}\silkworm\vcpkg\installed\x64-windows\include"
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
-      run: cmake ..\silkworm -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+      working-directory: C:\build
+      run: cmake ${{runner.workspace}}\silkworm -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
+      working-directory: C:\build
       # Execute the build. You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config ${{ matrix.config.build_type }} -j 2
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: C:\build
       run: |
         cmd/test/${{ matrix.config.build_type }}/core_test
         cmd/test/${{ matrix.config.build_type }}/node_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: |
-        cmd/test/core_test
-        cmd/test/node_test
-        cmd/test/consensus --threads 4
-        cmd/test/sentry_test
+        cmd/test/${{ matrix.config.build_type }}/core_test
+        cmd/test/${{ matrix.config.build_type }}/node_test
+        cmd/test/${{ matrix.config.build_type }}/consensus --threads 4
+        cmd/test/${{ matrix.config.build_type }}/sentry_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,6 @@ jobs:
         submodules: recursive
         fetch-depth: "0"
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ${{ github.job }}-${{ matrix.config.build_type }}  # Eg. "windows-Debug"
-
     - name: vcpkg build
       uses: johnwason/vcpkg-action@v4
       id: vcpkg
@@ -173,12 +168,14 @@ jobs:
       # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
+    - name: Add VCPKG libs to environment
+      run: |
+        Add-Content $env:GITHUB_PATH "${{runner.workspace}}\silkworm\vcpkg\installed\x64-windows\bin"
+        Add-Content $env:GITHUB_ENV "INCLUDE=${{runner.workspace}}\silkworm\vcpkg\installed\x64-windows\include"
+
     - name: Configure CMake
       working-directory: ${{runner.workspace}}/build
-      run: |
-        echo "${{runner.workspace}}\silkworm\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
-        $env:INCLUDE += ';${{runner.workspace}}\silkworm\vcpkg\installed\x64-windows\include'
-        cmake ..\silkworm -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+      run: cmake ..\silkworm -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/node/silkworm/recsplit/rec_split.hpp
+++ b/node/silkworm/recsplit/rec_split.hpp
@@ -47,6 +47,9 @@
 /* clang-format off */
 #define _USE_MATH_DEFINES
 #include <cmath>
+#if !defined(M_PI) && defined(_MSC_VER)
+#include <corecrt_math_defines.h>
+#endif
 /* clang-format on */
 
 #include <array>

--- a/sentry/silkworm/sentry/common/random.hpp
+++ b/sentry/silkworm/sentry/common/random.hpp
@@ -40,14 +40,14 @@ std::list<T*> random_list_items(std::list<T>& l, size_t max_count) {
         [[maybe_unused]] typedef void pointer;
         [[maybe_unused]] typedef void reference;
 
-        explicit BackInsertPtrIterator(std::list<T*>& container) : container_(container) {}
+        explicit BackInsertPtrIterator(std::list<T*>& container) : container_(&container) {}
 
         BackInsertPtrIterator& operator=(T& value) {
-            container_.push_back(&value);
+            container_->push_back(&value);
             return *this;
         }
         BackInsertPtrIterator& operator=(T&& value) {
-            container_.push_back(&value);
+            container_->push_back(&value);
             return *this;
         }
 
@@ -56,7 +56,7 @@ std::list<T*> random_list_items(std::list<T>& l, size_t max_count) {
         BackInsertPtrIterator operator++(int) { return *this; }
 
       private:
-        std::list<T*>& container_;
+        std::list<T*>* container_;
     };
 
     std::list<T*> out;


### PR DESCRIPTION
- There's a ccache step here on Windows, but it's not actually used, also it's experimental and only available in the bash shell which isn't used here so have removed it.
- Found a handy `Add-Content` to add to the path and other environment variables, allows it to be used in all subsequent steps too in the pscp shell
- `random_list_items` had a build issue with assignment operator `operator=` which is actually deleted because of the reference `container_` member variable. Didn't investigate the uses of it, just changed the member to a pointer.
- `M_PI` was not defined, apparently `_USE_MATH_DEFINES` is meant to work but doesn't seem to anymore. Now checking if using MSVC compiler and if `M_PI` is not defined then import `corecrt_math_defines.h`
- The recsplit test is failing on Windows, but the test GH action is not failing, maybe because it's not run as a cmake target? At least it's building now

Edit: It failed due to insufficient space, although worked on my own repo. From https://github.com/actions/runner-images/issues/1341 it seems like the D: drive is the default but is limited to 14GB, and the C: drive has a lot more, although might technically not be available, although after over 2 years it still seems to be. But something to keep in mind if an issue arises later, may need to look into forms of caching some of the build artifacts elsewhere 