### PR TITLE
sentry: RLPx Ping-Pong

### DIFF
--- a/silkworm/sentry/common/sleep.cpp
+++ b/silkworm/sentry/common/sleep.cpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "sleep.hpp"
+
+#include <boost/asio/this_coro.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+
+namespace silkworm::sentry::common {
+
+using namespace boost::asio;
+
+awaitable<void> sleep(std::chrono::milliseconds duration) {
+    auto executor = co_await this_coro::executor;
+    deadline_timer timer(executor);
+    timer.expires_from_now(boost::posix_time::milliseconds(duration.count()));
+    co_await timer.async_wait(use_awaitable);
+}
+
+}  // namespace silkworm::sentry::common

--- a/silkworm/sentry/common/sleep.hpp
+++ b/silkworm/sentry/common/sleep.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 
 #pragma once
 
-#include <cstdint>
+#include <chrono>
+#include <boost/asio/awaitable.hpp>
 
-enum class DisconnectReason : uint8_t {
-    DisconnectRequested = 0,
-    UselessPeer = 3,
-    TooManyPeers = 4,
-    ClientQuitting = 8,
-    PingTimeout = 11,
-};
+namespace silkworm::sentry::common {
+
+boost::asio::awaitable<void> sleep(std::chrono::milliseconds duration);
+
+}  // namespace silkworm::sentry::common

--- a/silkworm/sentry/peer_manager.cpp
+++ b/silkworm/sentry/peer_manager.cpp
@@ -54,7 +54,7 @@ awaitable<void> PeerManager::start_in_strand(common::Channel<std::shared_ptr<rlp
     }
 }
 
