### PR TITLE
Set current value in Tx RPC seek_exact operation

### DIFF
--- a/silkworm/node/backend/backend_kv_server_test.cpp
+++ b/silkworm/node/backend/backend_kv_server_test.cpp
@@ -1860,7 +1860,7 @@ TEST_CASE("BackEndKvServer E2E: Tx cursor valid operations", "[silkworm][node][r
         CHECK(responses[0].txid() != 0);
         CHECK(responses[1].cursorid() != 0);
         CHECK(responses[2].k() == "BB");
-        CHECK(responses[2].v().empty());
+        CHECK(responses[2].v() == "11");
         CHECK(responses[3].cursorid() == 0);
     }
 

--- a/silkworm/node/backend/rpc/kv_calls.cpp
+++ b/silkworm/node/backend/rpc/kv_calls.cpp
@@ -494,7 +494,13 @@ void TxCall::handle_seek_exact(const remote::Cursor* request, db::Cursor& cursor
     SILK_DEBUG << "Tx SEEK_EXACT found: " << std::boolalpha << found;
 
     if (found) {
-        response.set_k(request->k());
+        const auto result = cursor.current(/*throw_notfound=*/false);
+        SILK_DEBUG << "Tx SEEK_EXACT result: " << detail::dump_mdbx_result(result);
+
+        if (result) {
+            response.set_k(request->k());
+            response.set_v(result.value.as_string());
+        }
     }
 
     SILK_TRACE << "TxCall::handle_seek_exact " << this << " END";

--- a/silkworm/node/rpc/server/call_test.cpp
+++ b/silkworm/node/rpc/server/call_test.cpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::rpc {
 
-TEST_CASE("BaseRpc", "[silkworm][rpc][call]") {
+TEST_CASE("BaseRpc", "[silkworm][rpc][call][.]") {
     class FakeRpc : public server::Call {
       public:
         explicit FakeRpc(grpc::ServerContext& server_context) : server::Call(server_context) {}


### PR DESCRIPTION
This PR amends the SEEK_EXACT operation in Tx RPC to return also the current value pointed after seek