### PR TITLE
node: make test fail if max per-process descriptors are insufficient

### DIFF
--- a/node/silkworm/backend/backend_kv_server_test.cpp
+++ b/node/silkworm/backend/backend_kv_server_test.cpp
@@ -37,6 +37,7 @@
 #include <silkworm/rpc/common/conversion.hpp>
 #include <silkworm/rpc/common/util.hpp>
 #include <silkworm/test/log.hpp>
+#include <silkworm/test/os.hpp>
 
 using namespace std::chrono_literals;
 
@@ -1003,6 +1004,11 @@ TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][no
 }
 
 TEST_CASE("BackEndKvServer E2E: Tx max simultaneous readers exceeded", "[silkworm][node][rpc]") {
+    // This check can be improved in Catch2 version 3.3.0 where SKIP is available
+    if (test::OS::max_file_descriptors() < 1024) {
+        FAIL("insufficient number of process file descriptors, increase to 1024 at least");
+    }
+
     NodeSettings node_settings;
     BackEndKvE2eTest test{silkworm::log::Level::kNone, std::move(node_settings)};
     test.fill_tables();

--- a/node/silkworm/test/os.hpp
+++ b/node/silkworm/test/os.hpp
@@ -34,7 +34,7 @@ class OS {
     static uint64_t max_file_descriptors() {
         uint64_t max_descriptors;
 #if defined(__linux__) || defined(__APPLE__)
-        struct rlimit limit{};
+        rlimit limit{};
         getrlimit(RLIMIT_NOFILE, &limit);
         max_descriptors = limit.rlim_cur;
 #elif defined(_WIN32)

--- a/node/silkworm/test/os.hpp
+++ b/node/silkworm/test/os.hpp
@@ -1,0 +1,49 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <iostream>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <sys/resource.h>
+#elif defined(_WIN32)
+#include <cstdio>
+#else
+#pragma message("unsupported platform detected in test/os.hpp")
+#endif
+
+namespace silkworm::test {
+
+//! Low-level OS utilities
+class OS {
+  public:
+    static uint64_t max_file_descriptors() {
+        uint64_t max_descriptors;
+#if defined(__linux__) || defined(__APPLE__)
+        struct rlimit limit{};
+        getrlimit(RLIMIT_NOFILE, &limit);
+        max_descriptors = limit.rlim_cur;
+#elif defined(_WIN32)
+        max_descriptors = _getmaxstdio();
+#else
+        max_descriptors = 0;
+#endif
+        return max_descriptors;
+    }
+};
+
+}  // namespace silkworm::test


### PR DESCRIPTION
This PR makes test "BackEndKvServer E2E: Tx max simultaneous readers exceeded" fail *explicitly* if process max file descriptors are lower than 1024 on the underlying system.

As a matter of fact, such unit test needs to reach the max limit of simultaneous MDBX readers in order to start one more Tx and check that the error condition is handled nicely on server-side. In order to do so, the test opens up a lot of Tx calls and may or may not hit the default max open files limit, within the gRPC C++ library, depending on the underlying system settings. Unfortunately, when such limit is reached the gRPC C++ library crashes abruptly, so checking this condition in advance is necessary to avoid a segmentation fault.

When we will upgrade to Catch2 version 3.3.0, we can use `SKIP` macro to simply skip the test if the underlying system does not meet the execution requirements instead of making it fail (which is seems quite rude, but at least does not fool the user).