-boost::asio::awaitable<void> PeerManager::start_peer(const std::shared_ptr<rlpx::Peer>& peer) {
+boost::asio::awaitable<void> PeerManager::start_peer(std::shared_ptr<rlpx::Peer> peer) {
     try {
         co_await rlpx::Peer::start(peer);
     } catch (const boost::system::system_error& ex) {
@@ -72,7 +72,7 @@ boost::asio::awaitable<void> PeerManager::start_peer(const std::shared_ptr<rlpx:
 }
 
 boost::asio::awaitable<void> PeerManager::drop_peer(
-    const std::shared_ptr<rlpx::Peer>& peer,
+    std::shared_ptr<rlpx::Peer> peer,
     DisconnectReason reason) {
     try {
         co_await rlpx::Peer::drop(peer, reason);
@@ -131,15 +131,15 @@ void PeerManager::add_observer(std::weak_ptr<PeerManagerObserver> observer) {
     return observers;
 }
 
-void PeerManager::on_peer_added(std::shared_ptr<rlpx::Peer> peer) {
+void PeerManager::on_peer_added(const std::shared_ptr<rlpx::Peer>& peer) {
     for (auto& observer : observers()) {
-        observer->on_peer_added(std::move(peer));
+        observer->on_peer_added(peer);
     }
 }
 
-void PeerManager::on_peer_removed(std::shared_ptr<rlpx::Peer> peer) {
+void PeerManager::on_peer_removed(const std::shared_ptr<rlpx::Peer>& peer) {
     for (auto& observer : observers()) {
-        observer->on_peer_removed(std::move(peer));
+        observer->on_peer_removed(peer);
     }
 }
 

--- a/silkworm/sentry/peer_manager.hpp
+++ b/silkworm/sentry/peer_manager.hpp
@@ -56,9 +56,9 @@ class PeerManager {
 
   private:
     boost::asio::awaitable<void> start_in_strand(common::Channel<std::shared_ptr<rlpx::Peer>>& peer_channel);
-    boost::asio::awaitable<void> start_peer(const std::shared_ptr<rlpx::Peer>& peer);
-    boost::asio::awaitable<void> drop_peer(
-        const std::shared_ptr<rlpx::Peer>& peer,
+    boost::asio::awaitable<void> start_peer(std::shared_ptr<rlpx::Peer> peer);
+    static boost::asio::awaitable<void> drop_peer(
+        std::shared_ptr<rlpx::Peer> peer,
         DisconnectReason reason);
 
     static size_t max_peer_tasks(size_t max_peers);
@@ -67,8 +67,8 @@ class PeerManager {
     boost::asio::awaitable<void> enumerate_random_peers_in_strand(size_t max_count, EnumeratePeersCallback callback);
 
     [[nodiscard]] std::list<std::shared_ptr<PeerManagerObserver>> observers();
-    void on_peer_added(std::shared_ptr<rlpx::Peer> peer);
-    void on_peer_removed(std::shared_ptr<rlpx::Peer> peer);
+    void on_peer_added(const std::shared_ptr<rlpx::Peer>& peer);
+    void on_peer_removed(const std::shared_ptr<rlpx::Peer>& peer);
 
     std::list<std::shared_ptr<rlpx::Peer>> peers_;
     size_t max_peers_;

--- a/silkworm/sentry/rlpx/peer.hpp
+++ b/silkworm/sentry/rlpx/peer.hpp
@@ -59,10 +59,11 @@ class Peer {
           strand_(boost::asio::make_strand(io_context)),
           send_message_tasks_(strand_, 1000),
           send_message_channel_(io_context),
-          receive_message_channel_(io_context) {}
+          receive_message_channel_(io_context),
+          pong_channel_(io_context) {}
     ~Peer();
 
-    static boost::asio::awaitable<void> start(const std::shared_ptr<Peer>& peer);
+    static boost::asio::awaitable<void> start(std::shared_ptr<Peer> peer);
     static boost::asio::awaitable<void> drop(const std::shared_ptr<Peer>& peer, DisconnectReason reason);
 
     static void post_message(const std::shared_ptr<Peer>& peer, const common::Message& message);
@@ -90,6 +91,7 @@ class Peer {
     boost::asio::awaitable<void> send_message(common::Message message);
     boost::asio::awaitable<void> send_messages(framing::MessageStream& message_stream);
     boost::asio::awaitable<void> receive_messages(framing::MessageStream& message_stream);
+    boost::asio::awaitable<void> ping_periodically(framing::MessageStream& message_stream);
 
     common::SocketStream stream_;
     common::EccKeyPair node_key_;
@@ -102,6 +104,7 @@ class Peer {
     common::TaskGroup send_message_tasks_;
     common::Channel<common::Message> send_message_channel_;
     common::Channel<common::Message> receive_message_channel_;
+    common::Channel<common::Message> pong_channel_;
 };
 
 }  // namespace silkworm::sentry::rlpx

--- a/silkworm/sentry/rlpx/ping_message.cpp
+++ b/silkworm/sentry/rlpx/ping_message.cpp
@@ -1,0 +1,46 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "ping_message.hpp"
+
+#include <silkworm/core/rlp/encode_vector.hpp>
+
+namespace silkworm::sentry::rlpx {
+
+const uint8_t PingMessage::kId = 2;
+const uint8_t PongMessage::kId = 3;
+
+Bytes PingMessage::rlp_encode() const {
+    Bytes data;
+    rlp::encode(data, std::vector<uint8_t>{});
+    return data;
+}
+
+Bytes PongMessage::rlp_encode() const {
+    Bytes data;
+    rlp::encode(data, std::vector<uint8_t>{});
+    return data;
+}
+
+sentry::common::Message PingMessage::to_message() const {
+    return sentry::common::Message{kId, rlp_encode()};
+}
+
+sentry::common::Message PongMessage::to_message() const {
+    return sentry::common::Message{kId, rlp_encode()};
+}
+
+}

--- a/silkworm/sentry/rlpx/ping_message.hpp
+++ b/silkworm/sentry/rlpx/ping_message.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,12 +16,21 @@
 
 #pragma once
 
-#include <cstdint>
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/sentry/common/message.hpp>
 
-enum class DisconnectReason : uint8_t {
-    DisconnectRequested = 0,
-    UselessPeer = 3,
-    TooManyPeers = 4,
-    ClientQuitting = 8,
-    PingTimeout = 11,
+namespace silkworm::sentry::rlpx {
+
+struct PingMessage {
+    [[nodiscard]] Bytes rlp_encode() const;
+    [[nodiscard]] sentry::common::Message to_message() const;
+    static const uint8_t kId;
 };
+
+struct PongMessage {
+    [[nodiscard]] Bytes rlp_encode() const;
+    [[nodiscard]] sentry::common::Message to_message() const;
+    static const uint8_t kId;
+};
+
+}  // namespace silkworm::sentry::rlpx


### PR DESCRIPTION
* ping-pong logic
* fix: if Peer::handle quits without an exception Peer::start must quit too - use ||
* fix: PeerManager::on_peer_added/removed must not move multiple times in the loop
* fix: awaitable Peer::start/PeerManager::start_peer need to accept shared_ptr by value to make sure that it outlives the coroutine