### PR TITLE
node: fix Tx RPC unit tests

### DIFF
--- a/node/silkworm/backend/rpc/kv_calls.cpp
+++ b/node/silkworm/backend/rpc/kv_calls.cpp
@@ -155,7 +155,8 @@ awaitable<void> TxCall::operator()() {
             }
         };
         const auto write = [&]() -> awaitable<void> {
-            while (co_await write_stream.next()) {}
+            while (co_await write_stream.next()) {
+            }
         };
         const auto max_idle_timer = [&]() -> awaitable<void> {
             while (true) {

--- a/node/silkworm/backend/rpc/kv_calls.hpp
+++ b/node/silkworm/backend/rpc/kv_calls.hpp
@@ -85,8 +85,8 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
     };
 
     struct CursorPosition {
-        std::string current_key;
-        std::string current_value;
+        std::optional<std::string> current_key;
+        std::optional<std::string> current_value;
     };
 
     void handle(const remote::Cursor* request, remote::Pair& response);

--- a/node/silkworm/db/mdbx.cpp
+++ b/node/silkworm/db/mdbx.cpp
@@ -259,6 +259,21 @@ MDBX_stat Cursor::get_map_stat() const {
     return txn().get_map_stat(map());
 }
 
+MDBX_db_flags_t Cursor::get_map_flags() const {
+    if (!handle_) {
+        mdbx::error::success_or_throw(EINVAL);
+    }
+    return txn().get_handle_info(map()).flags;
+}
+
+bool Cursor::is_multi_value() const {
+    return get_map_flags() & MDBX_DUPSORT;
+}
+
+bool Cursor::is_dangling() const {
+    return eof() && !on_last();
+}
+
 size_t Cursor::size() const { return get_map_stat().ms_entries; }
 
 bool Cursor::empty() const { return size() == 0; }

--- a/node/silkworm/db/mdbx.hpp
+++ b/node/silkworm/db/mdbx.hpp
@@ -229,6 +229,15 @@ class Cursor : public ::mdbx::cursor {
     //! \brief Returns stat info of underlying dbi
     [[nodiscard]] MDBX_stat get_map_stat() const;
 
+    //! \brief Returns flags of underlying dbi
+    [[nodiscard]] MDBX_db_flags_t get_map_flags() const;
+
+    //! \brief Flag indicating if table is single-value or multi-value
+    [[nodiscard]] bool is_multi_value() const;
+
+    //! \brief Flag indicating if cursor has been positioned or not
+    [[nodiscard]] bool is_dangling() const;
+
     //! \brief Returns the size of the underlying table
     [[nodiscard]] size_t size() const;
 


### PR DESCRIPTION
Fixes #862 

Details:
- refactor Tx call to use awaitable operators correctly
- change deadline time-points to reschedule Asio timers
- fix unit test for max simultaneous Tx calls
- fix non-positioned cursors in max TTL save/restore
- add utility methods in db::Cursor