### PR TITLE
Skip server RPC test counting instances

### DIFF
--- a/silkworm/node/rpc/server/call_test.cpp
+++ b/silkworm/node/rpc/server/call_test.cpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::rpc {
 
-TEST_CASE("BaseRpc", "[silkworm][rpc][call]") {
+TEST_CASE("BaseRpc", "[silkworm][rpc][call][.]") {
     class FakeRpc : public server::Call {
       public:
         explicit FakeRpc(grpc::ServerContext& server_context) : server::Call(server_context) {}


### PR DESCRIPTION
This PR just skips one flaky unit test counting server-side RPC call instances.