### PR TITLE
build: fix CMake variable for build as submodule

### DIFF
--- a/silkworm/core/CMakeLists.txt
+++ b/silkworm/core/CMakeLists.txt
@@ -27,7 +27,7 @@ file(GLOB_RECURSE SILKWORM_CORE_SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp" "*.c" "*.h
 list(FILTER SILKWORM_CORE_SRC EXCLUDE REGEX "_test\\.cpp$")
 
 add_library(silkworm_core ${SILKWORM_CORE_SRC})
-target_include_directories(silkworm_core PUBLIC ${CMAKE_SOURCE_DIR})
+target_include_directories(silkworm_core PUBLIC ${SILKWORM_MAIN_DIR})
 target_include_directories(silkworm_core SYSTEM PUBLIC ${SILKWORM_MAIN_DIR}/third_party/expected/include)
 
 set(SILKWORM_CORE_PUBLIC_LIBS ethash::ethash evmc evmone intx::intx Microsoft.GSL::GSL nlohmann_json silkpre)

--- a/silkworm/node/CMakeLists.txt
+++ b/silkworm/node/CMakeLists.txt
@@ -91,7 +91,7 @@ if(SILKWORM_SANITIZE)
 endif()
 
 target_include_directories(silkworm_node PUBLIC
-        ${CMAKE_SOURCE_DIR}
+        ${SILKWORM_MAIN_DIR}
         ${SILKWORM_MAIN_SRC_DIR}/interfaces
         ${SILKWORM_MAIN_DIR}/third_party/magic_enum/include
         ${SILKWORM_MAIN_DIR}/third_party/libtorrent/include

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -55,7 +55,7 @@ if(SILKWORM_SANITIZE)
 endif()
 
 target_include_directories(${TARGET} PUBLIC
-  ${CMAKE_SOURCE_DIR}
+  ${SILKWORM_MAIN_DIR}
   "${SILKWORM_MAIN_SRC_DIR}/interfaces"
   "${SILKWORM_MAIN_DIR}/third_party/stbrumme-keccak"
   "${SILKWORM_MAIN_DIR}/third_party/stbrumme-crc32"

--- a/silkworm/sync/CMakeLists.txt
+++ b/silkworm/sync/CMakeLists.txt
@@ -45,7 +45,7 @@ if(SILKWORM_SANITIZE)
 endif()
 
 target_include_directories(silkworm_sync PUBLIC
-        ${CMAKE_SOURCE_DIR}
+        ${SILKWORM_MAIN_DIR}
         ${SILKWORM_MAIN_SRC_DIR}/interfaces
         ${SILKWORM_MAIN_DIR}/third_party/magic_enum/include)
 


### PR DESCRIPTION
This PR fixes build when Silkworm is used as submodule (e.g. in Silkrpc)