### PR TITLE
node: add snapshot support in access layer

### DIFF
--- a/cmd/snapshots.cpp
+++ b/cmd/snapshots.cpp
@@ -221,9 +221,9 @@ void download(const BitTorrentSettings& settings, int /*repetitions*/) {
         std::thread scheduler_thread{[&scheduler]() { scheduler.run(); }};
         SILK_DEBUG << "Signals registered on scheduler " << &scheduler;
 
-        SILK_INFO << "Bittorrent async download started for magnet file: " << settings.magnets_file_path;
+        SILK_INFO << "Bittorrent async download started for magnet file: " << *settings.magnets_file_path;
         client.execute_loop();
-        SILK_INFO << "Bittorrent async download completed for magnet file: " << settings.magnets_file_path;
+        SILK_INFO << "Bittorrent async download completed for magnet file: " << *settings.magnets_file_path;
 
         scheduler_thread.join();
     } catch (...) {

--- a/node/silkworm/bittorrent/bittorrent_client.cpp
+++ b/node/silkworm/bittorrent/bittorrent_client.cpp
@@ -187,13 +187,12 @@ bool BitTorrentClient::exists_resume_file(const lt::info_hash_t& info_hashes) co
 }
 
 bool BitTorrentClient::all_torrents_seeding() const {
-    /*for (const auto& torrent_handle : session_.get_torrents()) {
+    for (const auto& torrent_handle : session_.get_torrents()) {  // NOLINT(readability-use-anyofallof)
         if (!torrent_handle.status().is_seeding) {
             return false;
         }
     }
-    return true;*/
-    return std::ranges::all_of(session_.get_torrents(), [](auto& handle) { return handle.status().is_seeding; });
+    return true;
 }
 
 void BitTorrentClient::execute_loop() {

--- a/node/silkworm/bittorrent/bittorrent_client.cpp
+++ b/node/silkworm/bittorrent/bittorrent_client.cpp
@@ -16,11 +16,15 @@
 
 #include "bittorrent_client.hpp"
 
+#include <algorithm>
 #include <ctime>
 #include <fstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <libtorrent/alert_types.hpp>
+#include <libtorrent/hex.hpp>
 #include <libtorrent/magnet_uri.hpp>
 #include <libtorrent/read_resume_data.hpp>
 #include <libtorrent/write_resume_data.hpp>
@@ -34,6 +38,17 @@ namespace silkworm {
 
 namespace fs = std::filesystem;
 using namespace std::chrono_literals;
+
+//! The 7 best trackers for bittorrent
+const std::vector<std::string> kBestTrackers{
+    "udp://tracker.opentrackr.org:1337/announce",
+    "udp://9.rarbg.com:2810/announce",
+    "udp://tracker.torrent.eu.org:451/announce",
+    "udp://opentracker.i2p.rocks:6969/announce",
+    "udp://open.stealth.si:80/announce",
+    "https://opentracker.i2p.rocks:443/announce",
+    "udp://vibe.sleepyinternetfun.xyz:1738/announce",
+};
 
 std::vector<char> BitTorrentClient::load_file(const fs::path& filename) {
     std::ifstream input_file_stream{filename, std::ios_base::binary};
@@ -50,8 +65,8 @@ void BitTorrentClient::save_file(const fs::path& filename, const std::vector<cha
 
 BitTorrentClient::BitTorrentClient(BitTorrentSettings settings)
     : settings_(std::move(settings)),
-      session_file_{fs::path(settings_.repository_path) / fs::path(kSessionFileName)},
-      resume_dir_{fs::path(settings_.repository_path) / fs::path(kResumeDirName)},
+      session_file_{settings_.repository_path / fs::path{kSessionFileName}},
+      resume_dir_{settings_.repository_path / fs::path{kResumeDirName}},
       session_{load_or_create_session_parameters()} {
     SILK_TRACE << "BitTorrentClient::BitTorrentClient start";
     auto add_magnet_params_sequence = resume_or_create_magnets();
@@ -66,9 +81,31 @@ BitTorrentClient::~BitTorrentClient() {
     stop();
 }
 
+void BitTorrentClient::add_info_hash(const std::string& name, const std::string& info_hash) {
+    lt::sha1_hash sha1_info_hash;
+    lt::aux::from_hex(info_hash, sha1_info_hash.data());
+    lt::info_hash_t info_hashes{sha1_info_hash};
+    if (exists_resume_file(info_hashes)) {
+        SILK_DEBUG << "Resume file found: " << resume_file_path(info_hashes);
+        return;
+    }
+    lt::add_torrent_params torrent;
+    torrent.name = name;
+    torrent.info_hashes = info_hashes;
+    torrent.save_path = settings_.repository_path.string();
+    torrent.trackers = kBestTrackers;
+    session_.async_add_torrent(std::move(torrent));
+    SILK_DEBUG << "BitTorrentClient::add info_hash: " << info_hash << " added";
+}
+
 void BitTorrentClient::stop() {
     SILK_TRACE << "BitTorrentClient::stop start";
-    stop_token_ = true;
+    std::unique_lock stop_lock{stop_mutex_};
+    if (!stop_requested_) {
+        stop_requested_ = true;
+        stop_lock.unlock();
+        stop_condition_.notify_one();
+    }
     SILK_TRACE << "BitTorrentClient::stop end";
 }
 
@@ -96,7 +133,7 @@ lt::session_params BitTorrentClient::load_or_create_session_parameters() const {
 std::vector<lt::add_torrent_params> BitTorrentClient::resume_or_create_magnets() const {
     fs::create_directories(settings_.repository_path);
     SILKWORM_ASSERT(fs::exists(settings_.repository_path) && fs::is_directory(settings_.repository_path));
-    SILK_DEBUG << "Torrent repository folder: " << settings_.repository_path;
+    SILK_DEBUG << "Torrent repository folder: " << settings_.repository_path.string();
 
     fs::create_directories(resume_dir_);
     SILKWORM_ASSERT(fs::exists(resume_dir_) && fs::is_directory(resume_dir_));
@@ -112,14 +149,15 @@ std::vector<lt::add_torrent_params> BitTorrentClient::resume_or_create_magnets()
         const auto resume_data = load_file(file.path().string());
         if (!resume_data.empty()) {
             auto add_magnet = lt::read_resume_data(resume_data);
-            add_magnet.save_path = settings_.repository_path;
+            add_magnet.save_path = settings_.repository_path.string();
             add_magnet_params.push_back(add_magnet);
         }
     }
     SILK_DEBUG << "Torrents #resumed: " << add_magnet_params.size();
 
-    // Add magnet parameters for other magnet links
-    std::ifstream magnet_input_file_stream{settings_.magnets_file_path};
+    // Add magnet parameters for other magnet links (if any)
+    if (!settings_.magnets_file_path) return add_magnet_params;
+    std::ifstream magnet_input_file_stream{*settings_.magnets_file_path};
     std::string magnet_uri;
     while (std::getline(magnet_input_file_stream, magnet_uri)) {
         if (magnet_uri.empty()) continue;
@@ -129,7 +167,7 @@ std::vector<lt::add_torrent_params> BitTorrentClient::resume_or_create_magnets()
             SILK_DEBUG << "Resume file found: " << resume_file_path(add_magnet.info_hashes);
             continue;
         }
-        add_magnet.save_path = settings_.repository_path;
+        add_magnet.save_path = settings_.repository_path.string();
         add_magnet_params.push_back(add_magnet);
     }
 
@@ -148,16 +186,28 @@ bool BitTorrentClient::exists_resume_file(const lt::info_hash_t& info_hashes) co
     return std::filesystem::exists(resume_file_path(info_hashes));
 }
 
+bool BitTorrentClient::all_torrents_seeding() const {
+    /*for (const auto& torrent_handle : session_.get_torrents()) {
+        if (!torrent_handle.status().is_seeding) {
+            return false;
+        }
+    }
+    return true;*/
+    return std::ranges::all_of(session_.get_torrents(), [](auto& handle) { return handle.status().is_seeding; });
+}
+
 void BitTorrentClient::execute_loop() {
     SILK_TRACE << "BitTorrentClient::execute_loop start";
 
-    while (!stop_token_ && (settings_.seeding || !session_.get_torrents().empty())) {
+    bool stopped{false};
+    while (!stopped && (settings_.seeding || !all_torrents_seeding())) {
         request_torrent_updates();
         process_alerts();
 
-        std::this_thread::sleep_for(settings_.wait_between_alert_polls);
+        std::unique_lock stop_lock{stop_mutex_};
+        stopped = stop_condition_.wait_for(stop_lock, settings_.wait_between_alert_polls, [&] { return stop_requested_; });
     }
-    SILK_DEBUG << "Execution loop completed [stop_token=" << stop_token_ << "]";
+    SILK_DEBUG << "Execution loop completed [stop_condition=" << stop_requested_ << "]";
 
     request_save_resume_data(lt::torrent_handle::save_info_dict);
     while (outstanding_resume_requests_ > 0) {
@@ -265,10 +315,12 @@ bool BitTorrentClient::handle_alert(const lt::alert* alert) {
     if (const auto sta = lt::alert_cast<lt::state_update_alert>(alert)) {
         if (!sta->status.empty()) {
             for (const auto& ts : sta->status) {
-                SILK_DEBUG << "[" << std::to_string(ts.handle.id()) << "]: " << magic_enum::enum_name(ts.state) << ' '
+                SILK_DEBUG << "Torrent: " << ts.name << " id: " << ts.handle.id() << " state: " << magic_enum::enum_name(ts.state) << " "
                            << (ts.download_payload_rate / 1'000'000) << " MB/s " << (ts.total_done / 1'000'000) << " MB ("
-                           << (ts.progress_ppm / 10000) << "%) downloaded (" << ts.num_peers << " peers)\x1b[K";
+                           << (ts.progress_ppm / 10'000) << "%) downloaded (" << ts.num_peers << " peers)";
             }
+        } else {
+            SILK_DEBUG << "Empty state update alert:" << sta->message();
         }
         handled = true;
     }

--- a/node/silkworm/bittorrent/bittorrent_client_test.cpp
+++ b/node/silkworm/bittorrent/bittorrent_client_test.cpp
@@ -169,7 +169,6 @@ TEST_CASE("BitTorrentClient::add_info_hash", "[silkworm][snapshot][bittorrent]")
         BitTorrentClient client{settings};
         client.add_info_hash("test.seg", "df09957d8a28af3bc5137478885a8003677ca8");
         std::thread client_thread{[&client]() { client.execute_loop(); }};
-        std::this_thread::sleep_for(50ms);
         CHECK_NOTHROW(client.stop());
         client_thread.join();
     }
@@ -178,7 +177,6 @@ TEST_CASE("BitTorrentClient::add_info_hash", "[silkworm][snapshot][bittorrent]")
         BitTorrentClient client{settings};
         client.add_info_hash("test.seg", "df09957d8a28af3bc5137478885a8003677ca878");
         std::thread client_thread{[&client]() { client.execute_loop(); }};
-        std::this_thread::sleep_for(50ms);
         CHECK_NOTHROW(client.stop());
         client_thread.join();
     }
@@ -207,7 +205,6 @@ TEST_CASE("BitTorrentClient::execute_loop", "[silkworm][snapshot][bittorrent]") 
         repo.flush();
         BitTorrentClient client{settings};
         std::thread client_thread{[&client]() { client.execute_loop(); }};
-        std::this_thread::sleep_for(50ms);
         CHECK_NOTHROW(client.stop());
         client_thread.join();
     }

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -76,7 +76,7 @@ std::vector<std::string> read_snapshots(mdbx::txn& txn) {
     }
     const auto data{db_info_cursor.current()};
     // https://github.com/nlohmann/json/issues/2204
-    const auto json = nlohmann::json::parse(data.value.as_string(), nullptr, /*.allow_exceptions=*/ false);
+    const auto json = nlohmann::json::parse(data.value.as_string(), nullptr, /*.allow_exceptions=*/false);
     return json.get<std::vector<std::string>>();
 }
 

--- a/node/silkworm/db/access_layer.cpp
+++ b/node/silkworm/db/access_layer.cpp
@@ -69,6 +69,23 @@ void write_build_info_height(mdbx::txn& txn, Bytes key, BlockNum height) {
     tgt.upsert(db::to_slice(key), db::to_slice(value));
 }
 
+std::vector<std::string> read_snapshots(mdbx::txn& txn) {
+    Cursor db_info_cursor{txn, table::kDatabaseInfo};
+    if (!db_info_cursor.seek(mdbx::slice{kDbSnapshotsKey})) {
+        return {};
+    }
+    const auto data{db_info_cursor.current()};
+    // https://github.com/nlohmann/json/issues/2204
+    const auto json = nlohmann::json::parse(data.value.as_string(), nullptr, /*.allow_exceptions=*/ false);
+    return json.get<std::vector<std::string>>();
+}
+
+void write_snapshots(mdbx::txn& txn, const std::vector<std::string>& snapshot_file_names) {
+    Cursor db_info_cursor{txn, table::kDatabaseInfo};
+    nlohmann::json json_value = snapshot_file_names;
+    db_info_cursor.upsert(mdbx::slice{kDbSnapshotsKey}, mdbx::slice(json_value.dump().data()));
+}
+
 std::optional<BlockHeader> read_header(mdbx::txn& txn, BlockNum block_number, const evmc::bytes32& hash) {
     return read_header(txn, block_number, hash.bytes);
 }
@@ -687,6 +704,18 @@ uint64_t read_map_sequence(mdbx::txn& txn, const char* map_name) {
         throw std::length_error("Bad sequence value in db");
     }
     return endian::load_big_u64(from_slice(data.value).data());
+}
+
+uint64_t reset_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t new_sequence) {
+    uint64_t current_sequence{read_map_sequence(txn, map_name)};
+    if (new_sequence != current_sequence) {
+        Cursor target(txn, table::kSequence);
+        mdbx::slice key(map_name);
+        Bytes new_sequence_buffer(sizeof(uint64_t), '\0');
+        endian::store_big_u64(new_sequence_buffer.data(), new_sequence);
+        target.upsert(key, to_slice(new_sequence_buffer));
+    }
+    return current_sequence;
 }
 
 }  // namespace silkworm::db

--- a/node/silkworm/db/access_layer.hpp
+++ b/node/silkworm/db/access_layer.hpp
@@ -21,6 +21,7 @@
 
 #include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
 #include <silkworm/chain/config.hpp>
@@ -42,6 +43,12 @@ void write_schema_version(mdbx::txn& txn, const VersionBase& schema_version);
 //! \details Is useful to track whether increasing heights have been affected by
 //! upgrades or downgrades of Silkworm's build
 void write_build_info_height(mdbx::txn& txn, Bytes key, BlockNum height);
+
+//! \brief Read the list of snapshot file names
+std::vector<std::string> read_snapshots(mdbx::txn& txn);
+
+//! \brief Write the list of snapshot file names
+void write_snapshots(mdbx::txn& txn, const std::vector<std::string>& snapshot_file_names);
 
 //! \brief Reads a header with the specified key (block number, hash)
 std::optional<BlockHeader> read_header(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
@@ -179,5 +186,14 @@ uint64_t increment_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t i
 //! \remarks If the key is not present in Sequence bucket the return value is 0
 //! \throws std::std::length_error on badly recorded value
 uint64_t read_map_sequence(mdbx::txn& txn, const char* map_name);
+
+//! \brief Reset the sequence value for a given map (bucket)
+//! \param [in] map_name : the name of the map to reset the sequence for
+//! \param [in] new_sequence : the value to set the sequence to
+//! \returns The old value of the sequence
+//! \throws std::std::length_error on badly recorded value
+//! \remarks Initial sequence for any key (also unset) is 0. Changes to sequences are invisible until the transaction is
+//! committed
+uint64_t reset_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t new_sequence);
 
 }  // namespace silkworm::db

--- a/node/silkworm/db/access_layer_test.cpp
+++ b/node/silkworm/db/access_layer_test.cpp
@@ -139,7 +139,7 @@ namespace db {
         std::vector<std::string> table_names{};
 
         const auto walk_func{[&table_names](ByteView key, ByteView) {
-            table_names.push_back(byte_ptr_cast(key.data()));
+            table_names.emplace_back(byte_ptr_cast(key.data()));
         }};
 
         main_crs.to_first();
@@ -170,23 +170,30 @@ namespace db {
         auto& txn{context.txn()};
 
         auto val1{read_map_sequence(txn, table::kBlockTransactions.name)};
-        REQUIRE(val1 == 0);
+        CHECK(val1 == 0);
 
         auto val2{increment_map_sequence(txn, table::kBlockTransactions.name, 5)};
-        REQUIRE(val2 == 0);
+        CHECK(val2 == 0);
         auto val3{read_map_sequence(txn, table::kBlockTransactions.name)};
-        REQUIRE((val3 == 5));
+        CHECK(val3 == 5);
 
         auto val4{increment_map_sequence(txn, table::kBlockTransactions.name, 3)};
-        REQUIRE(val4 == 5);
+        CHECK(val4 == 5);
         auto val5{read_map_sequence(txn, table::kBlockTransactions.name)};
-        REQUIRE((val5 == 8));
+        CHECK(val5 == 8);
 
         context.commit_and_renew_txn();
         auto& txn2{context.txn()};
 
         auto val6{read_map_sequence(txn2, table::kBlockTransactions.name)};
-        REQUIRE((val6 == 8));
+        CHECK(val6 == 8);
+
+        // Reset sequence
+        auto val7{reset_map_sequence(txn2, table::kBlockTransactions.name, 19)};
+        CHECK(val7 == 8);
+
+        auto val8{read_map_sequence(txn2, table::kBlockTransactions.name)};
+        CHECK(val8 == 19);
 
         // Tamper with sequence
         Bytes fake_value(sizeof(uint32_t), '\0');
@@ -201,7 +208,7 @@ namespace db {
             REQUIRE(std::string(ex.what()) == "Bad sequence value in db");
             thrown = true;
         }
-        REQUIRE(thrown);
+        CHECK(thrown);
     }
 
     TEST_CASE("Schema Version") {
@@ -229,8 +236,8 @@ namespace db {
 
         SECTION("Incompatible schema") {
             // Reduce compat schema version
-            auto incompat_version = VersionBase{db::table::kRequiredSchemaVersion.Major - 1, 0, 0};
-            REQUIRE_NOTHROW(db::write_schema_version(context.txn(), incompat_version));
+            auto incompatible_version = VersionBase{db::table::kRequiredSchemaVersion.Major - 1, 0, 0};
+            REQUIRE_NOTHROW(db::write_schema_version(context.txn(), incompatible_version));
             REQUIRE_THROWS(db::table::check_or_create_chaindata_tables(context.txn()));
         }
 
@@ -405,6 +412,20 @@ namespace db {
         CHECK(stages::read_stage_prune_progress(txn, stages::kBlockBodiesKey) == 0);
     }
 
+    TEST_CASE("read_snapshots") {
+        test::Context context;
+        auto& txn{context.txn()};
+
+        const std::vector<std::string> snapshot_list{
+            "v1-000000-000500-bodies.seg",
+            "v1-000000-000500-headers.seg",
+            "v1-000000-000500-transactions.seg",
+        };
+
+        CHECK_NOTHROW(write_snapshots(txn, snapshot_list));
+        CHECK(read_snapshots(txn) == snapshot_list);
+    }
+
     TEST_CASE("read_difficulty") {
         test::Context context;
         auto& txn{context.txn()};
@@ -444,7 +465,7 @@ namespace db {
         REQUIRE(db_hash.has_value());
         REQUIRE(memcmp(hash.bytes, db_hash.value().bytes, sizeof(hash)) == 0);
 
-        // Read non existent canonical header hash
+        // Read non-existent canonical header hash
         db_hash = read_canonical_header_hash(txn, block_num + 1);
         REQUIRE(db_hash.has_value() == false);
 

--- a/node/silkworm/db/util.hpp
+++ b/node/silkworm/db/util.hpp
@@ -49,8 +49,11 @@ struct VersionBase {
 
 /* Common Keys */
 
-// Key for DbInfo bucket storing db schema version
+//! Key for DbInfo bucket storing db schema version
 inline constexpr const char* kDbSchemaVersionKey{"dbVersion"};
+
+//! Key for DbInfo bucket storing snapshot file names
+inline constexpr const char* kDbSnapshotsKey{"snapshots"};
 
 inline constexpr size_t kIncarnationLength{8};
 inline constexpr size_t kLocationLength{32};


### PR DESCRIPTION
This PR add support for snapshots in database access layer by adding:
- `read_snapshots` and `write_snapshots` functions to read/write the snapshot file list to/from the DatabaseInfo table
- `reset_map_sequence` to reset the bucket sequence number associated to any map