### PR TITLE
Refactor transaction data type in database access layer

### DIFF
--- a/cmd/check_changes.cpp
+++ b/cmd/check_changes.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
         data_dir.deploy();
         db::EnvConfig db_config{data_dir.chaindata().path().string()};
         auto env{db::open_env(db_config)};
-        auto txn{env.start_read()};
+        db::ROTxn txn{env};
         auto chain_config{db::read_chain_config(txn)};
         if (!chain_config.has_value()) {
             throw std::runtime_error("Unable to retrieve chain config");
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
         auto engine{consensus::engine_factory(chain_config.value())};
         Block block;
         for (; block_num < to; ++block_num) {
-            txn.renew_reading();
+            txn->renew_reading();
             if (!db::read_block_by_number(txn, block_num, /*read_senders=*/true, block)) {
                 break;
             }

--- a/cmd/check_pow.cpp
+++ b/cmd/check_pow.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
         // Set database parameters
         db::EnvConfig db_config{options.datadir};
         auto env{db::open_env(db_config)};
-        auto txn{env.start_read()};
+        db::ROTxn txn{env};
 
         auto config{db::read_chain_config(txn)};
         if (!config.has_value()) {

--- a/cmd/scan_txs.cpp
+++ b/cmd/scan_txs.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
         data_dir.deploy();
         db::EnvConfig db_config{data_dir.chaindata().path().string()};
         auto env{db::open_env(db_config)};
-        auto txn{env.start_read()};
+        db::ROTxn txn{env};
         auto chain_config{db::read_chain_config(txn)};
         if (!chain_config) {
             throw std::runtime_error("Unable to retrieve chain config");
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
             // Note: See the comment above. You may uncomment that line and comment the next line if you're certain
             // that Erigon is not syncing on the same machine. If you use a long-running transaction by doing this, and
             // you're mistaken (Erigon is syncing), the database file may 'grow quickly' as per the LMDB docs.
-            txn.renew_reading();
+            txn->renew_reading();
 
             // Read the block
             if (!db::read_block_by_number(txn, block_num, /*read_senders=*/true, block)) {

--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -27,7 +27,7 @@
 
 namespace silkworm::db {
 
-std::optional<VersionBase> read_schema_version(mdbx::txn& txn) {
+std::optional<VersionBase> read_schema_version(ROTxn& txn) {
     Cursor src(txn, db::table::kDatabaseInfo);
     if (!src.seek(mdbx::slice{kDbSchemaVersionKey})) {
         return std::nullopt;
@@ -43,7 +43,7 @@ std::optional<VersionBase> read_schema_version(mdbx::txn& txn) {
     return VersionBase{Major, Minor, Patch};
 }
 
-void write_schema_version(mdbx::txn& txn, const VersionBase& schema_version) {
+void write_schema_version(RWTxn& txn, const VersionBase& schema_version) {
     auto old_schema_version{read_schema_version(txn)};
     if (old_schema_version.has_value()) {
         if (schema_version == old_schema_version.value()) {
@@ -63,13 +63,13 @@ void write_schema_version(mdbx::txn& txn, const VersionBase& schema_version) {
     src.upsert(mdbx::slice{kDbSchemaVersionKey}, to_slice(value));
 }
 
-void write_build_info_height(mdbx::txn& txn, Bytes key, BlockNum height) {
+void write_build_info_height(RWTxn& txn, Bytes key, BlockNum height) {
     Cursor tgt(txn, db::table::kDatabaseInfo);
     Bytes value{db::block_key(height)};
     tgt.upsert(db::to_slice(key), db::to_slice(value));
 }
 
-std::vector<std::string> read_snapshots(mdbx::txn& txn) {
+std::vector<std::string> read_snapshots(ROTxn& txn) {
     Cursor db_info_cursor{txn, table::kDatabaseInfo};
     if (!db_info_cursor.seek(mdbx::slice{kDbSnapshotsKey})) {
         return {};
@@ -80,22 +80,22 @@ std::vector<std::string> read_snapshots(mdbx::txn& txn) {
     return json.get<std::vector<std::string>>();
 }
 
-void write_snapshots(mdbx::txn& txn, const std::vector<std::string>& snapshot_file_names) {
+void write_snapshots(RWTxn& txn, const std::vector<std::string>& snapshot_file_names) {
     Cursor db_info_cursor{txn, table::kDatabaseInfo};
     nlohmann::json json_value = snapshot_file_names;
     db_info_cursor.upsert(mdbx::slice{kDbSnapshotsKey}, mdbx::slice(json_value.dump().data()));
 }
 
-std::optional<BlockHeader> read_header(mdbx::txn& txn, BlockNum block_number, const evmc::bytes32& hash) {
+std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const evmc::bytes32& hash) {
     return read_header(txn, block_number, hash.bytes);
 }
 
-std::optional<BlockHeader> read_header(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
+std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
     auto key{block_key(block_number, hash)};
     return read_header(txn, key);
 }
 
-std::optional<BlockHeader> read_header(mdbx::txn& txn, ByteView key) {
+std::optional<BlockHeader> read_header(ROTxn& txn, ByteView key) {
     auto raw_header{read_header_raw(txn, key)};
     if (raw_header.empty()) {
         return std::nullopt;
@@ -106,7 +106,7 @@ std::optional<BlockHeader> read_header(mdbx::txn& txn, ByteView key) {
     return header;
 }
 
-Bytes read_header_raw(mdbx::txn& txn, ByteView key) {
+Bytes read_header_raw(ROTxn& txn, ByteView key) {
     Cursor src(txn, db::table::kHeaders);
     auto data{src.find(to_slice(key), false)};
     if (!data) {
@@ -115,7 +115,7 @@ Bytes read_header_raw(mdbx::txn& txn, ByteView key) {
     return Bytes{from_slice(data.value)};
 }
 
-std::optional<BlockHeader> read_header(mdbx::txn& txn, const evmc::bytes32& hash) {
+std::optional<BlockHeader> read_header(ROTxn& txn, const evmc::bytes32& hash) {
     auto block_num = read_block_number(txn, hash);
     if (!block_num) {
         return std::nullopt;
@@ -123,7 +123,7 @@ std::optional<BlockHeader> read_header(mdbx::txn& txn, const evmc::bytes32& hash
     return read_header(txn, *block_num, hash.bytes);
 }
 
-bool read_header(mdbx::txn& txn, const evmc::bytes32& hash, BlockNum number, BlockHeader& header) {
+bool read_header(ROTxn& txn, const evmc::bytes32& hash, BlockNum number, BlockHeader& header) {
     const Bytes key{block_key(number, hash.bytes)};
     const auto raw_header{read_header_raw(txn, key)};
     if (raw_header.empty()) {
@@ -134,7 +134,7 @@ bool read_header(mdbx::txn& txn, const evmc::bytes32& hash, BlockNum number, Blo
     return true;
 }
 
-std::vector<BlockHeader> read_headers(mdbx::txn& txn, BlockNum height) {
+std::vector<BlockHeader> read_headers(ROTxn& txn, BlockNum height) {
     std::vector<BlockHeader> headers;
     process_headers_at_height(txn, height, [&](BlockHeader&& header) {
         headers.emplace_back(std::move(header));
@@ -143,7 +143,7 @@ std::vector<BlockHeader> read_headers(mdbx::txn& txn, BlockNum height) {
 }
 
 // process headers at specific height
-size_t process_headers_at_height(mdbx::txn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func) {
+size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func) {
     db::Cursor headers_table(txn, db::table::kHeaders);
     auto key_prefix{db::block_key(height)};
 
@@ -161,7 +161,7 @@ size_t process_headers_at_height(mdbx::txn& txn, BlockNum height, std::function<
     return count;
 }
 
-void write_header(mdbx::txn& txn, const BlockHeader& header, bool with_header_numbers) {
+void write_header(RWTxn& txn, const BlockHeader& header, bool with_header_numbers) {
     Bytes value{};
     rlp::encode(value, header);
     auto header_hash = bit_cast<evmc_bytes32>(keccak256(value));  // avoid header.hash() because it re-does rlp encoding
@@ -176,7 +176,7 @@ void write_header(mdbx::txn& txn, const BlockHeader& header, bool with_header_nu
     }
 }
 
-std::optional<ByteView> read_rlp_encoded_header(mdbx::txn& txn, BlockNum bn, const evmc::bytes32& hash) {
+std::optional<ByteView> read_rlp_encoded_header(ROTxn& txn, BlockNum bn, const evmc::bytes32& hash) {
     Cursor header_table(txn, db::table::kHeaders);
     auto key = db::block_key(bn, hash.bytes);
     auto data = header_table.find(db::to_slice(key), /*throw_notfound*/ false);
@@ -184,7 +184,7 @@ std::optional<ByteView> read_rlp_encoded_header(mdbx::txn& txn, BlockNum bn, con
     return db::from_slice(data.value);
 }
 
-std::optional<BlockHeader> read_canonical_header(mdbx::txn& txn, BlockNum b) {  // also known as read-header-by-number
+std::optional<BlockHeader> read_canonical_header(ROTxn& txn, BlockNum b) {  // also known as read-header-by-number
     std::optional<evmc::bytes32> h = read_canonical_hash(txn, b);
     if (!h) {
         return std::nullopt;  // not found
@@ -196,7 +196,7 @@ static Bytes header_numbers_key(evmc::bytes32 hash) {
     return {hash.bytes, 32};
 }
 
-std::optional<BlockNum> read_block_number(mdbx::txn& txn, const evmc::bytes32& hash) {
+std::optional<BlockNum> read_block_number(ROTxn& txn, const evmc::bytes32& hash) {
     Cursor blockhashes_table(txn, db::table::kHeaderNumbers);
     auto key = header_numbers_key(hash);
     auto data = blockhashes_table.find(db::to_slice(key), /*throw_notfound*/ false);
@@ -207,23 +207,23 @@ std::optional<BlockNum> read_block_number(mdbx::txn& txn, const evmc::bytes32& h
     return block_num;
 }
 
-void write_header_number(mdbx::txn& txn, const uint8_t (&hash)[kHashLength], const BlockNum number) {
+void write_header_number(RWTxn& txn, const uint8_t (&hash)[kHashLength], const BlockNum number) {
     Cursor target(txn, table::kHeaderNumbers);
     auto value{db::block_key(number)};
     target.upsert({hash, kHashLength}, to_slice(value));
 }
 
-std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, BlockNum b, const evmc::bytes32& hash) {
+std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, BlockNum b, const evmc::bytes32& hash) {
     return db::read_total_difficulty(txn, b, hash.bytes);
 }
 
-std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, BlockNum block_number,
+std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, BlockNum block_number,
                                                    const uint8_t (&hash)[kHashLength]) {
     auto key{block_key(block_number, hash)};
     return read_total_difficulty(txn, key);
 }
 
-std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, ByteView key) {
+std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, ByteView key) {
     Cursor src(txn, table::kDifficulty);
     auto data{src.find(to_slice(key), false)};
     if (!data) {
@@ -235,7 +235,7 @@ std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, ByteView key)
     return td;
 }
 
-void write_total_difficulty(mdbx::txn& txn, const Bytes& key, const intx::uint256& total_difficulty) {
+void write_total_difficulty(RWTxn& txn, const Bytes& key, const intx::uint256& total_difficulty) {
     SILKWORM_ASSERT(key.length() == sizeof(BlockNum) + kHashLength);
     Bytes value{};
     rlp::encode(value, total_difficulty);
@@ -244,19 +244,19 @@ void write_total_difficulty(mdbx::txn& txn, const Bytes& key, const intx::uint25
     target.upsert(to_slice(key), to_slice(value));
 }
 
-void write_total_difficulty(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength],
+void write_total_difficulty(RWTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength],
                             const intx::uint256& total_difficulty) {
     auto key{block_key(block_number, hash)};
     write_total_difficulty(txn, key, total_difficulty);
 }
 
-void write_total_difficulty(mdbx::txn& txn, BlockNum block_number, const evmc::bytes32& hash,
+void write_total_difficulty(RWTxn& txn, BlockNum block_number, const evmc::bytes32& hash,
                             const intx::uint256& total_difficulty) {
     auto key{block_key(block_number, hash.bytes)};
     write_total_difficulty(txn, key, total_difficulty);
 }
 
-std::tuple<BlockNum, evmc::bytes32> read_canonical_head(mdbx::txn& txn) {
+std::tuple<BlockNum, evmc::bytes32> read_canonical_head(ROTxn& txn) {
     Cursor cursor(txn, table::kCanonicalHashes);
     auto data = cursor.to_last();
     if (!data) return {};
@@ -266,7 +266,7 @@ std::tuple<BlockNum, evmc::bytes32> read_canonical_head(mdbx::txn& txn) {
     return {bn, hash};
 }
 
-std::optional<evmc::bytes32> read_canonical_header_hash(mdbx::txn& txn, BlockNum number) {
+std::optional<evmc::bytes32> read_canonical_header_hash(ROTxn& txn, BlockNum number) {
     Cursor source(txn, table::kCanonicalHashes);
     auto key{db::block_key(number)};
     auto data{source.find(to_slice(key), /*throw_notfound=*/false)};
@@ -278,17 +278,17 @@ std::optional<evmc::bytes32> read_canonical_header_hash(mdbx::txn& txn, BlockNum
     return ret;
 }
 
-void write_canonical_header(mdbx::txn& txn, const BlockHeader& header) {
+void write_canonical_header(RWTxn& txn, const BlockHeader& header) {
     write_canonical_header_hash(txn, header.hash().bytes, header.number);
 }
 
-void write_canonical_header_hash(mdbx::txn& txn, const uint8_t (&hash)[kHashLength], BlockNum number) {
+void write_canonical_header_hash(RWTxn& txn, const uint8_t (&hash)[kHashLength], BlockNum number) {
     Cursor target(txn, table::kCanonicalHashes);
     auto key{db::block_key(number)};
     target.upsert(to_slice(key), db::to_slice(hash));
 }
 
-void read_transactions(mdbx::txn& txn, uint64_t base_id, uint64_t count, std::vector<Transaction>& out) {
+void read_transactions(ROTxn& txn, uint64_t base_id, uint64_t count, std::vector<Transaction>& out) {
     if (count == 0) {
         out.clear();
         return;
@@ -297,7 +297,7 @@ void read_transactions(mdbx::txn& txn, uint64_t base_id, uint64_t count, std::ve
     read_transactions(src, base_id, count, out);
 }
 
-void write_transactions(mdbx::txn& txn, const std::vector<Transaction>& transactions, uint64_t base_id) {
+void write_transactions(RWTxn& txn, const std::vector<Transaction>& transactions, uint64_t base_id) {
     if (transactions.empty()) {
         return;
     }
@@ -331,7 +331,7 @@ void read_transactions(mdbx::cursor& txn_table, uint64_t base_id, uint64_t count
     SILKWORM_ASSERT(i == count);
 }
 
-bool read_block_by_number(mdbx::txn& txn, BlockNum number, bool read_senders, Block& block) {
+bool read_block_by_number(ROTxn& txn, BlockNum number, bool read_senders, Block& block) {
     Cursor canonical_hashes_cursor(txn, table::kCanonicalHashes);
     const Bytes key{block_key(number)};
     const auto data{canonical_hashes_cursor.find(to_slice(key), false)};
@@ -343,14 +343,14 @@ bool read_block_by_number(mdbx::txn& txn, BlockNum number, bool read_senders, Bl
     return read_block(txn, std::span<const uint8_t, kHashLength>{hash_ptr, kHashLength}, number, read_senders, block);
 }
 
-bool read_block(mdbx::txn& txn, const evmc::bytes32& hash, BlockNum number, Block& block) {
+bool read_block(ROTxn& txn, const evmc::bytes32& hash, BlockNum number, Block& block) {
     // Read header
     read_header(txn, hash, number, block.header);
     // Read body
     return read_body(txn, hash, number, block);  // read_senders == false
 }
 
-bool read_block(mdbx::txn& txn, std::span<const uint8_t, kHashLength> hash, BlockNum number, bool read_senders,
+bool read_block(ROTxn& txn, std::span<const uint8_t, kHashLength> hash, BlockNum number, bool read_senders,
                 Block& block) {
     // Read header
     const Bytes key{block_key(number, hash)};
@@ -365,7 +365,7 @@ bool read_block(mdbx::txn& txn, std::span<const uint8_t, kHashLength> hash, Bloc
 }
 
 // process blocks at specific height
-size_t process_blocks_at_height(mdbx::txn& txn, BlockNum height, std::function<void(Block&)> process_func, bool read_senders) {
+size_t process_blocks_at_height(ROTxn& txn, BlockNum height, std::function<void(Block&)> process_func, bool read_senders) {
     db::Cursor bodies_table(txn, db::table::kBlockBodies);
     auto key_prefix{db::block_key(height)};
 
@@ -397,17 +397,17 @@ size_t process_blocks_at_height(mdbx::txn& txn, BlockNum height, std::function<v
     return count;
 }
 
-bool read_body(mdbx::txn& txn, const evmc::bytes32& h, BlockNum bn, BlockBody& body) {
+bool read_body(ROTxn& txn, const evmc::bytes32& h, BlockNum bn, BlockBody& body) {
     return db::read_body(txn, bn, h.bytes, /*read_senders=*/false, body);
 }
 
-bool read_body(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength], bool read_senders,
+bool read_body(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength], bool read_senders,
                BlockBody& out) {
     auto key{block_key(block_number, hash)};
     return read_body(txn, key, read_senders, out);
 }
 
-bool read_body(mdbx::txn& txn, const Bytes& key, bool read_senders, BlockBody& out) {
+bool read_body(ROTxn& txn, const Bytes& key, bool read_senders, BlockBody& out) {
     Cursor src(txn, table::kBlockBodies);
     auto data{src.find(to_slice(key), false)};
     if (!data) {
@@ -424,7 +424,7 @@ bool read_body(mdbx::txn& txn, const Bytes& key, bool read_senders, BlockBody& o
     return true;
 }
 
-bool read_body(mdbx::txn& txn, const evmc::bytes32& h, BlockBody& body) {
+bool read_body(ROTxn& txn, const evmc::bytes32& h, BlockBody& body) {
     auto block_num = read_block_number(txn, h);
     if (!block_num) {
         return false;
@@ -432,7 +432,7 @@ bool read_body(mdbx::txn& txn, const evmc::bytes32& h, BlockBody& body) {
     return db::read_body(txn, *block_num, h.bytes, /*read_senders=*/false, body);
 }
 
-bool read_canonical_block(mdbx::txn& txn, BlockNum height, Block& block) {
+bool read_canonical_block(ROTxn& txn, BlockNum height, Block& block) {
     std::optional<evmc::bytes32> h = read_canonical_hash(txn, height);
     if (!h) return false;
 
@@ -442,21 +442,21 @@ bool read_canonical_block(mdbx::txn& txn, BlockNum height, Block& block) {
     return read_body(txn, *h, height, block);
 }
 
-bool has_body(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
+bool has_body(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
     auto key{block_key(block_number, hash)};
     Cursor src(txn, table::kBlockBodies);
     return src.find(to_slice(key), false);
 }
 
-bool has_body(mdbx::txn& txn, BlockNum block_number, const evmc::bytes32& hash) {
+bool has_body(ROTxn& txn, BlockNum block_number, const evmc::bytes32& hash) {
     return db::has_body(txn, block_number, hash.bytes);
 }
 
-void write_body(mdbx::txn& txn, const BlockBody& body, const evmc::bytes32& hash, BlockNum bn) {
+void write_body(RWTxn& txn, const BlockBody& body, const evmc::bytes32& hash, BlockNum bn) {
     write_body(txn, body, hash.bytes, bn);
 }
 
-void write_body(mdbx::txn& txn, const BlockBody& body, const uint8_t (&hash)[kHashLength], const BlockNum number) {
+void write_body(RWTxn& txn, const BlockBody& body, const uint8_t (&hash)[kHashLength], const BlockNum number) {
     detail::BlockBodyForStorage body_for_storage{};
     body_for_storage.ommers = body.ommers;
     body_for_storage.txn_count = body.transactions.size();
@@ -471,18 +471,18 @@ void write_body(mdbx::txn& txn, const BlockBody& body, const uint8_t (&hash)[kHa
     write_transactions(txn, body.transactions, body_for_storage.base_txn_id);
 }
 
-static ByteView read_senders_raw(mdbx::txn& txn, const Bytes& key) {
+static ByteView read_senders_raw(ROTxn& txn, const Bytes& key) {
     Cursor src(txn, table::kSenders);
     auto data{src.find(to_slice(key), /*throw_notfound = */ false)};
     return data ? from_slice(data.value) : ByteView();
 }
 
-std::vector<evmc::address> read_senders(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
+std::vector<evmc::address> read_senders(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]) {
     auto key{block_key(block_number, hash)};
     return read_senders(txn, key);
 }
 
-std::vector<evmc::address> read_senders(mdbx::txn& txn, const Bytes& key) {
+std::vector<evmc::address> read_senders(ROTxn& txn, const Bytes& key) {
     std::vector<evmc::address> senders{};
     auto data_view{read_senders_raw(txn, key)};
     if (!data_view.empty()) {
@@ -493,7 +493,7 @@ std::vector<evmc::address> read_senders(mdbx::txn& txn, const Bytes& key) {
     return senders;
 }
 
-void parse_senders(mdbx::txn& txn, const Bytes& key, std::vector<Transaction>& out) {
+void parse_senders(ROTxn& txn, const Bytes& key, std::vector<Transaction>& out) {
     if (out.empty()) {
         return;
     }
@@ -514,7 +514,7 @@ void parse_senders(mdbx::txn& txn, const Bytes& key, std::vector<Transaction>& o
     }
 }
 
-std::optional<ByteView> read_code(mdbx::txn& txn, const evmc::bytes32& code_hash) {
+std::optional<ByteView> read_code(ROTxn& txn, const evmc::bytes32& code_hash) {
     Cursor src(txn, table::kCode);
     auto key{to_slice(code_hash)};
     auto data{src.find(key, /*throw_notfound=*/false)};
@@ -525,7 +525,7 @@ std::optional<ByteView> read_code(mdbx::txn& txn, const evmc::bytes32& code_hash
 }
 
 // Erigon FindByHistory for account
-static std::optional<ByteView> historical_account(mdbx::txn& txn, const evmc::address& address, BlockNum block_number) {
+static std::optional<ByteView> historical_account(ROTxn& txn, const evmc::address& address, BlockNum block_number) {
     Cursor src(txn, table::kAccountHistory);
     const Bytes history_key{account_history_key(address, block_number)};
     const auto data{src.lower_bound(to_slice(history_key), /*throw_notfound=*/false)};
@@ -545,7 +545,7 @@ static std::optional<ByteView> historical_account(mdbx::txn& txn, const evmc::ad
 }
 
 // Erigon FindByHistory for storage
-static std::optional<ByteView> historical_storage(mdbx::txn& txn, const evmc::address& address, uint64_t incarnation,
+static std::optional<ByteView> historical_storage(ROTxn& txn, const evmc::address& address, uint64_t incarnation,
                                                   const evmc::bytes32& location, BlockNum block_number) {
     Cursor src(txn, table::kStorageHistory);
     const Bytes history_key{storage_history_key(address, location, block_number)};
@@ -573,7 +573,7 @@ static std::optional<ByteView> historical_storage(mdbx::txn& txn, const evmc::ad
     return find_value_suffix(src, change_set_key, location);
 }
 
-std::optional<Account> read_account(mdbx::txn& txn, const evmc::address& address, std::optional<BlockNum> block_num) {
+std::optional<Account> read_account(ROTxn& txn, const evmc::address& address, std::optional<BlockNum> block_num) {
     std::optional<ByteView> encoded{block_num.has_value() ? historical_account(txn, address, block_num.value())
                                                           : std::nullopt};
 
@@ -604,7 +604,7 @@ std::optional<Account> read_account(mdbx::txn& txn, const evmc::address& address
     return acc;
 }
 
-evmc::bytes32 read_storage(mdbx::txn& txn, const evmc::address& address, uint64_t incarnation,
+evmc::bytes32 read_storage(ROTxn& txn, const evmc::address& address, uint64_t incarnation,
                            const evmc::bytes32& location, std::optional<BlockNum> block_num) {
     std::optional<ByteView> val{block_num.has_value()
                                     ? historical_storage(txn, address, incarnation, location, block_num.value())
@@ -630,7 +630,7 @@ static std::optional<uint64_t> historical_previous_incarnation() {
     return std::nullopt;
 }
 
-std::optional<uint64_t> read_previous_incarnation(mdbx::txn& txn, const evmc::address& address,
+std::optional<uint64_t> read_previous_incarnation(ROTxn& txn, const evmc::address& address,
                                                   std::optional<BlockNum> block_num) {
     if (block_num.has_value()) {
         return historical_previous_incarnation();
@@ -644,7 +644,7 @@ std::optional<uint64_t> read_previous_incarnation(mdbx::txn& txn, const evmc::ad
     return std::nullopt;
 }
 
-AccountChanges read_account_changes(mdbx::txn& txn, BlockNum block_num) {
+AccountChanges read_account_changes(ROTxn& txn, BlockNum block_num) {
     AccountChanges changes;
 
     Cursor src(txn, table::kAccountChangeSet);
@@ -662,7 +662,7 @@ AccountChanges read_account_changes(mdbx::txn& txn, BlockNum block_num) {
     return changes;
 }
 
-StorageChanges read_storage_changes(mdbx::txn& txn, BlockNum block_num) {
+StorageChanges read_storage_changes(ROTxn& txn, BlockNum block_num) {
     StorageChanges changes;
 
     const Bytes block_prefix{block_key(block_num)};
@@ -695,7 +695,7 @@ StorageChanges read_storage_changes(mdbx::txn& txn, BlockNum block_num) {
     return changes;
 }
 
-std::optional<ChainConfig> read_chain_config(mdbx::txn& txn) {
+std::optional<ChainConfig> read_chain_config(ROTxn& txn) {
     Cursor src(txn, table::kCanonicalHashes);
     auto data{src.find(to_slice(block_key(0)), /*throw_notfound=*/false)};
     if (!data) {
@@ -714,7 +714,7 @@ std::optional<ChainConfig> read_chain_config(mdbx::txn& txn) {
     return ChainConfig::from_json(json);
 }
 
-void update_chain_config(mdbx::txn& txn, const ChainConfig& config) {
+void update_chain_config(RWTxn& txn, const ChainConfig& config) {
     auto genesis_hash{read_canonical_header_hash(txn, 0)};
     if (!genesis_hash.has_value()) {
         return;
@@ -730,11 +730,11 @@ static Bytes head_header_key() {
     return key;
 }
 
-void write_head_header_hash(mdbx::txn& txn, const evmc::bytes32& hash) {
+void write_head_header_hash(RWTxn& txn, const evmc::bytes32& hash) {
     write_head_header_hash(txn, hash.bytes);
 }
 
-void write_head_header_hash(mdbx::txn& txn, const uint8_t (&hash)[kHashLength]) {
+void write_head_header_hash(RWTxn& txn, const uint8_t (&hash)[kHashLength]) {
     Cursor target(txn, table::kHeadHeader);
     Bytes key = head_header_key();
     auto skey = db::to_slice(key);
@@ -742,7 +742,7 @@ void write_head_header_hash(mdbx::txn& txn, const uint8_t (&hash)[kHashLength]) 
     target.upsert(skey, to_slice(hash));
 }
 
-std::optional<evmc::bytes32> read_head_header_hash(mdbx::txn& txn) {
+std::optional<evmc::bytes32> read_head_header_hash(ROTxn& txn) {
     Cursor src(txn, table::kHeadHeader);
     Bytes key = head_header_key();
     auto skey = db::to_slice(key);
@@ -753,7 +753,7 @@ std::optional<evmc::bytes32> read_head_header_hash(mdbx::txn& txn) {
     return to_bytes32(from_slice(data.value));
 }
 
-std::optional<evmc::bytes32> read_canonical_hash(mdbx::txn& txn, BlockNum b) {  // throws db exceptions
+std::optional<evmc::bytes32> read_canonical_hash(ROTxn& txn, BlockNum b) {  // throws db exceptions
     Cursor hashes_table(txn, db::table::kCanonicalHashes);
     // accessing this table with only b we will get the hash of the canonical block at height b
     auto key = db::block_key(b);
@@ -763,7 +763,7 @@ std::optional<evmc::bytes32> read_canonical_hash(mdbx::txn& txn, BlockNum b) {  
     return to_bytes32(from_slice(data.value));  // copy
 }
 
-void write_canonical_hash(mdbx::txn& txn, BlockNum b, const evmc::bytes32& hash) {
+void write_canonical_hash(RWTxn& txn, BlockNum b, const evmc::bytes32& hash) {
     Bytes key = db::block_key(b);
     auto skey = db::to_slice(key);
     auto svalue = db::to_slice(hash);
@@ -772,14 +772,14 @@ void write_canonical_hash(mdbx::txn& txn, BlockNum b, const evmc::bytes32& hash)
     hashes_table.upsert(skey, svalue);
 }
 
-void delete_canonical_hash(mdbx::txn& txn, BlockNum b) {
+void delete_canonical_hash(RWTxn& txn, BlockNum b) {
     Cursor hashes_table(txn, db::table::kCanonicalHashes);
     Bytes key = db::block_key(b);
     auto skey = db::to_slice(key);
     (void)hashes_table.erase(skey);
 }
 
-uint64_t increment_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t increment) {
+uint64_t increment_map_sequence(RWTxn& txn, const char* map_name, uint64_t increment) {
     uint64_t current_value{read_map_sequence(txn, map_name)};
     if (increment) {
         Cursor target(txn, table::kSequence);
@@ -792,7 +792,7 @@ uint64_t increment_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t i
     return current_value;
 }
 
-uint64_t read_map_sequence(mdbx::txn& txn, const char* map_name) {
+uint64_t read_map_sequence(ROTxn& txn, const char* map_name) {
     Cursor target(txn, table::kSequence);
     mdbx::slice key(map_name);
     auto data{target.find(key, /*throw_notfound=*/false)};
@@ -805,7 +805,7 @@ uint64_t read_map_sequence(mdbx::txn& txn, const char* map_name) {
     return endian::load_big_u64(from_slice(data.value).data());
 }
 
-uint64_t reset_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t new_sequence) {
+uint64_t reset_map_sequence(RWTxn& txn, const char* map_name, uint64_t new_sequence) {
     uint64_t current_sequence{read_map_sequence(txn, map_name)};
     if (new_sequence != current_sequence) {
         Cursor target(txn, table::kSequence);

--- a/silkworm/node/db/access_layer.hpp
+++ b/silkworm/node/db/access_layer.hpp
@@ -33,161 +33,161 @@
 namespace silkworm::db {
 
 //! \brief Pulls database schema version
-std::optional<VersionBase> read_schema_version(mdbx::txn& txn);
+std::optional<VersionBase> read_schema_version(ROTxn& txn);
 
 //! \brief Writes database schema version (throws on downgrade)
-void write_schema_version(mdbx::txn& txn, const VersionBase& schema_version);
+void write_schema_version(RWTxn& txn, const VersionBase& schema_version);
 
 //! \brief Updates database info with build info at provided height
 //! \details Is useful to track whether increasing heights have been affected by
 //! upgrades or downgrades of Silkworm's build
-void write_build_info_height(mdbx::txn& txn, Bytes key, BlockNum height);
+void write_build_info_height(RWTxn& txn, Bytes key, BlockNum height);
 
 //! \brief Read the list of snapshot file names
-std::vector<std::string> read_snapshots(mdbx::txn& txn);
+std::vector<std::string> read_snapshots(ROTxn& txn);
 
 //! \brief Write the list of snapshot file names
-void write_snapshots(mdbx::txn& txn, const std::vector<std::string>& snapshot_file_names);
+void write_snapshots(RWTxn& txn, const std::vector<std::string>& snapshot_file_names);
 
 //! \brief Reads a header with the specified key (block number, hash)
-std::optional<BlockHeader> read_header(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
-std::optional<BlockHeader> read_header(mdbx::txn& txn, BlockNum block_number, const evmc::bytes32&);
-std::optional<BlockHeader> read_header(mdbx::txn& txn, ByteView key);
-Bytes read_header_raw(mdbx::txn& txn, ByteView key);
+std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
+std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const evmc::bytes32&);
+std::optional<BlockHeader> read_header(ROTxn& txn, ByteView key);
+Bytes read_header_raw(ROTxn& txn, ByteView key);
 
 //! \brief Reads a header with the specified hash
-std::optional<BlockHeader> read_header(mdbx::txn& txn, const evmc::bytes32& hash);
+std::optional<BlockHeader> read_header(ROTxn& txn, const evmc::bytes32& hash);
 
 //! \brief Reads all headers at the specified height
-std::vector<BlockHeader> read_headers(mdbx::txn& txn, BlockNum height);
+std::vector<BlockHeader> read_headers(ROTxn& txn, BlockNum height);
 
 //! \brief Apply a user defined func to the headers at specific height
-size_t process_headers_at_height(mdbx::txn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func);
+size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func);
 
 //! \brief Reads a header without rlp-decoding it
-std::optional<ByteView> read_rlp_encoded_header(mdbx::txn& txn, BlockNum bn, const evmc::bytes32& hash);
+std::optional<ByteView> read_rlp_encoded_header(ROTxn& txn, BlockNum bn, const evmc::bytes32& hash);
 
 //! \brief Reads the canonical head
-std::tuple<BlockNum, evmc::bytes32> read_canonical_head(mdbx::txn& txn);
+std::tuple<BlockNum, evmc::bytes32> read_canonical_head(ROTxn& txn);
 
 //! \brief Reads the canonical header from a block number
-std::optional<BlockHeader> read_canonical_header(mdbx::txn& txn, BlockNum b);
+std::optional<BlockHeader> read_canonical_header(ROTxn& txn, BlockNum b);
 
 //! \brief Writes given header to table::kHeaders
-void write_header(mdbx::txn& txn, const BlockHeader& header, bool with_header_numbers = false);
+void write_header(RWTxn& txn, const BlockHeader& header, bool with_header_numbers = false);
 
 //! \brief Read block number from hash
-std::optional<BlockNum> read_block_number(mdbx::txn& txn, const evmc::bytes32& hash);
+std::optional<BlockNum> read_block_number(ROTxn& txn, const evmc::bytes32& hash);
 
 //! \brief Writes header hash in table::kHeaderNumbers
-void write_header_number(mdbx::txn& txn, const uint8_t (&hash)[kHashLength], BlockNum number);
+void write_header_number(RWTxn& txn, const uint8_t (&hash)[kHashLength], BlockNum number);
 
 //! \brief Writes the header hash in table::kCanonicalHashes
-void write_canonical_header(mdbx::txn& txn, const BlockHeader& header);
+void write_canonical_header(RWTxn& txn, const BlockHeader& header);
 
 //! \brief Reads the header hash in table::kCanonicalHashes
-std::optional<evmc::bytes32> read_canonical_header_hash(mdbx::txn& txn, BlockNum number);
+std::optional<evmc::bytes32> read_canonical_header_hash(ROTxn& txn, BlockNum number);
 
 //! \brief Writes the header hash in table::kCanonicalHashes
-void write_canonical_header_hash(mdbx::txn& txn, const uint8_t (&hash)[kHashLength], BlockNum number);
+void write_canonical_header_hash(RWTxn& txn, const uint8_t (&hash)[kHashLength], BlockNum number);
 
 //! \brief Read a block body (in an out parameter) returning true on success and false on missing block
-[[nodiscard]] bool read_body(mdbx::txn& txn, const Bytes& key, bool read_senders, BlockBody& out);
-[[nodiscard]] bool read_body(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength],
+[[nodiscard]] bool read_body(ROTxn& txn, const Bytes& key, bool read_senders, BlockBody& out);
+[[nodiscard]] bool read_body(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength],
                              bool read_senders, BlockBody& out);
-[[nodiscard]] bool read_body(mdbx::txn& txn, const evmc::bytes32& hash, BlockNum bn, BlockBody& body);
-[[nodiscard]] bool read_body(mdbx::txn& txn, const evmc::bytes32& hash, BlockBody& body);
+[[nodiscard]] bool read_body(ROTxn& txn, const evmc::bytes32& hash, BlockNum bn, BlockBody& body);
+[[nodiscard]] bool read_body(ROTxn& txn, const evmc::bytes32& hash, BlockBody& body);
 
 //! \brief Read the canonical block at specified height
-[[nodiscard]] bool read_canonical_block(mdbx::txn& txn, BlockNum height, Block& block);
+[[nodiscard]] bool read_canonical_block(ROTxn& txn, BlockNum height, Block& block);
 
 //! \brief Apply a user defined func to the bodies at specific height
-size_t process_blocks_at_height(mdbx::txn& txn, BlockNum height, std::function<void(Block&)> process_func,
+size_t process_blocks_at_height(ROTxn& txn, BlockNum height, std::function<void(Block&)> process_func,
                                 bool read_senders = false);
 
 //! \brief Check the presence of a block body using block number and hash
-[[nodiscard]] bool has_body(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
-[[nodiscard]] bool has_body(mdbx::txn& txn, BlockNum block_number, const evmc::bytes32& hash);
+[[nodiscard]] bool has_body(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
+[[nodiscard]] bool has_body(ROTxn& txn, BlockNum block_number, const evmc::bytes32& hash);
 
 //! \brief Writes block body in table::kBlockBodies
-void write_body(mdbx::txn& txn, const BlockBody& body, const evmc::bytes32& hash, BlockNum bn);
-void write_body(mdbx::txn& txn, const BlockBody& body, const uint8_t (&hash)[kHashLength], BlockNum number);
+void write_body(RWTxn& txn, const BlockBody& body, const evmc::bytes32& hash, BlockNum bn);
+void write_body(RWTxn& txn, const BlockBody& body, const uint8_t (&hash)[kHashLength], BlockNum number);
 
 // See Erigon ReadTd
-std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, BlockNum, const evmc::bytes32& hash);
-std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, BlockNum, const uint8_t (&hash)[kHashLength]);
-std::optional<intx::uint256> read_total_difficulty(mdbx::txn& txn, ByteView key);
+std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, BlockNum, const evmc::bytes32& hash);
+std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, BlockNum, const uint8_t (&hash)[kHashLength]);
+std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, ByteView key);
 
 // See Erigon WriteTd
-void write_total_difficulty(mdbx::txn& txn, BlockNum, const evmc::bytes32& hash, const intx::uint256& total_difficulty);
-void write_total_difficulty(mdbx::txn& txn, BlockNum, const uint8_t (&hash)[kHashLength], const intx::uint256& td);
-void write_total_difficulty(mdbx::txn& txn, const Bytes& key, const intx::uint256& total_difficulty);
+void write_total_difficulty(RWTxn& txn, BlockNum, const evmc::bytes32& hash, const intx::uint256& total_difficulty);
+void write_total_difficulty(RWTxn& txn, BlockNum, const uint8_t (&hash)[kHashLength], const intx::uint256& td);
+void write_total_difficulty(RWTxn& txn, const Bytes& key, const intx::uint256& total_difficulty);
 
 // Reads canonical block; see Erigon ReadBlockByNumber.
 // Returns true on success and false on missing block.
-[[nodiscard]] bool read_block_by_number(mdbx::txn& txn, BlockNum number, bool read_senders, Block& out);
+[[nodiscard]] bool read_block_by_number(ROTxn& txn, BlockNum number, bool read_senders, Block& out);
 
 // Reads a block; see Erigon ReadBlock.
 // Returns true on success and false on missing block.
-[[nodiscard]] bool read_block(mdbx::txn& txn, std::span<const uint8_t, kHashLength> hash, BlockNum number,
+[[nodiscard]] bool read_block(ROTxn& txn, std::span<const uint8_t, kHashLength> hash, BlockNum number,
                               bool read_senders, Block& out);
-[[nodiscard]] bool read_block(mdbx::txn& txn, const evmc::bytes32& hash, BlockNum number, Block& block);
+[[nodiscard]] bool read_block(ROTxn& txn, const evmc::bytes32& hash, BlockNum number, Block& block);
 
 // See Erigon ReadSenders
-std::vector<evmc::address> read_senders(mdbx::txn& txn, const Bytes& key);
-std::vector<evmc::address> read_senders(mdbx::txn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
+std::vector<evmc::address> read_senders(ROTxn& txn, const Bytes& key);
+std::vector<evmc::address> read_senders(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
 //! \brief Fills transactions' senders addresses directly in place
-void parse_senders(mdbx::txn& txn, const Bytes& key, std::vector<Transaction>& out);
+void parse_senders(ROTxn& txn, const Bytes& key, std::vector<Transaction>& out);
 
 // See Erigon ReadTransactions
-void read_transactions(mdbx::txn& txn, uint64_t base_id, uint64_t count, std::vector<Transaction>& out);
+void read_transactions(ROTxn& txn, uint64_t base_id, uint64_t count, std::vector<Transaction>& out);
 void read_transactions(mdbx::cursor& txn_table, uint64_t base_id, uint64_t count, std::vector<Transaction>& out);
 
 //! \brief Persist transactions into db's bucket table::kBlockTransactions.
 //! The key starts from base_id and is incremented by 1 for each transaction.
 //! \remarks Before calling this ensure you got a proper base_id by incrementing sequence for table::kBlockTransactions.
-void write_transactions(mdbx::txn& txn, const std::vector<Transaction>& transactions, uint64_t base_id);
+void write_transactions(RWTxn& txn, const std::vector<Transaction>& transactions, uint64_t base_id);
 
-std::optional<ByteView> read_code(mdbx::txn& txn, const evmc::bytes32& code_hash);
+std::optional<ByteView> read_code(ROTxn& txn, const evmc::bytes32& code_hash);
 
 // Reads current or historical (if block_number is specified) account.
-std::optional<Account> read_account(mdbx::txn& txn, const evmc::address& address,
+std::optional<Account> read_account(ROTxn& txn, const evmc::address& address,
                                     std::optional<BlockNum> block_number = std::nullopt);
 
 // Reads current or historical (if block_number is specified) storage.
-evmc::bytes32 read_storage(mdbx::txn& txn, const evmc::address& address, uint64_t incarnation,
+evmc::bytes32 read_storage(ROTxn& txn, const evmc::address& address, uint64_t incarnation,
                            const evmc::bytes32& location, std::optional<BlockNum> block_number = std::nullopt);
 
 // Reads current or historical (if block_number is specified) previous incarnation.
-std::optional<uint64_t> read_previous_incarnation(mdbx::txn& txn, const evmc::address& address,
+std::optional<uint64_t> read_previous_incarnation(ROTxn& txn, const evmc::address& address,
                                                   std::optional<BlockNum> block_number = std::nullopt);
 
-AccountChanges read_account_changes(mdbx::txn& txn, BlockNum block_number);
+AccountChanges read_account_changes(ROTxn& txn, BlockNum block_number);
 
-StorageChanges read_storage_changes(mdbx::txn& txn, BlockNum block_number);
+StorageChanges read_storage_changes(ROTxn& txn, BlockNum block_number);
 
 //! \brief Retrieves the chain_id for which database is populated
 //! \see Erigon chainConfig / chainConfigWithGenesis
-std::optional<ChainConfig> read_chain_config(mdbx::txn& txn);
+std::optional<ChainConfig> read_chain_config(ROTxn& txn);
 
 //! \brief Writes / Updates chain config provided genesis has been initialized
-void update_chain_config(mdbx::txn& txn, const ChainConfig& config);
+void update_chain_config(RWTxn& txn, const ChainConfig& config);
 
 //! \brief Updates highest header hash in table::kHeadHeader
-void write_head_header_hash(mdbx::txn& txn, const uint8_t (&hash)[kHashLength]);
-void write_head_header_hash(mdbx::txn& txn, const evmc::bytes32& hash);
+void write_head_header_hash(RWTxn& txn, const uint8_t (&hash)[kHashLength]);
+void write_head_header_hash(RWTxn& txn, const evmc::bytes32& hash);
 
 //! \brief Reads highest header hash from table::kHeadHeader
-std::optional<evmc::bytes32> read_head_header_hash(mdbx::txn& txn);
+std::optional<evmc::bytes32> read_head_header_hash(ROTxn& txn);
 
 //! \brief Reads canonical hash from block number
-std::optional<evmc::bytes32> read_canonical_hash(mdbx::txn& txn, BlockNum b);
+std::optional<evmc::bytes32> read_canonical_hash(ROTxn& txn, BlockNum b);
 
 //! \brief Delete a canonical hash associated to a block number
-void delete_canonical_hash(mdbx::txn& txn, BlockNum b);
+void delete_canonical_hash(RWTxn& txn, BlockNum b);
 
 //! \brief Write canonical hash
-void write_canonical_hash(mdbx::txn& txn, BlockNum b, const evmc::bytes32& hash);
+void write_canonical_hash(RWTxn& txn, BlockNum b, const evmc::bytes32& hash);
 
 //! \brief Gets/Increments the sequence value for a given map (bucket)
 //! \param [in] map_name : the name of the map to get a sequence for
@@ -196,12 +196,12 @@ void write_canonical_hash(mdbx::txn& txn, BlockNum b, const evmc::bytes32& hash)
 //! \throws std::std::length_error on badly recorded value
 //! \remarks Initial sequence for any key (also unset) is 0. Changes to sequences are invisible until the transaction is
 //! committed
-uint64_t increment_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t increment = 1u);
+uint64_t increment_map_sequence(RWTxn& txn, const char* map_name, uint64_t increment = 1u);
 
 //! \brief Returns the current sequence for a map_name
 //! \remarks If the key is not present in Sequence bucket the return value is 0
 //! \throws std::std::length_error on badly recorded value
-uint64_t read_map_sequence(mdbx::txn& txn, const char* map_name);
+uint64_t read_map_sequence(ROTxn& txn, const char* map_name);
 
 //! \brief Reset the sequence value for a given map (bucket)
 //! \param [in] map_name : the name of the map to reset the sequence for
@@ -210,6 +210,6 @@ uint64_t read_map_sequence(mdbx::txn& txn, const char* map_name);
 //! \throws std::std::length_error on badly recorded value
 //! \remarks Initial sequence for any key (also unset) is 0. Changes to sequences are invisible until the transaction is
 //! committed
-uint64_t reset_map_sequence(mdbx::txn& txn, const char* map_name, uint64_t new_sequence);
+uint64_t reset_map_sequence(RWTxn& txn, const char* map_name, uint64_t new_sequence);
 
 }  // namespace silkworm::db

--- a/silkworm/node/db/buffer.hpp
+++ b/silkworm/node/db/buffer.hpp
@@ -29,6 +29,7 @@
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/receipt.hpp>
+#include <silkworm/node/db/mdbx.hpp>
 #include <silkworm/node/db/util.hpp>
 
 namespace silkworm::db {
@@ -36,7 +37,7 @@ namespace silkworm::db {
 class Buffer : public State {
   public:
     // txn must be valid (its handle != nullptr)
-    explicit Buffer(mdbx::txn& txn, BlockNum prune_history_threshold,
+    explicit Buffer(ROTxn& txn, BlockNum prune_history_threshold,
                     std::optional<BlockNum> historical_block = std::nullopt)
         : txn_{txn}, prune_history_threshold_{prune_history_threshold}, historical_block_{historical_block} {
         assert(txn_);
@@ -130,7 +131,7 @@ class Buffer : public State {
     //! \brief Persists *state* accrued contents into db
     void write_state_to_db();
 
-    mdbx::txn& txn_;
+    ROTxn& txn_;
     uint64_t prune_history_threshold_;
     std::optional<uint64_t> historical_block_{};
 

--- a/silkworm/node/db/buffer.hpp
+++ b/silkworm/node/db/buffer.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <cassert>
 #include <optional>
 #include <vector>
 
@@ -39,9 +38,7 @@ class Buffer : public State {
     // txn must be valid (its handle != nullptr)
     explicit Buffer(ROTxn& txn, BlockNum prune_history_threshold,
                     std::optional<BlockNum> historical_block = std::nullopt)
-        : txn_{txn}, prune_history_threshold_{prune_history_threshold}, historical_block_{historical_block} {
-        assert(txn_);
-    }
+        : txn_{txn}, prune_history_threshold_{prune_history_threshold}, historical_block_{historical_block} {}
 
     /** @name Readers */
     ///@{

--- a/silkworm/node/db/buffer_test.cpp
+++ b/silkworm/node/db/buffer_test.cpp
@@ -28,7 +28,7 @@ namespace silkworm::db {
 TEST_CASE("Storage update") {
     test::SetLogVerbosityGuard log_guard{log::Level::kNone};
     test::Context context;
-    auto& txn{context.txn()};
+    auto& txn{context.rw_txn()};
 
     const auto address{0xbe00000000000000000000000000000000000000_address};
     const Bytes key{storage_prefix(address, kDefaultIncarnation)};
@@ -72,7 +72,7 @@ TEST_CASE("Storage update") {
 TEST_CASE("Account update") {
     test::SetLogVerbosityGuard log_guard{log::Level::kNone};
     test::Context context;
-    auto& txn{context.txn()};
+    auto& txn{context.rw_txn()};
 
     SECTION("New EOA account") {
         const auto address{0xbe00000000000000000000000000000000000000_address};
@@ -86,7 +86,7 @@ TEST_CASE("Account update") {
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         auto account_changeset{db::open_cursor(txn, table::kAccountChangeSet)};
-        REQUIRE(txn.get_map_stat(account_changeset.map()).ms_entries == 1);
+        REQUIRE(txn->get_map_stat(account_changeset.map()).ms_entries == 1);
         auto data{account_changeset.to_first()};
         auto data_key_view{db::from_slice(data.key)};
         auto data_value_view{db::from_slice(data.value)};
@@ -117,7 +117,7 @@ TEST_CASE("Account update") {
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         auto account_changeset{db::open_cursor(txn, table::kAccountChangeSet)};
-        REQUIRE(txn.get_map_stat(account_changeset.map()).ms_entries == 1);
+        REQUIRE(txn->get_map_stat(account_changeset.map()).ms_entries == 1);
         auto data{account_changeset.to_first()};
         auto data_key_view{db::from_slice(data.key)};
         auto data_value_view{db::from_slice(data.value)};

--- a/silkworm/node/db/genesis.cpp
+++ b/silkworm/node/db/genesis.cpp
@@ -107,8 +107,9 @@ std::pair<bool, std::vector<std::string>> validate_genesis_json(const nlohmann::
     ret.first = ret.second.empty();
     return ret;
 }
-bool initialize_genesis(mdbx::txn& txn, const nlohmann::json& genesis_json, bool allow_exceptions) {
-    if (!txn.is_readwrite()) {
+
+bool initialize_genesis(RWTxn& txn, const nlohmann::json& genesis_json, bool allow_exceptions) {
+    if (!txn->is_readwrite()) {
         if (!allow_exceptions) {
             return false;
         }

--- a/silkworm/node/db/genesis.hpp
+++ b/silkworm/node/db/genesis.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/node/db/access_layer.hpp>
+#include <silkworm/node/db/mdbx.hpp>
 
 namespace silkworm::db {
 //! \brief Validates provided genesis json payload
@@ -29,6 +30,6 @@ std::pair<bool, std::vector<std::string>> validate_genesis_json(const nlohmann::
 //! \param [in] genesis_json : the payload to write
 //! \param [in] allow_exceptions : whether to throw exceptions on failure(s)
 //! \returns True/False
-bool initialize_genesis(mdbx::txn& txn, const nlohmann::json& genesis_json, bool allow_exceptions);
+bool initialize_genesis(RWTxn& txn, const nlohmann::json& genesis_json, bool allow_exceptions);
 
 }  // namespace silkworm::db

--- a/silkworm/node/db/genesis_test.cpp
+++ b/silkworm/node/db/genesis_test.cpp
@@ -28,7 +28,7 @@ namespace db {
 
     TEST_CASE("Database genesis initialization") {
         test::Context context;
-        auto& txn{context.txn()};
+        auto& txn{context.rw_txn()};
 
         SECTION("Initialize with Mainnet") {
             auto source_data{silkworm::read_genesis_data(silkworm::kMainnetConfig.chain_id)};

--- a/silkworm/node/db/stages.cpp
+++ b/silkworm/node/db/stages.cpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::db::stages {
 
-static BlockNum get_stage_data(mdbx::txn& txn, const char* stage_name, const db::MapConfig& domain,
+static BlockNum get_stage_data(ROTxn& txn, const char* stage_name, const db::MapConfig& domain,
                                const char* key_prefix = nullptr) {
     if (!is_known_stage(stage_name)) {
         throw std::invalid_argument("Unknown stage name " + std::string(stage_name));
@@ -47,7 +47,7 @@ static BlockNum get_stage_data(mdbx::txn& txn, const char* stage_name, const db:
     }
 }
 
-static void set_stage_data(mdbx::txn& txn, const char* stage_name, uint64_t block_num, const db::MapConfig& domain,
+static void set_stage_data(RWTxn& txn, const char* stage_name, uint64_t block_num, const db::MapConfig& domain,
                            const char* key_prefix = nullptr) {
     if (!is_known_stage(stage_name)) {
         throw std::invalid_argument("Unknown stage name");
@@ -70,27 +70,27 @@ static void set_stage_data(mdbx::txn& txn, const char* stage_name, uint64_t bloc
     }
 }
 
-BlockNum read_stage_progress(mdbx::txn& txn, const char* stage_name) {
+BlockNum read_stage_progress(ROTxn& txn, const char* stage_name) {
     return get_stage_data(txn, stage_name, silkworm::db::table::kSyncStageProgress);
 }
 
-BlockNum read_stage_prune_progress(mdbx::txn& txn, const char* stage_name) {
+BlockNum read_stage_prune_progress(ROTxn& txn, const char* stage_name) {
     return get_stage_data(txn, stage_name, silkworm::db::table::kSyncStageProgress, "prune_");
 }
 
-void write_stage_progress(mdbx::txn& txn, const char* stage_name, BlockNum block_num) {
+void write_stage_progress(RWTxn& txn, const char* stage_name, BlockNum block_num) {
     set_stage_data(txn, stage_name, block_num, silkworm::db::table::kSyncStageProgress);
 }
 
-void write_stage_prune_progress(mdbx::txn& txn, const char* stage_name, BlockNum block_num) {
+void write_stage_prune_progress(RWTxn& txn, const char* stage_name, BlockNum block_num) {
     set_stage_data(txn, stage_name, block_num, silkworm::db::table::kSyncStageProgress, "prune_");
 }
 
-BlockNum read_stage_unwind(mdbx::txn& txn, const char* stage_name) {
+BlockNum read_stage_unwind(ROTxn& txn, const char* stage_name) {
     return get_stage_data(txn, stage_name, silkworm::db::table::kSyncStageUnwind);
 }
 
-void write_stage_unwind(mdbx::txn& txn, const char* stage_name, BlockNum block_num) {
+void write_stage_unwind(RWTxn& txn, const char* stage_name, BlockNum block_num) {
     set_stage_data(txn, stage_name, block_num, silkworm::db::table::kSyncStageUnwind);
 }
 

--- a/silkworm/node/db/stages.hpp
+++ b/silkworm/node/db/stages.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <silkworm/node/db/mdbx.hpp>
 #include <silkworm/node/db/tables.hpp>
 
 /*
@@ -111,27 +112,27 @@ inline constexpr size_t kLargeBlockSegmentWorthRegen{100'000};
 //! \param [in] txn : a reference to a ro/rw db transaction
 //! \param [in] stage_name : the name of the requested stage (must be known see kAllStages[])
 //! \return The actual chain height (BlockNum) the stage has reached
-BlockNum read_stage_progress(mdbx::txn& txn, const char* stage_name);
+BlockNum read_stage_progress(ROTxn& txn, const char* stage_name);
 
 //! \brief Reads from db the prune progress (block height) of the provided stage name
 //! \param [in] txn : a reference to a ro/rw db transaction
 //! \param [in] stage_name : the name of the requested stage (must be known see kAllStages[])
 //! \return The actual chain height (BlockNum) the stage has pruned its data up to
 //! \remarks A pruned height X means the prune stage function has run up to this block
-BlockNum read_stage_prune_progress(mdbx::txn& txn, const char* stage_name);
+BlockNum read_stage_prune_progress(ROTxn& txn, const char* stage_name);
 
 //! \brief Writes into db the progress (block height) for the provided stage name
 //! \param [in] txn : a reference to a rw db transaction
 //! \param [in] stage_name : the name of the involved stage (must be known see kAllStages[])
 //! \param [in] block_num : the actual chain height (BlockNum) the stage must record
-void write_stage_progress(mdbx::txn& txn, const char* stage_name, BlockNum block_num);
+void write_stage_progress(RWTxn& txn, const char* stage_name, BlockNum block_num);
 
 //! \brief Writes into db the prune progress (block height) for the provided stage name
 //! \param [in] txn : a reference to a rw db transaction
 //! \param [in] stage_name : the name of the involved stage (must be known see kAllStages[])
 //! \param [in] block_num : the actual chain height (BlockNum) the stage must record
 //! \remarks A pruned height X means the prune stage function has run up to this block
-void write_stage_prune_progress(mdbx::txn& txn, const char* stage_name, BlockNum block_num);
+void write_stage_prune_progress(RWTxn& txn, const char* stage_name, BlockNum block_num);
 
 //! \brief Reads from db the invalidation point (block height) of provided stage name. Invalidation point means that
 //! that stage needs to roll back to the invalidation point and re-execute its work for subsequent blocks (if any)
@@ -140,14 +141,14 @@ void write_stage_prune_progress(mdbx::txn& txn, const char* stage_name, BlockNum
 //! \return The invalidation point
 //! \remarks An invalidation point == 0 means there is no invalidation point. BlockNum 0 is the genesis and you can't
 //! unwind it
-BlockNum read_stage_unwind(mdbx::txn& txn, const char* stage_name);
+BlockNum read_stage_unwind(ROTxn& txn, const char* stage_name);
 
 //! \brief Writes into db the invalidation point (block height) for the provided stage name
 //! \param [in] txn : a reference to a rw db transaction
 //! \param [in] stage_name : the name of the involved stage (must be known see kAllStages[])
 //! \param [in] block_num : the actual chain invalidation point (BlockNum) the stage must record. If omitted the value
 //! defaults to 0 which means to clear any previously recorded invalidation point.
-void write_stage_unwind(mdbx::txn& txn, const char* stage_name, BlockNum block_num = 0);
+void write_stage_unwind(RWTxn& txn, const char* stage_name, BlockNum block_num = 0);
 
 //! \brief Whether the provided stage name is known to Silkworm
 //! \param [in] stage_name : The name of the stage to check for

--- a/silkworm/node/db/tables.cpp
+++ b/silkworm/node/db/tables.cpp
@@ -22,11 +22,11 @@
 
 namespace silkworm::db::table {
 
-void check_or_create_chaindata_tables(mdbx::txn& txn) {
+void check_or_create_chaindata_tables(RWTxn& txn) {
     for (const auto& config : kChainDataTables) {
         if (db::has_map(txn, config.name)) {
-            auto table_map{txn.open_map(config.name)};
-            auto table_info{txn.get_handle_info(table_map)};
+            auto table_map{txn->open_map(config.name)};
+            auto table_info{txn->get_handle_info(table_map)};
             auto table_key_mode{table_info.key_mode()};
             auto table_value_mode{table_info.value_mode()};
             if (table_key_mode != config.key_mode || table_value_mode != config.value_mode) {
@@ -36,7 +36,7 @@ void check_or_create_chaindata_tables(mdbx::txn& txn) {
             continue;
         }
         // Create missing table
-        (void)txn.create_map(config.name, config.key_mode, config.value_mode);  // Will throw if tx is RO
+        (void)txn->create_map(config.name, config.key_mode, config.value_mode);  // Will throw if tx is RO
     }
 
     auto db_schema_version{db::read_schema_version(txn)};

--- a/silkworm/node/db/tables.hpp
+++ b/silkworm/node/db/tables.hpp
@@ -349,6 +349,6 @@ inline constexpr db::MapConfig kChainDataTables[]{
 };
 
 //! \brief Ensures all defined tables are present in db with consistent flags. Should a table not exist it gets created
-void check_or_create_chaindata_tables(mdbx::txn& txn);
+void check_or_create_chaindata_tables(RWTxn& txn);
 
 }  // namespace silkworm::db::table

--- a/silkworm/node/stagedsync/stage.cpp
+++ b/silkworm/node/stagedsync/stage.cpp
@@ -23,12 +23,12 @@ namespace silkworm::stagedsync {
 Stage::Stage(SyncContext* sync_context, const char* stage_name, NodeSettings* node_settings)
     : sync_context_{sync_context}, stage_name_{stage_name}, node_settings_{node_settings} {}
 
-BlockNum Stage::get_progress(db::RWTxn& txn) { return db::stages::read_stage_progress(*txn, stage_name_); }
+BlockNum Stage::get_progress(db::ROTxn& txn) { return db::stages::read_stage_progress(txn, stage_name_); }
 
-BlockNum Stage::get_prune_progress(db::RWTxn& txn) { return db::stages::read_stage_prune_progress(*txn, stage_name_); }
+BlockNum Stage::get_prune_progress(db::ROTxn& txn) { return db::stages::read_stage_prune_progress(txn, stage_name_); }
 
 void Stage::update_progress(db::RWTxn& txn, BlockNum progress) {
-    db::stages::write_stage_progress(*txn, stage_name_, progress);
+    db::stages::write_stage_progress(txn, stage_name_, progress);
 }
 
 void Stage::check_block_sequence(BlockNum actual, BlockNum expected) {

--- a/silkworm/node/stagedsync/stage.hpp
+++ b/silkworm/node/stagedsync/stage.hpp
@@ -104,10 +104,10 @@ class Stage : public Stoppable {
     [[nodiscard]] virtual Stage::Result prune(db::RWTxn& txn) = 0;
 
     //! \brief Returns the actual progress recorded into db
-    BlockNum get_progress(db::RWTxn& txn);
+    BlockNum get_progress(db::ROTxn& txn);
 
     //! \brief Returns the actual prune progress recorded into db
-    BlockNum get_prune_progress(db::RWTxn& txn);
+    BlockNum get_prune_progress(db::ROTxn& txn);
 
     //! \brief Updates current stage progress
     void update_progress(db::RWTxn& txn, BlockNum progress);

--- a/silkworm/node/stagedsync/stage_blockhashes.cpp
+++ b/silkworm/node/stagedsync/stage_blockhashes.cpp
@@ -34,7 +34,7 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         const auto previous_progress{get_progress(txn)};
-        const auto headers_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kHeadersKey)};
+        const auto headers_stage_progress{db::stages::read_stage_progress(txn, db::stages::kHeadersKey)};
         if (previous_progress == headers_stage_progress) {
             // Nothing to process
             operation_ = OperationType::None;

--- a/silkworm/node/stagedsync/stage_finish.cpp
+++ b/silkworm/node/stagedsync/stage_finish.cpp
@@ -30,7 +30,7 @@ Stage::Result Finish::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         const auto previous_progress{get_progress(txn)};
-        auto execution_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
+        auto execution_stage_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress >= execution_stage_progress) {
             // Nothing to process
             const auto stop_at_block = Environment::get_stop_at_block();  // User can specify to stop at some block
@@ -50,7 +50,7 @@ Stage::Result Finish::forward(db::RWTxn& txn) {
         // Log the new version of app at this height
         if (sync_context_->is_first_cycle) {
             Bytes build_info{byte_ptr_cast(node_settings_->build_info.data())};
-            db::write_build_info_height(*txn, build_info, execution_stage_progress);
+            db::write_build_info_height(txn, build_info, execution_stage_progress);
         }
         txn.commit();
 
@@ -82,7 +82,7 @@ Stage::Result Finish::unwind(db::RWTxn& txn) {
     operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();
-        auto previous_progress{db::stages::read_stage_progress(*txn, stage_name_)};
+        auto previous_progress{db::stages::read_stage_progress(txn, stage_name_)};
         if (to >= previous_progress) return ret;
         throw_if_stopping();
         update_progress(txn, to);

--- a/silkworm/node/stagedsync/stage_hashstate.cpp
+++ b/silkworm/node/stagedsync/stage_hashstate.cpp
@@ -32,7 +32,7 @@ Stage::Result HashState::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         const auto previous_progress{get_progress(txn)};
-        auto execution_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
+        auto execution_stage_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress == execution_stage_progress) {
             // Nothing to process
             return ret;
@@ -83,7 +83,7 @@ Stage::Result HashState::forward(db::RWTxn& txn) {
         }
 
         throw_if_stopping();
-        db::stages::write_stage_progress(*txn, db::stages::kHashStateKey, execution_stage_progress);
+        db::stages::write_stage_progress(txn, db::stages::kHashStateKey, execution_stage_progress);
         txn.commit();
 
     } catch (const StageError& ex) {
@@ -118,7 +118,7 @@ Stage::Result HashState::unwind(db::RWTxn& txn) {
     operation_ = OperationType::Unwind;
     try {
         throw_if_stopping();
-        auto previous_progress{db::stages::read_stage_progress(*txn, stage_name_)};
+        auto previous_progress{db::stages::read_stage_progress(txn, stage_name_)};
         if (to >= previous_progress) {
             // Nothing to unwind actually
             return ret;

--- a/silkworm/node/stagedsync/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stage_interhashes.cpp
@@ -39,7 +39,7 @@ Stage::Result InterHashes::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         auto previous_progress{get_progress(txn)};
-        auto hashstate_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kHashStateKey)};
+        auto hashstate_stage_progress{db::stages::read_stage_progress(txn, db::stages::kHashStateKey)};
         if (previous_progress == hashstate_stage_progress) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -63,12 +63,12 @@ Stage::Result InterHashes::forward(db::RWTxn& txn) {
         }
 
         // Retrieve header's state_root at target block to be compared with the one computed here
-        auto header_hash{db::read_canonical_header_hash(*txn, hashstate_stage_progress)};
+        auto header_hash{db::read_canonical_header_hash(txn, hashstate_stage_progress)};
         if (!header_hash.has_value()) {
             throw std::runtime_error("Could not find hash for canonical header " +
                                      std::to_string(hashstate_stage_progress));
         }
-        auto header{db::read_header(*txn, hashstate_stage_progress, header_hash->bytes)};
+        auto header{db::read_header(txn, hashstate_stage_progress, header_hash->bytes)};
         if (!header_hash.has_value()) {
             throw std::runtime_error("Could not find canonical header number " +
                                      std::to_string(hashstate_stage_progress) +
@@ -93,7 +93,7 @@ Stage::Result InterHashes::forward(db::RWTxn& txn) {
 
         success_or_throw(ret);
         throw_if_stopping();
-        db::stages::write_stage_progress(*txn, db::stages::kIntermediateHashesKey, hashstate_stage_progress);
+        db::stages::write_stage_progress(txn, db::stages::kIntermediateHashesKey, hashstate_stage_progress);
         txn.commit();
 
     } catch (const StageError& ex) {
@@ -146,12 +146,12 @@ Stage::Result InterHashes::unwind(db::RWTxn& txn) {
 
         // Retrieve header's state_root at target block to be compared with the one computed here
         // Retrieve header's state_root at target block to be compared with the one computed here
-        auto header_hash{db::read_canonical_header_hash(*txn, to)};
+        auto header_hash{db::read_canonical_header_hash(txn, to)};
         if (!header_hash.has_value()) {
             throw std::runtime_error("Could not find hash for canonical header " +
                                      std::to_string(to));
         }
-        auto header{db::read_header(*txn, to, header_hash->bytes)};
+        auto header{db::read_header(txn, to, header_hash->bytes)};
         if (!header_hash.has_value()) {
             throw std::runtime_error("Could not find canonical header number " +
                                      std::to_string(to) +
@@ -171,7 +171,7 @@ Stage::Result InterHashes::unwind(db::RWTxn& txn) {
 
         success_or_throw(ret);
         throw_if_stopping();
-        db::stages::write_stage_progress(*txn, db::stages::kIntermediateHashesKey, to);
+        db::stages::write_stage_progress(txn, db::stages::kIntermediateHashesKey, to);
         txn.commit();
 
     } catch (const StageError& ex) {

--- a/silkworm/node/stagedsync/stage_log_index.cpp
+++ b/silkworm/node/stagedsync/stage_log_index.cpp
@@ -26,7 +26,7 @@ Stage::Result LogIndex::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         auto previous_progress{get_progress(txn)};
-        const auto target_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
+        const auto target_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress == target_progress) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -98,7 +98,7 @@ Stage::Result LogIndex::unwind(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         const auto previous_progress{get_progress(txn)};
-        const auto execution_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
+        const auto execution_stage_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress <= to || execution_stage_progress <= to) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -188,7 +188,7 @@ Stage::Result LogIndex::prune(db::RWTxn& txn) {
         }
 
         reset_log_progress();
-        db::stages::write_stage_prune_progress(*txn, stage_name_, forward_progress);
+        db::stages::write_stage_prune_progress(txn, stage_name_, forward_progress);
         txn.commit();
 
     } catch (const StageError& ex) {

--- a/silkworm/node/stagedsync/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stage_senders.cpp
@@ -76,7 +76,7 @@ Stage::Result Senders::unwind(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         const auto previous_progress{get_progress(txn)};
-        const auto bodies_stage_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockBodiesKey)};
+        const auto bodies_stage_progress{db::stages::read_stage_progress(txn, db::stages::kBlockBodiesKey)};
         if (previous_progress <= to || bodies_stage_progress <= to) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -238,9 +238,9 @@ Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
     try {
         // Check stage boundaries using previous execution of current stage and current execution of previous stage
-        auto previous_progress{db::stages::read_stage_progress(*txn, db::stages::kSendersKey)};
-        auto block_hashes_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockHashesKey)};
-        auto block_bodies_progress{db::stages::read_stage_progress(*txn, db::stages::kBlockBodiesKey)};
+        auto previous_progress{db::stages::read_stage_progress(txn, db::stages::kSendersKey)};
+        auto block_hashes_progress{db::stages::read_stage_progress(txn, db::stages::kBlockHashesKey)};
+        auto block_bodies_progress{db::stages::read_stage_progress(txn, db::stages::kBlockBodiesKey)};
         auto target_progress{std::min(block_hashes_progress, block_bodies_progress)};
 
         if (previous_progress == target_progress) {
@@ -350,7 +350,7 @@ Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
         store_senders(txn);
 
         // Update stage progress with last reached block number
-        db::stages::write_stage_progress(*txn, db::stages::kSendersKey, reached_block_num);
+        db::stages::write_stage_progress(txn, db::stages::kSendersKey, reached_block_num);
     } catch (const StageError& ex) {
         log::Error(log_prefix_,
                    {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});

--- a/silkworm/node/stagedsync/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stage_tx_lookup.cpp
@@ -31,7 +31,7 @@ Stage::Result TxLookup::forward(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         auto previous_progress{get_progress(txn)};
-        const auto target_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
+        const auto target_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress == target_progress) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -100,7 +100,7 @@ Stage::Result TxLookup::unwind(db::RWTxn& txn) {
 
         // Check stage boundaries from previous execution and previous stage execution
         const auto previous_progress{get_progress(txn)};
-        const auto execution_progress{db::stages::read_stage_progress(*txn, db::stages::kExecutionKey)};
+        const auto execution_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress <= to || execution_progress <= to) {
             // Nothing to process
             operation_ = OperationType::None;
@@ -190,7 +190,7 @@ Stage::Result TxLookup::prune(db::RWTxn& txn) {
         }
 
         reset_log_progress();
-        db::stages::write_stage_prune_progress(*txn, stage_name_, forward_progress);
+        db::stages::write_stage_prune_progress(txn, stage_name_, forward_progress);
         txn.commit();
 
     } catch (const StageError& ex) {

--- a/silkworm/node/stagedsync/stage_tx_lookup_test.cpp
+++ b/silkworm/node/stagedsync/stage_tx_lookup_test.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Stage Transaction Lookups") {
 
     transactions_table.upsert(db::to_slice(db::block_key(1)), db::to_slice(tx_rlp));
     bodies_table.upsert(db::to_slice(db::block_key(1, hash_0.bytes)), db::to_slice(block.encode()));
-    REQUIRE_NOTHROW(db::write_canonical_header_hash(*txn, hash_0.bytes, 1));
+    REQUIRE_NOTHROW(db::write_canonical_header_hash(txn, hash_0.bytes, 1));
 
     // ---------------------------------------
     // Push second block
@@ -66,11 +66,11 @@ TEST_CASE("Stage Transaction Lookups") {
 
     transactions_table.upsert(db::to_slice(db::block_key(2)), db::to_slice(tx_rlp));
     bodies_table.upsert(db::to_slice(db::block_key(2, hash_1.bytes)), db::to_slice(block.encode()));
-    REQUIRE_NOTHROW(db::write_canonical_header_hash(*txn, hash_1.bytes, 2));
+    REQUIRE_NOTHROW(db::write_canonical_header_hash(txn, hash_1.bytes, 2));
 
-    db::stages::write_stage_progress(*txn, db::stages::kBlockBodiesKey, 2);
-    db::stages::write_stage_progress(*txn, db::stages::kBlockHashesKey, 2);
-    db::stages::write_stage_progress(*txn, db::stages::kExecutionKey, 2);
+    db::stages::write_stage_progress(txn, db::stages::kBlockBodiesKey, 2);
+    db::stages::write_stage_progress(txn, db::stages::kBlockHashesKey, 2);
+    db::stages::write_stage_progress(txn, db::stages::kExecutionKey, 2);
 
     // Execute stage forward
     stagedsync::SyncContext sync_context{};


### PR DESCRIPTION
This PR changes the database access layer to use Silkworm abstractions for transactions (i.e. `ROTxn` and `RWTxn`) instead of MDBX ones.

Such change is the first in a series needed to introduce database memory mutations (aka overlays), which require pluggable custom transaction and cursor implementations.