### PR TITLE
node: refactor database cursor creations to use factory methods

### DIFF
--- a/silkworm/node/backend/rpc/kv_calls.hpp
+++ b/silkworm/node/backend/rpc/kv_calls.hpp
@@ -18,6 +18,7 @@
 
 #include <exception>
 #include <map>
+#include <memory>
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -80,7 +81,7 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
 
   private:
     struct TxCursor {
-        db::PooledCursor cursor;
+        std::unique_ptr<db::ROCursorDupSort> cursor;
         std::string bucket_name;
     };
 
@@ -97,7 +98,7 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
 
     void handle_cursor_close(const remote::Cursor* request);
 
-    void handle_operation(const remote::Cursor* request, db::PooledCursor& cursor, remote::Pair& response);
+    void handle_operation(const remote::Cursor* request, db::ROCursorDupSort& cursor, remote::Pair& response);
 
     void handle_max_ttl_timer_expired();
 
@@ -105,35 +106,35 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
 
     bool restore_cursors(std::vector<CursorPosition>& positions);
 
-    void handle_first(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_first(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_first_dup(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_first_dup(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_seek(const remote::Cursor* request, db::PooledCursor& cursor, remote::Pair& response);
+    void handle_seek(const remote::Cursor* request, db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_seek_both(const remote::Cursor* request, db::PooledCursor& cursor, remote::Pair& response);
+    void handle_seek_both(const remote::Cursor* request, db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_seek_exact(const remote::Cursor* request, db::PooledCursor& cursor, remote::Pair& response);
+    void handle_seek_exact(const remote::Cursor* request, db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_seek_both_exact(const remote::Cursor* request, db::PooledCursor& cursor, remote::Pair& response);
+    void handle_seek_both_exact(const remote::Cursor* request, db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_current(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_current(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_last(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_last(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_last_dup(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_last_dup(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_next(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_next(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_next_dup(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_next_dup(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_next_no_dup(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_next_no_dup(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_prev(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_prev(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_prev_dup(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_prev_dup(db::ROCursorDupSort& cursor, remote::Pair& response);
 
-    void handle_prev_no_dup(db::PooledCursor& cursor, remote::Pair& response);
+    void handle_prev_no_dup(db::ROCursorDupSort& cursor, remote::Pair& response);
 
     void throw_with_internal_error(const remote::Cursor* request, const std::exception& exc);
 
@@ -144,7 +145,7 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
     static mdbx::env* chaindata_env_;
     static std::chrono::milliseconds max_ttl_duration_;
 
-    mdbx::txn_managed read_only_txn_;
+    db::ROTxn read_only_txn_;
     std::map<uint32_t, TxCursor> cursors_;
     uint32_t last_cursor_id_{0};
 };

--- a/silkworm/node/db/buffer_test.cpp
+++ b/silkworm/node/db/buffer_test.cpp
@@ -40,10 +40,10 @@ TEST_CASE("Storage update") {
     const auto location_b{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
     const auto value_b{0x0000000000000000000000000000000000000000000000000000000000000132_bytes32};
 
-    db::PooledCursor state{txn, table::kPlainState};
+    auto state = txn.rw_cursor_dup_sort(table::kPlainState);
 
-    upsert_storage_value(state, key, location_a, value_a1);
-    upsert_storage_value(state, key, location_b, value_b);
+    upsert_storage_value(*state, key, location_a, value_a1);
+    upsert_storage_value(*state, key, location_b, value_b);
 
     Buffer buffer{txn, 0};
 
@@ -59,12 +59,12 @@ TEST_CASE("Storage update") {
     buffer.write_to_db();
 
     // Location A should have the new value
-    const std::optional<ByteView> db_value_a{find_value_suffix(state, key, location_a)};
+    const std::optional<ByteView> db_value_a{find_value_suffix(*state, key, location_a)};
     REQUIRE(db_value_a.has_value());
     CHECK(db_value_a == zeroless_view(value_a2));
 
     // Location B should not change
-    const std::optional<ByteView> db_value_b{find_value_suffix(state, key, location_b)};
+    const std::optional<ByteView> db_value_b{find_value_suffix(*state, key, location_b)};
     REQUIRE(db_value_b.has_value());
     CHECK(db_value_b == zeroless_view(value_b));
 }

--- a/silkworm/node/db/mdbx.cpp
+++ b/silkworm/node/db/mdbx.cpp
@@ -267,7 +267,7 @@ PooledCursor::~PooledCursor() {
     }
 }
 
-void PooledCursor::bind(RWTxn& txn, ::mdbx::map_handle map) {
+void PooledCursor::bind(ROTxn& txn, ::mdbx::map_handle map) {
     if (!handle_) throw std::runtime_error("cannot bind a closed cursor");
     // Check cursor is bound to a live transaction
     if (auto cm_tx{mdbx_cursor_txn(handle_)}; cm_tx) {

--- a/silkworm/node/db/memory_mutation.cpp
+++ b/silkworm/node/db/memory_mutation.cpp
@@ -43,7 +43,7 @@ MemoryOverlay::MemoryOverlay(MemoryOverlay&& other) noexcept : memory_env_(std::
     return memory_env_.start_write();
 }
 
-MemoryMutation::MemoryMutation(MemoryOverlay& memory_db, RWTxn* txn)
+MemoryMutation::MemoryMutation(MemoryOverlay& memory_db, ROTxn* txn)
     : RWTxn{::mdbx::txn_managed{}}, memory_db_(memory_db), txn_(txn) {
     managed_txn_ = memory_db_.start_rw_tx();
 
@@ -70,7 +70,7 @@ bool MemoryMutation::is_entry_deleted(const std::string& bucket_name, const Byte
     return deleted_entries_.at(bucket_name) == key;
 }
 
-void MemoryMutation::update_txn(RWTxn* txn) {
+void MemoryMutation::update_txn(ROTxn* txn) {
     txn_ = txn;
     stateless_cursors_.clear();
 }

--- a/silkworm/node/db/memory_mutation.cpp
+++ b/silkworm/node/db/memory_mutation.cpp
@@ -92,8 +92,10 @@ std::unique_ptr<RWCursorDupSort> MemoryMutation::rw_cursor_dup_sort(const MapCon
 }
 
 void MemoryMutation::rollback() {
-    managed_txn_.abort();
-    // memory_db_.close(); // TODO(canepat) add only if rollback is really needed
+    // Idempotent rollback: abort iff transaction is still alive (i.e. handle is not null)
+    if (managed_txn_) {
+        managed_txn_.abort();
+    }
     stateless_cursors_.clear();
 }
 

--- a/silkworm/node/db/memory_mutation.hpp
+++ b/silkworm/node/db/memory_mutation.hpp
@@ -41,15 +41,15 @@ class MemoryMutationCursor;
 
 class MemoryMutation : public RWTxn {
   public:
-    MemoryMutation(MemoryOverlay& memory_db, RWTxn* txn);
+    MemoryMutation(MemoryOverlay& memory_db, ROTxn* txn);
     ~MemoryMutation() override;
 
     [[nodiscard]] bool is_table_cleared(const std::string& bucket_name) const;
     [[nodiscard]] bool is_entry_deleted(const std::string& bucket_name, const Bytes& key) const;
 
-    [[nodiscard]] db::RWTxn* external_txn() const { return txn_; }
+    [[nodiscard]] db::ROTxn* external_txn() const { return txn_; }
 
-    void update_txn(RWTxn* txn);
+    void update_txn(ROTxn* txn);
 
     std::unique_ptr<ROCursor> ro_cursor(const MapConfig& config) override;
     std::unique_ptr<ROCursorDupSort> ro_cursor_dup_sort(const MapConfig& config) override;
@@ -62,7 +62,7 @@ class MemoryMutation : public RWTxn {
     std::unique_ptr<MemoryMutationCursor> make_cursor(const MapConfig& config);
 
     MemoryOverlay& memory_db_;
-    db::RWTxn* txn_;
+    db::ROTxn* txn_;
     std::map<std::string, db::PooledCursor> stateless_cursors_;
     std::map<std::string, Bytes> deleted_entries_;
     std::map<std::string, bool> cleared_tables_;

--- a/silkworm/node/db/memory_mutation_cursor.cpp
+++ b/silkworm/node/db/memory_mutation_cursor.cpp
@@ -32,8 +32,22 @@ bool MemoryMutationCursor::is_entry_deleted(const Bytes& key) const {
     return memory_mutation_.is_entry_deleted(config_.name, key);
 }
 
+void MemoryMutationCursor::bind(ROTxn& txn, const MapConfig& config) {
+    memory_mutation_.update_txn(&txn);
+    cursor_->bind(txn, config);
+    memory_cursor_->bind(txn, config);
+}
+
 ::mdbx::map_handle MemoryMutationCursor::map() const {
     return memory_cursor_->map();
+}
+
+bool MemoryMutationCursor::is_multi_value() const {
+    return cursor_->is_multi_value();
+}
+
+bool MemoryMutationCursor::is_dangling() const {
+    return cursor_->is_dangling();
 }
 
 CursorResult MemoryMutationCursor::to_first() {

--- a/silkworm/node/db/memory_mutation_cursor.hpp
+++ b/silkworm/node/db/memory_mutation_cursor.hpp
@@ -32,7 +32,13 @@ class MemoryMutationCursor : public RWCursorDupSort {
     [[nodiscard]] bool is_table_cleared() const;
     [[nodiscard]] bool is_entry_deleted(const Bytes& key) const;
 
+    void bind(ROTxn& txn, const MapConfig& config) override;
+
     [[nodiscard]] ::mdbx::map_handle map() const override;
+
+    [[nodiscard]] bool is_multi_value() const override;
+
+    [[nodiscard]] bool is_dangling() const override;
 
     CursorResult to_first() override;
     CursorResult to_first(bool throw_notfound) override;

--- a/silkworm/node/db/memory_mutation_test.cpp
+++ b/silkworm/node/db/memory_mutation_test.cpp
@@ -72,6 +72,17 @@ TEST_CASE("MemoryMutation", "[silkworm][node][db][memory_mutation]") {
         MemoryMutation mutation{overlay, &main_rw_txn};
         CHECK_THROWS_AS(MemoryMutation(overlay, &main_rw_txn), ::mdbx::exception);
     }
+
+    SECTION("Rollback an empty mutation") {
+        MemoryMutation mutation{overlay, &main_rw_txn};
+        CHECK_NOTHROW(mutation.rollback());
+    }
+
+    SECTION("Rollback twice an empty mutation") {
+        MemoryMutation mutation{overlay, &main_rw_txn};
+        CHECK_NOTHROW(mutation.rollback());
+        CHECK_NOTHROW(mutation.rollback());
+    }
 }
 
 }  // namespace silkworm::db


### PR DESCRIPTION
This PR substitutes each creation of `db::PooledCursor` with a call to one of the factory methods:

- `ROTxn::ro_cursor`
- `ROTxn::ro_cursor_dup_sort`
- `RWTxn::rw_cursor`
- `RWTxn::rw_cursor_dup_sort`

and adjusts the code accordingly. Other related changes include:

- move assignment operators for `ROTxn` and `RWTxn`
- switch from `RWTxn` to `ROTxn` for `MemoryMutation` external transaction