### PR TITLE
rpcdaemon: add commands folder

### DIFF
--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -33,6 +33,9 @@ if(NOT SILKWORM_CORE_ONLY)
   find_package(Boost REQUIRED)
   find_package(CLI11 REQUIRED)
 
+  # Silkworm components
+  add_subdirectory(rpcdaemon)
+
   add_executable(silkworm silkworm.cpp common.cpp)
   target_link_libraries(silkworm PRIVATE silkworm_node silkworm_sync silkworm-buildinfo CLI11::CLI11 $<$<BOOL:${MSVC}>:Kernel32.lib>)
 

--- a/cmd/rpcdaemon/CMakeLists.txt
+++ b/cmd/rpcdaemon/CMakeLists.txt
@@ -1,0 +1,85 @@
+#[[
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+if(MSVC)
+    add_link_options(/STACK:10000000)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    add_link_options(-Wl,-stack_size -Wl,0x1000000)
+endif()
+
+find_package(absl REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(Protobuf REQUIRED)
+if(SILKRPC_USE_MIMALLOC)
+    find_package(mimalloc 2.0 REQUIRED)
+endif()
+
+if(MSVC)
+    add_compile_options(/bigobj)
+endif()
+
+# Silkrpc toolbox
+add_executable(silkrpc_toolbox
+    silkrpc_toolbox.cpp
+    ethbackend_async.cpp ethbackend_coroutines.cpp ethbackend.cpp
+    kv_seek_async_callback.cpp kv_seek_async_coroutines.cpp kv_seek_async.cpp kv_seek.cpp kv_seek_both.cpp)
+target_include_directories(silkrpc_toolbox PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(silkrpc_toolbox absl::flags_parse gRPC::grpc++ protobuf::libprotobuf silkrpc)
+
+# TO BE REMOVED: START: temporarily disable warnings entirely to make silkrpc_toolbox compile as it is
+get_target_property(SILKRPCTOOLBOX_COMPILE_OPTIONS silkrpc_toolbox COMPILE_OPTIONS)
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wall")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Werror")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wextra")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wshadow")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wimplicit-fallthrough")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wsign-conversion")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wno-missing-field-initializers")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wnon-virtual-dtor")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wthread-safety")
+list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-pedantic")
+set_property(TARGET silkrpc_toolbox PROPERTY COMPILE_OPTIONS ${SILKRPCTOOLBOX_COMPILE_OPTIONS})
+# TO BE REMOVED: END: temporarily disable warnings entirely to make silkrpc_toolbox compile as it is
+
+# Silkrpc daemon
+set(SILKRPC_DAEMON_LIBRARIES
+    silkworm-buildinfo
+    silkrpc
+    absl::flags_parse)
+if(SILKRPC_USE_MIMALLOC)
+    list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc)
+endif()
+
+add_executable(silkrpcdaemon silkrpc_daemon.cpp ../common.cpp)
+target_include_directories(silkrpcdaemon PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(silkrpcdaemon PRIVATE ${SILKRPC_DAEMON_LIBRARIES})
+
+# TO BE REMOVED: START: temporarily disable warnings entirely to make silkrpcdaemon compile as it is
+get_target_property(SILKRPCDAEMON_COMPILE_OPTIONS silkrpcdaemon COMPILE_OPTIONS)
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wall")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Werror")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wextra")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wshadow")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wimplicit-fallthrough")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wsign-conversion")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wno-missing-field-initializers")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wnon-virtual-dtor")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wthread-safety")
+list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-pedantic")
+set_property(TARGET silkrpcdaemon PROPERTY COMPILE_OPTIONS ${SILKRPCDAEMON_COMPILE_OPTIONS})
+# TO BE REMOVED: END: temporarily disable warnings entirely to make silkrpcdaemon compile as it is

--- a/cmd/rpcdaemon/ethbackend.cpp
+++ b/cmd/rpcdaemon/ethbackend.cpp
@@ -19,18 +19,15 @@
 #include <string>
 
 #include <grpcpp/grpcpp.h>
-#include <silkworm/core/common/util.hpp>
 
 #include <silkworm/interfaces/remote/ethbackend.grpc.pb.h>
 #include <silkworm/interfaces/types/types.pb.h>
-#include <silkworm/silkrpc/common/constants.hpp>
-#include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/grpc/util.hpp>
 
 inline std::ostream& operator<<(std::ostream& out, const types::H160& address) {
     out << "address=" << address.has_hi();
     if (address.has_hi()) {
-        auto hi_half = address.hi();
+        auto& hi_half = address.hi();
         out << std::hex << hi_half.hi() << hi_half.lo();
     } else {
         auto lo_half = address.lo();

--- a/cmd/rpcdaemon/ethbackend.cpp
+++ b/cmd/rpcdaemon/ethbackend.cpp
@@ -1,0 +1,101 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/interfaces/remote/ethbackend.grpc.pb.h>
+#include <silkworm/interfaces/types/types.pb.h>
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/silkrpc/grpc/util.hpp>
+
+inline std::ostream& operator<<(std::ostream& out, const types::H160& address) {
+    out << "address=" << address.has_hi();
+    if (address.has_hi()) {
+        auto hi_half = address.hi();
+        out << std::hex << hi_half.hi() << hi_half.lo();
+    } else {
+        auto lo_half = address.lo();
+        out << std::hex << lo_half;
+    }
+    out << std::dec;
+    return out;
+}
+
+int ethbackend(const std::string& target) {
+    // Create ETHBACKEND stub using insecure channel to target
+    grpc::Status status;
+
+    const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    const auto stub = remote::ETHBACKEND::NewStub(channel);
+
+    grpc::ClientContext eb_context;
+    remote::EtherbaseReply eb_reply;
+    std::cout << "ETHBACKEND Etherbase ->\n";
+    status = stub->Etherbase(&eb_context, remote::EtherbaseRequest{}, &eb_reply);
+    if (status.ok()) {
+        std::cout << "ETHBACKEND Etherbase <- " << status << " address: " << eb_reply.address() << "\n";
+    } else {
+        std::cout << "ETHBACKEND Etherbase <- " << status << "\n";
+    }
+
+    grpc::ClientContext nv_context;
+    remote::NetVersionReply nv_reply;
+    std::cout << "ETHBACKEND NetVersion ->\n";
+    status = stub->NetVersion(&nv_context, remote::NetVersionRequest{}, &nv_reply);
+    if (status.ok()) {
+        std::cout << "ETHBACKEND NetVersion <- " << status << " id: " << nv_reply.id() << "\n";
+    } else {
+        std::cout << "ETHBACKEND NetVersion <- " << status << "\n";
+    }
+
+    grpc::ClientContext v_context;
+    types::VersionReply v_reply;
+    std::cout << "ETHBACKEND Version ->\n";
+    status = stub->Version(&v_context, google::protobuf::Empty{}, &v_reply);
+    if (status.ok()) {
+        std::cout << "ETHBACKEND Version <- " << status << " major.minor.patch: " << v_reply.major() << "." << v_reply.minor() << "." << v_reply.patch() << "\n";
+    } else {
+        std::cout << "ETHBACKEND Version <- " << status << "\n";
+    }
+
+    grpc::ClientContext pv_context;
+    remote::ProtocolVersionReply pv_reply;
+    std::cout << "ETHBACKEND ProtocolVersion ->\n";
+    status = stub->ProtocolVersion(&pv_context, remote::ProtocolVersionRequest{}, &pv_reply);
+    if (status.ok()) {
+        std::cout << "ETHBACKEND ProtocolVersion <- " << status << " id: " << pv_reply.id() << "\n";
+    } else {
+        std::cout << "ETHBACKEND ProtocolVersion <- " << status << "\n";
+    }
+
+    grpc::ClientContext cv_context;
+    remote::ClientVersionReply cv_reply;
+    std::cout << "ETHBACKEND ClientVersion ->\n";
+    status = stub->ClientVersion(&cv_context, remote::ClientVersionRequest{}, &cv_reply);
+    if (status.ok()) {
+        std::cout << "ETHBACKEND ClientVersion <- " << status << " nodename: " << cv_reply.nodename() << "\n";
+    } else {
+        std::cout << "ETHBACKEND ClientVersion <- " << status << "\n";
+    }
+
+    return 0;
+}

--- a/cmd/rpcdaemon/ethbackend_async.cpp
+++ b/cmd/rpcdaemon/ethbackend_async.cpp
@@ -17,18 +17,15 @@
 #include <iostream>
 
 #include <grpcpp/grpcpp.h>
-#include <silkworm/core/common/util.hpp>
 
-#include <silkworm//interfaces/remote/ethbackend.grpc.pb.h>
-#include <silkworm/silkrpc/common/constants.hpp>
-#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/interfaces/remote/ethbackend.grpc.pb.h>
 #include <silkworm/silkrpc/grpc/util.hpp>
 
 int ethbackend_async(const std::string& target) {
     // Create ETHBACKEND stub using insecure channel to target
     grpc::CompletionQueue queue;
     grpc::Status status;
-    void * got_tag;
+    void* got_tag;
     bool ok;
 
     const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());

--- a/cmd/rpcdaemon/ethbackend_async.cpp
+++ b/cmd/rpcdaemon/ethbackend_async.cpp
@@ -1,0 +1,128 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <iostream>
+
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm//interfaces/remote/ethbackend.grpc.pb.h>
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/silkrpc/grpc/util.hpp>
+
+int ethbackend_async(const std::string& target) {
+    // Create ETHBACKEND stub using insecure channel to target
+    grpc::CompletionQueue queue;
+    grpc::Status status;
+    void * got_tag;
+    bool ok;
+
+    const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    const auto stub = remote::ETHBACKEND::NewStub(channel);
+
+    // Etherbase
+    grpc::ClientContext eb_context;
+    const auto eb_reader = stub->PrepareAsyncEtherbase(&eb_context, remote::EtherbaseRequest{}, &queue);
+
+    eb_reader->StartCall();
+    std::cout << "ETHBACKEND Etherbase ->\n";
+    remote::EtherbaseReply eb_reply;
+    eb_reader->Finish(&eb_reply, &status, eb_reader.get());
+    bool has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != eb_reader.get()) {
+        return -1;
+    }
+    if (status.ok()) {
+        std::cout << "ETHBACKEND Etherbase <- " << status << " address: " << eb_reply.has_address() << "\n";
+    } else {
+        std::cout << "ETHBACKEND Etherbase <- " << status << "\n";
+    }
+
+    // NetVersion
+    grpc::ClientContext nv_context;
+    const auto nv_reader = stub->PrepareAsyncNetVersion(&nv_context, remote::NetVersionRequest{}, &queue);
+
+    nv_reader->StartCall();
+    std::cout << "ETHBACKEND NetVersion ->\n";
+    remote::NetVersionReply nv_reply;
+    nv_reader->Finish(&nv_reply, &status, nv_reader.get());
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != nv_reader.get()) {
+        return -1;
+    }
+    if (status.ok()) {
+        std::cout << "ETHBACKEND NetVersion <- " << status << " id: " << nv_reply.id() << "\n";
+    } else {
+        std::cout << "ETHBACKEND NetVersion <- " << status << "\n";
+    }
+
+    // Version
+    grpc::ClientContext v_context;
+    const auto v_reader = stub->PrepareAsyncVersion(&v_context, google::protobuf::Empty{}, &queue);
+
+    v_reader->StartCall();
+    std::cout << "ETHBACKEND Version ->\n";
+    types::VersionReply v_reply;
+    v_reader->Finish(&v_reply, &status, v_reader.get());
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != v_reader.get()) {
+        return -1;
+    }
+    if (status.ok()) {
+        std::cout << "ETHBACKEND Version <- " << status << " major.minor.patch: " << v_reply.major() << "." << v_reply.minor() << "." << v_reply.patch() << "\n";
+    } else {
+        std::cout << "ETHBACKEND Version <- " << status << "\n";
+    }
+
+    // ProtocolVersion
+    grpc::ClientContext pv_context;
+    const auto pv_reader = stub->PrepareAsyncProtocolVersion(&pv_context, remote::ProtocolVersionRequest{}, &queue);
+
+    pv_reader->StartCall();
+    std::cout << "ETHBACKEND ProtocolVersion ->\n";
+    remote::ProtocolVersionReply pv_reply;
+    pv_reader->Finish(&pv_reply, &status, pv_reader.get());
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != pv_reader.get()) {
+        return -1;
+    }
+    if (status.ok()) {
+        std::cout << "ETHBACKEND ProtocolVersion <- " << status << " id: " << pv_reply.id() << "\n";
+    } else {
+        std::cout << "ETHBACKEND ProtocolVersion <- " << status << "\n";
+    }
+
+    // ClientVersion
+    grpc::ClientContext cv_context;
+    const auto cv_reader = stub->PrepareAsyncClientVersion(&cv_context, remote::ClientVersionRequest{}, &queue);
+
+    cv_reader->StartCall();
+    std::cout << "ETHBACKEND ClientVersion ->\n";
+    remote::ClientVersionReply cv_reply;
+    cv_reader->Finish(&cv_reply, &status, cv_reader.get());
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != cv_reader.get()) {
+        return -1;
+    }
+    if (status.ok()) {
+        std::cout << "ETHBACKEND ClientVersion <- " << status << " nodename: " << cv_reply.nodename() << "\n";
+    } else {
+        std::cout << "ETHBACKEND ClientVersion <- " << status << "\n";
+    }
+
+    return 0;
+}

--- a/cmd/rpcdaemon/ethbackend_coroutines.cpp
+++ b/cmd/rpcdaemon/ethbackend_coroutines.cpp
@@ -1,0 +1,90 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/silkrpc/config.hpp>
+
+#include <exception>
+#include <iomanip>
+#include <iostream>
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/interfaces/types/types.pb.h>
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/silkrpc/concurrency/context_pool.hpp>
+#include <silkworm/silkrpc/ethbackend/remote_backend.hpp>
+
+inline std::ostream& operator<<(std::ostream& out, const types::H160& address) {
+    out << "address=" << address.has_hi();
+    if (address.has_hi()) {
+        auto hi_half = address.hi();
+        out << std::hex << hi_half.hi() << hi_half.lo();
+    } else {
+        auto lo_half = address.lo();
+        out << std::hex << lo_half;
+    }
+    out << std::dec;
+    return out;
+}
+
+boost::asio::awaitable<void> ethbackend_etherbase(silkrpc::ethbackend::BackEnd& backend) {
+    try {
+        std::cout << "ETHBACKEND Etherbase ->\n";
+        const auto address = co_await backend.etherbase();
+        std::cout << "ETHBACKEND Etherbase <- address: " << address << "\n";
+    } catch (const std::exception& e) {
+        std::cout << "ETHBACKEND Etherbase <- error: " << e.what() << "\n";
+    }
+}
+
+int ethbackend_coroutines(const std::string& target) {
+    try {
+        // TODO(canepat): handle also secure channel for remote
+        silkrpc::ChannelFactory create_channel = [&]() {
+            return grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+        };
+        // TODO(canepat): handle also local (shared-memory) database
+        silkrpc::ContextPool context_pool{1, create_channel};
+        auto& context = context_pool.next_context();
+        auto io_context = context.io_context();
+        auto grpc_context = context.grpc_context();
+
+        boost::asio::signal_set signals(*io_context, SIGINT, SIGTERM);
+        signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
+            std::cout << "Signal caught, error: " << error.message() << " number: " << signal_number << std::endl << std::flush;
+            context_pool.stop();
+        });
+
+        const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+
+        // Etherbase
+        silkrpc::ethbackend::RemoteBackEnd eth_backend{*io_context, channel, *grpc_context};
+        boost::asio::co_spawn(*io_context, ethbackend_etherbase(eth_backend), [&](std::exception_ptr exptr) {
+            context_pool.stop();
+        });
+
+        context_pool.run();
+    } catch (const std::exception& e) {
+        std::cerr << "Exception: " << e.what() << "\n" << std::flush;
+    } catch (...) {
+        std::cerr << "Unexpected exception\n" << std::flush;
+    }
+    return 0;
+}

--- a/cmd/rpcdaemon/ethbackend_coroutines.cpp
+++ b/cmd/rpcdaemon/ethbackend_coroutines.cpp
@@ -14,19 +14,19 @@
    limitations under the License.
 */
 
-#include <silkworm/silkrpc/config.hpp>
-
 #include <exception>
 #include <iomanip>
 #include <iostream>
 
+// clang-format off
+#include <silkworm/silkrpc/config.hpp>
+// clang-format on
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <grpcpp/grpcpp.h>
-#include <silkworm/core/common/util.hpp>
 
 #include <silkworm/interfaces/types/types.pb.h>
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/ethbackend/remote_backend.hpp>
@@ -34,7 +34,7 @@
 inline std::ostream& operator<<(std::ostream& out, const types::H160& address) {
     out << "address=" << address.has_hi();
     if (address.has_hi()) {
-        auto hi_half = address.hi();
+        auto& hi_half = address.hi();
         out << std::hex << hi_half.hi() << hi_half.lo();
     } else {
         auto lo_half = address.lo();
@@ -68,7 +68,8 @@ int ethbackend_coroutines(const std::string& target) {
 
         boost::asio::signal_set signals(*io_context, SIGINT, SIGTERM);
         signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
-            std::cout << "Signal caught, error: " << error.message() << " number: " << signal_number << std::endl << std::flush;
+            std::cout << "Signal caught, error: " << error.message() << " number: " << signal_number << std::endl
+                      << std::flush;
             context_pool.stop();
         });
 
@@ -82,9 +83,11 @@ int ethbackend_coroutines(const std::string& target) {
 
         context_pool.run();
     } catch (const std::exception& e) {
-        std::cerr << "Exception: " << e.what() << "\n" << std::flush;
+        std::cerr << "Exception: " << e.what() << "\n"
+                  << std::flush;
     } catch (...) {
-        std::cerr << "Unexpected exception\n" << std::flush;
+        std::cerr << "Unexpected exception\n"
+                  << std::flush;
     }
     return 0;
 }

--- a/cmd/rpcdaemon/kv_seek.cpp
+++ b/cmd/rpcdaemon/kv_seek.cpp
@@ -18,11 +18,9 @@
 #include <iostream>
 
 #include <grpcpp/grpcpp.h>
+
 #include <silkworm/core/common/util.hpp>
-
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
-
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/grpc/util.hpp>
 

--- a/cmd/rpcdaemon/kv_seek.cpp
+++ b/cmd/rpcdaemon/kv_seek.cpp
@@ -1,0 +1,118 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <iomanip>
+#include <iostream>
+
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/interfaces/remote/kv.grpc.pb.h>
+
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/silkrpc/grpc/util.hpp>
+
+int kv_seek(const std::string& target, const std::string& table_name, const silkworm::Bytes& key) {
+    // Create KV stub using insecure channel to target
+    grpc::ClientContext context;
+
+    const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    const auto stub = remote::KV::NewStub(channel);
+    const auto reader_writer = stub->Tx(&context);
+    std::cout << "KV Tx START\n";
+
+    // Read TX identifier
+    auto txid_pair = remote::Pair{};
+    auto success = reader_writer->Read(&txid_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving TXID\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    const auto tx_id = txid_pair.cursorid();
+    std::cout << "KV Tx START <- txid: " << tx_id << "\n";
+
+    // Open cursor
+    auto open_message = remote::Cursor{};
+    open_message.set_op(remote::Op::OPEN);
+    open_message.set_bucketname(table_name);
+    success = reader_writer->Write(open_message);
+    if (!success) {
+        std::cerr << "KV stream closed sending OPEN operation req\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n";
+    auto open_pair = remote::Pair{};
+    success = reader_writer->Read(&open_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving OPEN operation rsp\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    auto cursor_id = open_pair.cursorid();
+    std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n";
+
+    // Seek given key in given table
+    auto seek_message = remote::Cursor{};
+    seek_message.set_op(remote::Op::SEEK);
+    seek_message.set_cursor(cursor_id);
+    seek_message.set_k(key.c_str(), key.length());
+    success = reader_writer->Write(seek_message);
+    if (!success) {
+        std::cerr << "KV stream closed sending SEEK operation req\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx SEEK -> cursor: " << cursor_id << " key: " << key << "\n";
+    auto seek_pair = remote::Pair{};
+    success = reader_writer->Read(&seek_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving SEEK operation rsp\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    const auto& rsp_key = silkworm::byte_view_of_string(seek_pair.k());
+    const auto& rsp_value = silkworm::byte_view_of_string(seek_pair.v());
+    std::cout << "KV Tx SEEK <- key: " << rsp_key << " value: " << rsp_value << std::endl;
+
+    // Close cursor
+    auto close_message = remote::Cursor{};
+    close_message.set_op(remote::Op::CLOSE);
+    close_message.set_cursor(cursor_id);
+    success = reader_writer->Write(close_message);
+    if (!success) {
+        std::cerr << "KV stream closed sending CLOSE operation req\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n";
+    auto close_pair = remote::Pair{};
+    success = reader_writer->Read(&close_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving CLOSE operation rsp\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx CLOSE <- cursor: " << close_pair.cursorid() << "\n";
+
+    reader_writer->WritesDone();
+    grpc::Status status = reader_writer->Finish();
+    std::cout << "KV Tx STATUS: " << status << "\n";
+
+    return 0;
+}

--- a/cmd/rpcdaemon/kv_seek_async.cpp
+++ b/cmd/rpcdaemon/kv_seek_async.cpp
@@ -1,0 +1,142 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/interfaces/remote/kv.grpc.pb.h>
+
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+
+int kv_seek_async(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout) {
+    // Create KV stub using insecure channel to target
+    grpc::ClientContext context;
+    grpc::CompletionQueue queue;
+    grpc::Status status;
+    void * got_tag;
+    bool ok;
+
+    const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    const auto stub = remote::KV::NewStub(channel);
+
+    // Prepare RPC call context and stream
+    context.set_deadline(std::chrono::system_clock::system_clock::now() + std::chrono::milliseconds{timeout});
+    const auto reader_writer = stub->PrepareAsyncTx(&context, &queue);
+
+    void* START_TAG  = reinterpret_cast<void *>(0);
+    void* OPEN_TAG   = reinterpret_cast<void *>(1);
+    void* SEEK_TAG   = reinterpret_cast<void *>(2);
+    void* CLOSE_TAG  = reinterpret_cast<void *>(3);
+    void* FINISH_TAG = reinterpret_cast<void *>(4);
+
+    // 1) StartCall
+    std::cout << "KV Tx START\n";
+    // 1.1) StartCall + Next
+    reader_writer->StartCall(START_TAG);
+    bool has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != START_TAG) {
+        return -1;
+    }
+    // 1.2) Read + Next
+    auto txid_pair = remote::Pair{};
+    reader_writer->Read(&txid_pair, START_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != START_TAG) {
+        return -1;
+    }
+    const auto tx_id = txid_pair.cursorid();
+    std::cout << "KV Tx START <- txid: " << tx_id << "\n";
+
+    // 2) Open cursor
+    std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n";
+    // 2.1) Write + Next
+    auto open_message = remote::Cursor{};
+    open_message.set_op(remote::Op::OPEN);
+    open_message.set_bucketname(table_name);
+    reader_writer->Write(open_message, OPEN_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != OPEN_TAG) {
+        return -1;
+    }
+    // 2.2) Read + Next
+    auto open_pair = remote::Pair{};
+    reader_writer->Read(&open_pair, OPEN_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != OPEN_TAG) {
+        return -1;
+    }
+    auto cursor_id = open_pair.cursorid();
+    std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n";
+
+    // 3) Seek given key in given table
+    std::cout << "KV Tx SEEK -> cursor: " << cursor_id << " key: " << key << "\n";
+    // 3.1) Write + Next
+    auto seek_message = remote::Cursor{};
+    seek_message.set_op(remote::Op::SEEK);
+    seek_message.set_cursor(cursor_id);
+    seek_message.set_k(key.c_str(), key.length());
+    reader_writer->Write(seek_message, SEEK_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != SEEK_TAG) {
+        return -1;
+    }
+    // 3.2) Read + Next
+    auto seek_pair = remote::Pair{};
+    reader_writer->Read(&seek_pair, SEEK_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != SEEK_TAG) {
+        return -1;
+    }
+    const auto& key_bytes = silkworm::byte_view_of_string(seek_pair.k());
+    const auto& value_bytes = silkworm::byte_view_of_string(seek_pair.v());
+    std::cout << "KV Tx SEEK <- key: " << key_bytes << " value: " << value_bytes << std::endl;
+
+    // 4) Close cursor
+    std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n";
+    // 4.1) Write + Next
+    auto close_message = remote::Cursor{};
+    close_message.set_op(remote::Op::CLOSE);
+    close_message.set_cursor(cursor_id);
+    reader_writer->Write(close_message, CLOSE_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != CLOSE_TAG) {
+        return -1;
+    }
+    // 4.2) Read + Next
+    auto close_pair = remote::Pair{};
+    reader_writer->Read(&close_pair, CLOSE_TAG);
+    has_event = queue.Next(&got_tag, &ok);
+    if (!has_event || got_tag != CLOSE_TAG) {
+        return -1;
+    }
+    std::cout << "KV Tx CLOSE <- cursor: " << close_pair.cursorid() << "\n";
+
+    // 5) Finish
+    reader_writer->Finish(&status, FINISH_TAG);
+    if (!status.ok()) {
+        std::cout << "KV Tx Status <- error_code: " << status.error_code() << "\n";
+        std::cout << "KV Tx Status <- error_message: " << status.error_message() << "\n";
+        std::cout << "KV Tx Status <- error_details: " << status.error_details() << "\n";
+        return -1;
+    }
+
+    return 0;
+}

--- a/cmd/rpcdaemon/kv_seek_async.cpp
+++ b/cmd/rpcdaemon/kv_seek_async.cpp
@@ -19,11 +19,9 @@
 #include <iostream>
 
 #include <grpcpp/grpcpp.h>
+
 #include <silkworm/core/common/util.hpp>
-
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
-
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 int kv_seek_async(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout) {
@@ -31,7 +29,7 @@ int kv_seek_async(const std::string& target, const std::string& table_name, cons
     grpc::ClientContext context;
     grpc::CompletionQueue queue;
     grpc::Status status;
-    void * got_tag;
+    void* got_tag;
     bool ok;
 
     const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
@@ -41,11 +39,11 @@ int kv_seek_async(const std::string& target, const std::string& table_name, cons
     context.set_deadline(std::chrono::system_clock::system_clock::now() + std::chrono::milliseconds{timeout});
     const auto reader_writer = stub->PrepareAsyncTx(&context, &queue);
 
-    void* START_TAG  = reinterpret_cast<void *>(0);
-    void* OPEN_TAG   = reinterpret_cast<void *>(1);
-    void* SEEK_TAG   = reinterpret_cast<void *>(2);
-    void* CLOSE_TAG  = reinterpret_cast<void *>(3);
-    void* FINISH_TAG = reinterpret_cast<void *>(4);
+    void* START_TAG = reinterpret_cast<void*>(0);
+    void* OPEN_TAG = reinterpret_cast<void*>(1);
+    void* SEEK_TAG = reinterpret_cast<void*>(2);
+    void* CLOSE_TAG = reinterpret_cast<void*>(3);
+    void* FINISH_TAG = reinterpret_cast<void*>(4);
 
     // 1) StartCall
     std::cout << "KV Tx START\n";

--- a/cmd/rpcdaemon/kv_seek_async_callback.cpp
+++ b/cmd/rpcdaemon/kv_seek_async_callback.cpp
@@ -1,0 +1,150 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <chrono>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/interfaces/remote/kv.grpc.pb.h>
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+
+
+class GrpcKvCallbackReactor final : public grpc::ClientBidiReactor<remote::Cursor, remote::Pair> {
+public:
+    explicit GrpcKvCallbackReactor(remote::KV::Stub& stub, std::chrono::milliseconds timeout) : stub_(stub) {
+        context_.set_deadline(std::chrono::system_clock::now() + timeout);
+        stub_.experimental_async()->Tx(&context_, this);
+        StartCall();
+    }
+
+    void read_start(std::function<void(bool, remote::Pair)> read_completed) {
+        read_completed_ = read_completed;
+        StartRead(&pair_);
+    }
+
+    void write_start(remote::Cursor* cursor, std::function<void(bool)> write_completed) {
+        write_completed_ = write_completed;
+        StartWrite(cursor);
+    }
+
+    void OnReadDone(bool ok) override {
+        read_completed_(ok, pair_);
+    }
+
+    void OnWriteDone(bool ok) override {
+        write_completed_(ok);
+    }
+
+private:
+    remote::KV::Stub& stub_;
+    grpc::ClientContext context_;
+    remote::Pair pair_;
+    std::function<void(bool, remote::Pair)> read_completed_;
+    std::function<void(bool)> write_completed_;
+};
+
+int kv_seek_async_callback(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout) {
+    boost::asio::io_context context;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work{context.get_executor()};
+
+    const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    auto stub = remote::KV::NewStub(channel);
+
+    boost::asio::signal_set signals(context, SIGINT, SIGTERM);
+    signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
+        std::cout << "Signal caught, error: " << error.message() << " number: " << signal_number << std::endl << std::flush;
+        context.stop();
+    });
+
+    GrpcKvCallbackReactor reactor{*stub, std::chrono::milliseconds{timeout}};
+
+    std::cout << "KV Tx START\n";
+    reactor.read_start([&](bool ok, remote::Pair txid_pair) {
+        if (!ok) {
+            std::cout << "KV Tx error reading TXID" << std::flush;
+            return;
+        }
+        const auto tx_id = txid_pair.cursorid();
+        std::cout << "KV Tx START <- txid: " << tx_id << "\n";
+        auto open_message = remote::Cursor{};
+        open_message.set_op(remote::Op::OPEN);
+        open_message.set_bucketname(table_name);
+        reactor.write_start(&open_message, [&](bool ok) {
+            if (!ok) {
+                std::cout << "error writing OPEN gRPC" << std::flush;
+                return;
+            }
+            std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n";
+            reactor.read_start([&](bool ok, remote::Pair open_pair) {
+                if (!ok) {
+                    std::cout << "error reading OPEN gRPC" << std::flush;
+                    return;
+                }
+                const auto cursor_id = open_pair.cursorid();
+                std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n";
+                auto seek_message = remote::Cursor{};
+                seek_message.set_op(remote::Op::SEEK);
+                seek_message.set_cursor(cursor_id);
+                seek_message.set_k(key.c_str(), key.length());
+                reactor.write_start(&seek_message, [&, cursor_id](bool ok) {
+                    if (!ok) {
+                        std::cout << "error writing SEEK gRPC" << std::flush;
+                        return;
+                    }
+                    std::cout << "KV Tx SEEK -> cursor: " << cursor_id << " key: " << key << "\n";
+                    reactor.read_start([&, cursor_id](bool ok, remote::Pair seek_pair) {
+                        if (!ok) {
+                            std::cout << "error reading SEEK gRPC" << std::flush;
+                            return;
+                        }
+                        const auto& key_bytes = silkworm::byte_view_of_string(seek_pair.k());
+                        const auto& value_bytes = silkworm::byte_view_of_string(seek_pair.v());
+                        std::cout << "KV Tx SEEK <- key: " << key_bytes << " value: " << value_bytes << std::endl;
+                        auto close_message = remote::Cursor{};
+                        close_message.set_op(remote::Op::CLOSE);
+                        close_message.set_cursor(cursor_id);
+                        reactor.write_start(&close_message, [&, cursor_id](bool ok) {
+                            if (!ok) {
+                                std::cout << "error writing CLOSE gRPC" << std::flush;
+                                return;
+                            }
+                            std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n";
+                            reactor.read_start([&](bool ok, remote::Pair close_pair) {
+                                if (!ok) {
+                                    std::cout << "error reading CLOSE gRPC" << std::flush;
+                                    return;
+                                }
+                                std::cout << "KV Tx CLOSE <- cursor: " << close_pair.cursorid() << "\n";
+                                context.stop();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    context.run();
+
+    return 0;
+}

--- a/cmd/rpcdaemon/kv_seek_async_callback.cpp
+++ b/cmd/rpcdaemon/kv_seek_async_callback.cpp
@@ -22,15 +22,13 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <grpcpp/grpcpp.h>
-#include <silkworm/core/common/util.hpp>
 
+#include <silkworm/core/common/util.hpp>
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
-
 class GrpcKvCallbackReactor final : public grpc::ClientBidiReactor<remote::Cursor, remote::Pair> {
-public:
+  public:
     explicit GrpcKvCallbackReactor(remote::KV::Stub& stub, std::chrono::milliseconds timeout) : stub_(stub) {
         context_.set_deadline(std::chrono::system_clock::now() + timeout);
         stub_.experimental_async()->Tx(&context_, this);
@@ -55,7 +53,7 @@ public:
         write_completed_(ok);
     }
 
-private:
+  private:
     remote::KV::Stub& stub_;
     grpc::ClientContext context_;
     remote::Pair pair_;
@@ -72,7 +70,8 @@ int kv_seek_async_callback(const std::string& target, const std::string& table_n
 
     boost::asio::signal_set signals(context, SIGINT, SIGTERM);
     signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
-        std::cout << "Signal caught, error: " << error.message() << " number: " << signal_number << std::endl << std::flush;
+        std::cout << "Signal caught, error: " << error.message() << " number: " << signal_number << std::endl
+                  << std::flush;
         context.stop();
     });
 

--- a/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
+++ b/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
@@ -14,17 +14,19 @@
    limitations under the License.
 */
 
-#include <silkworm/silkrpc/config.hpp>
-
 #include <functional>
 #include <iomanip>
 #include <iostream>
 #include <utility>
 
+// clang-format off
+#include <silkworm/silkrpc/config.hpp>
+// clang-format on
+
 #include <boost/asio/co_spawn.hpp>
 #include <grpcpp/grpcpp.h>
-#include <silkworm/core/common/util.hpp>
 
+#include <silkworm/core/common/util.hpp>
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
@@ -35,16 +37,22 @@ using silkrpc::LogLevel;
 
 boost::asio::awaitable<void> kv_seek(silkrpc::ethdb::Database& kv_db, const std::string& table_name, const silkworm::Bytes& key) {
     const auto kv_transaction = co_await kv_db.begin();
-    std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n" << std::flush;
+    std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n"
+              << std::flush;
     const auto kv_cursor = co_await kv_transaction->cursor(table_name);
     auto cursor_id = kv_cursor->cursor_id();
-    std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n" << std::flush;
-    std::cout << "KV Tx SEEK -> cursor: " << cursor_id << " key: " << key << "\n" << std::flush;
+    std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n"
+              << std::flush;
+    std::cout << "KV Tx SEEK -> cursor: " << cursor_id << " key: " << key << "\n"
+              << std::flush;
     auto kv_pair = co_await kv_cursor->seek(key);
-    std::cout << "KV Tx SEEK <- key: " << kv_pair.key << " value: " << kv_pair.value << "\n" << std::flush;
-    std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n" << std::flush;
+    std::cout << "KV Tx SEEK <- key: " << kv_pair.key << " value: " << kv_pair.value << "\n"
+              << std::flush;
+    std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n"
+              << std::flush;
     co_await kv_transaction->close();
-    std::cout << "KV Tx CLOSE <- cursor: 0\n" << std::flush;
+    std::cout << "KV Tx CLOSE <- cursor: 0\n"
+              << std::flush;
     co_return;
 }
 
@@ -66,9 +74,11 @@ int kv_seek_async_coroutines(const std::string& target, const std::string& table
 
         context_pool.run();
     } catch (const std::exception& e) {
-        std::cerr << "Exception: " << e.what() << "\n" << std::flush;
+        std::cerr << "Exception: " << e.what() << "\n"
+                  << std::flush;
     } catch (...) {
-        std::cerr << "Unexpected exception\n" << std::flush;
+        std::cerr << "Unexpected exception\n"
+                  << std::flush;
     }
 
     return 0;

--- a/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
+++ b/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
@@ -1,0 +1,75 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/silkrpc/config.hpp>
+
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+
+#include <boost/asio/co_spawn.hpp>
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/silkrpc/concurrency/context_pool.hpp>
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/log.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/silkrpc/ethdb/kv/remote_database.hpp>
+
+using silkrpc::LogLevel;
+
+boost::asio::awaitable<void> kv_seek(silkrpc::ethdb::Database& kv_db, const std::string& table_name, const silkworm::Bytes& key) {
+    const auto kv_transaction = co_await kv_db.begin();
+    std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n" << std::flush;
+    const auto kv_cursor = co_await kv_transaction->cursor(table_name);
+    auto cursor_id = kv_cursor->cursor_id();
+    std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n" << std::flush;
+    std::cout << "KV Tx SEEK -> cursor: " << cursor_id << " key: " << key << "\n" << std::flush;
+    auto kv_pair = co_await kv_cursor->seek(key);
+    std::cout << "KV Tx SEEK <- key: " << kv_pair.key << " value: " << kv_pair.value << "\n" << std::flush;
+    std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n" << std::flush;
+    co_await kv_transaction->close();
+    std::cout << "KV Tx CLOSE <- cursor: 0\n" << std::flush;
+    co_return;
+}
+
+int kv_seek_async_coroutines(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout) {
+    try {
+        // TODO(canepat): handle also secure channel for remote
+        silkrpc::ChannelFactory create_channel = [&]() {
+            return grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+        };
+        // TODO(canepat): handle also local (shared-memory) database
+        silkrpc::ContextPool context_pool{1, create_channel};
+        auto& context = context_pool.next_context();
+        auto io_context = context.io_context();
+        auto& database = context.database();
+
+        boost::asio::co_spawn(*io_context, kv_seek(*database, table_name, key), [&](std::exception_ptr exptr) {
+            context_pool.stop();
+        });
+
+        context_pool.run();
+    } catch (const std::exception& e) {
+        std::cerr << "Exception: " << e.what() << "\n" << std::flush;
+    } catch (...) {
+        std::cerr << "Unexpected exception\n" << std::flush;
+    }
+
+    return 0;
+}

--- a/cmd/rpcdaemon/kv_seek_both.cpp
+++ b/cmd/rpcdaemon/kv_seek_both.cpp
@@ -1,0 +1,120 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/interfaces/remote/kv.grpc.pb.h>
+
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/util.hpp>
+#include <silkworm/silkrpc/grpc/util.hpp>
+
+int kv_seek_both(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, const silkworm::Bytes& subkey) {
+    // Create KV stub using insecure channel to target
+    grpc::ClientContext context;
+
+    const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    const auto stub = remote::KV::NewStub(channel);
+    const auto reader_writer = stub->Tx(&context);
+    std::cout << "KV Tx START\n";
+
+    // Read TX identifier
+    auto txid_pair = remote::Pair{};
+    auto success = reader_writer->Read(&txid_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving TXID\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    const auto tx_id = txid_pair.cursorid();
+    std::cout << "KV Tx START <- txid: " << tx_id << "\n";
+
+    // Open cursor
+    auto open_message = remote::Cursor{};
+    open_message.set_op(remote::Op::OPEN);
+    open_message.set_bucketname(table_name);
+    success = reader_writer->Write(open_message);
+    if (!success) {
+        std::cerr << "KV stream closed sending OPEN operation req\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx OPEN -> table_name: " << table_name << "\n";
+    auto open_pair = remote::Pair{};
+    success = reader_writer->Read(&open_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving OPEN operation rsp\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    auto cursor_id = open_pair.cursorid();
+    std::cout << "KV Tx OPEN <- cursor: " << cursor_id << "\n";
+
+    // Seek given key in given table
+    auto seek_both_message = remote::Cursor{};
+    seek_both_message.set_op(remote::Op::SEEK_BOTH);
+    seek_both_message.set_cursor(cursor_id);
+    seek_both_message.set_k(key.c_str(), key.length());
+    seek_both_message.set_v(subkey.c_str(), subkey.length());
+    success = reader_writer->Write(seek_both_message);
+    if (!success) {
+        std::cerr << "KV stream closed sending SEEK_BOTH operation req\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx SEEK_BOTH -> cursor: " << cursor_id << " key: " << key << " subkey: " << subkey << "\n";
+    auto seek_both_pair = remote::Pair{};
+    success = reader_writer->Read(&seek_both_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving SEEK_BOTH operation rsp\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    const auto& rsp_key = silkworm::byte_view_of_string(seek_both_pair.k());
+    const auto& rsp_value = silkworm::byte_view_of_string(seek_both_pair.v());
+    std::cout << "KV Tx SEEK_BOTH <- key: " << rsp_key << " value: " << rsp_value << std::endl;
+
+    // Close cursor
+    auto close_message = remote::Cursor{};
+    close_message.set_op(remote::Op::CLOSE);
+    close_message.set_cursor(cursor_id);
+    success = reader_writer->Write(close_message);
+    if (!success) {
+        std::cerr << "KV stream closed sending CLOSE operation req\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx CLOSE -> cursor: " << cursor_id << "\n";
+    auto close_pair = remote::Pair{};
+    success = reader_writer->Read(&close_pair);
+    if (!success) {
+        std::cerr << "KV stream closed receiving CLOSE operation rsp\n";
+        std::cout << "KV Tx STATUS: " << reader_writer->Finish() << "\n";
+        return -1;
+    }
+    std::cout << "KV Tx CLOSE <- cursor: " << close_pair.cursorid() << "\n";
+
+    reader_writer->WritesDone();
+    grpc::Status status = reader_writer->Finish();
+    std::cout << "KV Tx STATUS: " << status << "\n";
+
+    return 0;
+}

--- a/cmd/rpcdaemon/kv_seek_both.cpp
+++ b/cmd/rpcdaemon/kv_seek_both.cpp
@@ -19,11 +19,9 @@
 #include <string>
 
 #include <grpcpp/grpcpp.h>
+
 #include <silkworm/core/common/util.hpp>
-
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
-
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/grpc/util.hpp>
 

--- a/cmd/rpcdaemon/silkrpc_daemon.cpp
+++ b/cmd/rpcdaemon/silkrpc_daemon.cpp
@@ -1,0 +1,107 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/silkrpc/config.hpp>
+
+#include <string>
+
+#include <absl/flags/flag.h>
+#include <absl/flags/parse.h>
+#include <absl/flags/usage.h>
+#include <absl/flags/usage_config.h>
+#include <absl/strings/match.h>
+#include <boost/asio/version.hpp>
+#include <grpcpp/grpcpp.h>
+
+#include <silkworm/buildinfo.h>
+#include <silkworm/silkrpc/common/log.hpp>
+#include <silkworm/silkrpc/daemon.hpp>
+
+#include "../common.hpp"
+
+using namespace silkworm::cmd;
+
+ABSL_FLAG(std::string, chaindata, silkrpc::kEmptyChainData, "chain data path as string");
+ABSL_FLAG(std::string, http_port, silkrpc::kDefaultHttpPort, "Ethereum JSON RPC API local end-point as string <address>:<port>");
+ABSL_FLAG(std::string, engine_port, silkrpc::kDefaultEnginePort, "Engine JSON RPC API local end-point as string <address>:<port>");
+ABSL_FLAG(std::string, target, silkrpc::kDefaultTarget, "Erigon Core gRPC service location as string <address>:<port>");
+ABSL_FLAG(std::string, api_spec, silkrpc::kDefaultEth1ApiSpec, "JSON RPC API namespaces as comma-separated list of strings");
+ABSL_FLAG(uint32_t, num_contexts, std::thread::hardware_concurrency() / 3, "number of running I/O contexts as 32-bit integer");
+ABSL_FLAG(uint32_t, num_workers, 16, "number of worker threads as 32-bit integer");
+ABSL_FLAG(uint32_t, timeout, silkrpc::kDefaultTimeout.count(), "gRPC call timeout as 32-bit integer");
+ABSL_FLAG(silkrpc::LogLevel, log_verbosity, silkrpc::LogLevel::Critical, "logging verbosity level");
+ABSL_FLAG(silkrpc::WaitMode, wait_mode, silkrpc::WaitMode::blocking, "scheduler wait mode");
+ABSL_FLAG(std::string, jwt_secret_file, silkrpc::kDefaultJwtFilename, "Token file to ensure safe connection between CL and EL");
+ABSL_FLAG(std::string, datadir, silkrpc::kDefaultDataDir, "DB Path");
+
+//! Assemble the application version using the Cable build information
+std::string get_version_from_build_info() {
+    const auto build_info{silkworm_get_buildinfo()};
+
+    std::string application_version{"silkrpcdaemon version: "};
+    application_version.append(build_info->project_version);
+    return application_version;
+}
+
+//! Assemble the application fully-qualified name using the Cable build information
+std::string get_name_from_build_info() {
+    return get_node_name_from_build_info(silkworm_get_buildinfo());
+}
+
+//! Assemble the relevant library version information
+std::string get_library_versions() {
+    std::string library_versions{"gRPC: "};
+    library_versions.append(grpc::Version());
+    library_versions.append(" Boost Asio: ");
+    library_versions.append(std::to_string(BOOST_ASIO_VERSION));
+    return library_versions;
+}
+
+silkrpc::DaemonSettings parse_args(int argc, char* argv[]) {
+    absl::FlagsUsageConfig config;
+    config.contains_helpshort_flags = [](absl::string_view) { return false; };
+    config.contains_help_flags = [](absl::string_view filename) { return absl::EndsWith(filename, "main.cpp"); };
+    config.contains_helppackage_flags = [](absl::string_view) { return false; };
+    config.normalize_filename = [](absl::string_view f) { return std::string{f.substr(f.rfind("/") + 1)}; };
+    config.version_string = []() { return get_version_from_build_info() + "\n"; };
+    absl::SetFlagsUsageConfig(config);
+    absl::SetProgramUsageMessage("C++ implementation of Ethereum JSON RPC API service within Thorax architecture");
+    absl::ParseCommandLine(argc, argv);
+
+    const auto datadir = absl::GetFlag(FLAGS_datadir);
+    std::optional<std::string> datadir_optional;
+    if (!datadir.empty())  {
+        datadir_optional = datadir;
+    }
+    const silkrpc::DaemonSettings rpc_daemon_settings{
+        datadir_optional,
+        absl::GetFlag(FLAGS_http_port),
+        absl::GetFlag(FLAGS_engine_port),
+        absl::GetFlag(FLAGS_api_spec),
+        absl::GetFlag(FLAGS_target),
+        absl::GetFlag(FLAGS_num_contexts),
+        absl::GetFlag(FLAGS_num_workers),
+        absl::GetFlag(FLAGS_log_verbosity),
+        absl::GetFlag(FLAGS_wait_mode),
+        absl::GetFlag(FLAGS_jwt_secret_file),
+    };
+
+    return rpc_daemon_settings;
+}
+
+int main(int argc, char* argv[]) {
+    return silkrpc::Daemon::run(parse_args(argc, argv), {get_name_from_build_info(), get_library_versions()});
+}

--- a/cmd/rpcdaemon/silkrpc_daemon.cpp
+++ b/cmd/rpcdaemon/silkrpc_daemon.cpp
@@ -14,8 +14,6 @@
    limitations under the License.
 */
 
-#include <silkworm/silkrpc/config.hpp>
-
 #include <string>
 
 #include <absl/flags/flag.h>
@@ -28,6 +26,7 @@
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/silkrpc/common/log.hpp>
+#include <silkworm/silkrpc/config.hpp>
 #include <silkworm/silkrpc/daemon.hpp>
 
 #include "../common.hpp"
@@ -75,7 +74,7 @@ silkrpc::DaemonSettings parse_args(int argc, char* argv[]) {
     config.contains_helpshort_flags = [](absl::string_view) { return false; };
     config.contains_help_flags = [](absl::string_view filename) { return absl::EndsWith(filename, "main.cpp"); };
     config.contains_helppackage_flags = [](absl::string_view) { return false; };
-    config.normalize_filename = [](absl::string_view f) { return std::string{f.substr(f.rfind("/") + 1)}; };
+    config.normalize_filename = [](absl::string_view f) { return std::string{f.substr(f.rfind('/') + 1)}; };
     config.version_string = []() { return get_version_from_build_info() + "\n"; };
     absl::SetFlagsUsageConfig(config);
     absl::SetProgramUsageMessage("C++ implementation of Ethereum JSON RPC API service within Thorax architecture");
@@ -83,10 +82,10 @@ silkrpc::DaemonSettings parse_args(int argc, char* argv[]) {
 
     const auto datadir = absl::GetFlag(FLAGS_datadir);
     std::optional<std::string> datadir_optional;
-    if (!datadir.empty())  {
+    if (!datadir.empty()) {
         datadir_optional = datadir;
     }
-    const silkrpc::DaemonSettings rpc_daemon_settings{
+    silkrpc::DaemonSettings rpc_daemon_settings{
         datadir_optional,
         absl::GetFlag(FLAGS_http_port),
         absl::GetFlag(FLAGS_engine_port),
@@ -98,7 +97,6 @@ silkrpc::DaemonSettings parse_args(int argc, char* argv[]) {
         absl::GetFlag(FLAGS_wait_mode),
         absl::GetFlag(FLAGS_jwt_secret_file),
     };
-
     return rpc_daemon_settings;
 }
 

--- a/cmd/rpcdaemon/silkrpc_toolbox.cpp
+++ b/cmd/rpcdaemon/silkrpc_toolbox.cpp
@@ -20,8 +20,8 @@
 #include <absl/flags/flag.h>
 #include <absl/flags/parse.h>
 #include <absl/flags/usage.h>
-#include <silkworm/core/common/util.hpp>
 
+#include <silkworm/core/common/util.hpp>
 #include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 
@@ -236,7 +236,8 @@ int kv_seek() {
 }
 
 int main(int argc, char* argv[]) {
-    absl::SetProgramUsageMessage("Execute specified Silkrpc tool:\n"
+    absl::SetProgramUsageMessage(
+        "Execute specified Silkrpc tool:\n"
         "\tethbackend\t\t\tquery the Erigon/Silkworm ETHBACKEND remote interface\n"
         "\tethbackend_async\t\tquery the Erigon/Silkworm ETHBACKEND remote interface\n"
         "\tethbackend_coroutines\t\tquery the Erigon/Silkworm ETHBACKEND remote interface\n"
@@ -244,8 +245,7 @@ int main(int argc, char* argv[]) {
         "\tkv_seek_async\t\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_async_callback\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_async_coroutines\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
-        "\tkv_seek_both\t\t\tquery using SEEK_BOTH the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
-    );
+        "\tkv_seek_both\t\t\tquery using SEEK_BOTH the Erigon/Silkworm Key-Value (KV) remote interface to database\n");
     const auto positional_args = absl::ParseCommandLine(argc, argv);
     if (positional_args.size() < 2) {
         std::cerr << "No Silkrpc tool specified as first positional argument\n\n";
@@ -281,7 +281,7 @@ int main(int argc, char* argv[]) {
         return kv_seek();
     }
 
-    std::cerr << "Unknown tool " << tool <<  " specified as first argument\n\n";
+    std::cerr << "Unknown tool " << tool << " specified as first argument\n\n";
     std::cerr << absl::ProgramUsageMessage();
     return -1;
 }

--- a/cmd/rpcdaemon/silkrpc_toolbox.cpp
+++ b/cmd/rpcdaemon/silkrpc_toolbox.cpp
@@ -1,0 +1,287 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <iostream>
+#include <string>
+
+#include <absl/flags/flag.h>
+#include <absl/flags/parse.h>
+#include <absl/flags/usage.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/log.hpp>
+
+int ethbackend_async(const std::string& target);
+int ethbackend_coroutines(const std::string& target);
+int ethbackend(const std::string& target);
+int kv_seek_async_callback(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout);
+int kv_seek_async_coroutines(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout);
+int kv_seek_async(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout);
+int kv_seek_both(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, const silkworm::Bytes& subkey);
+int kv_seek(const std::string& target, const std::string& table_name, const silkworm::Bytes& key);
+
+ABSL_FLAG(std::string, key, "", "key as hex string w/o leading 0x");
+ABSL_FLAG(silkrpc::LogLevel, log_verbosity, silkrpc::LogLevel::Critical, "logging level as string");
+ABSL_FLAG(std::string, seekkey, "", "seek key as hex string w/o leading 0x");
+ABSL_FLAG(std::string, subkey, "", "subkey as hex string w/o leading 0x");
+ABSL_FLAG(std::string, tool, "", "gRPC remote interface tool name as string");
+ABSL_FLAG(std::string, target, silkrpc::kDefaultTarget, "Erigon location as string <address>:<port>");
+ABSL_FLAG(std::string, table, "", "database table name as string");
+ABSL_FLAG(uint32_t, timeout, silkrpc::kDefaultTimeout.count(), "gRPC call timeout as integer");
+
+int ethbackend_async() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    return ethbackend_async(target);
+}
+
+int ethbackend_coroutines() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    return ethbackend_coroutines(target);
+}
+
+int ethbackend() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    return ethbackend(target);
+}
+
+int kv_seek_async_callback() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    auto key{absl::GetFlag(FLAGS_key)};
+    const auto key_bytes = silkworm::from_hex(key);
+    if (key.empty() || !key_bytes.has_value()) {
+        std::cerr << "Parameter key is invalid: [" << key << "]\n";
+        std::cerr << "Use --key flag to specify the key in key-value dupsort table\n";
+        return -1;
+    }
+
+    auto timeout{absl::GetFlag(FLAGS_timeout)};
+    if (timeout < 0) {
+        std::cerr << "Parameter timeout is invalid: [" << timeout << "]\n";
+        std::cerr << "Use --timeout flag to specify the timeout in msecs for Erigon KV gRPC calls\n";
+        return -1;
+    }
+
+    return kv_seek_async_callback(target, table_name, key_bytes.value(), timeout);
+}
+
+int kv_seek_async_coroutines() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    auto key{absl::GetFlag(FLAGS_key)};
+    const auto key_bytes = silkworm::from_hex(key);
+    if (key.empty() || !key_bytes.has_value()) {
+        std::cerr << "Parameter key is invalid: [" << key << "]\n";
+        std::cerr << "Use --key flag to specify the key in key-value dupsort table\n";
+        return -1;
+    }
+
+    auto timeout{absl::GetFlag(FLAGS_timeout)};
+    if (timeout < 0) {
+        std::cerr << "Parameter timeout is invalid: [" << timeout << "]\n";
+        std::cerr << "Use --timeout flag to specify the timeout in msecs for Erigon KV gRPC calls\n";
+        return -1;
+    }
+
+    return kv_seek_async_coroutines(target, table_name, key_bytes.value(), timeout);
+}
+
+int kv_seek_async() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    auto key{absl::GetFlag(FLAGS_key)};
+    const auto key_bytes = silkworm::from_hex(key);
+    if (key.empty() || !key_bytes.has_value()) {
+        std::cerr << "Parameter key is invalid: [" << key << "]\n";
+        std::cerr << "Use --key flag to specify the key in key-value dupsort table\n";
+        return -1;
+    }
+
+    auto timeout{absl::GetFlag(FLAGS_timeout)};
+    if (timeout < 0) {
+        std::cerr << "Parameter timeout is invalid: [" << timeout << "]\n";
+        std::cerr << "Use --timeout flag to specify the timeout in msecs for Erigon KV gRPC calls\n";
+        return -1;
+    }
+
+    return kv_seek_async(target, table_name, key_bytes.value(), timeout);
+}
+
+int kv_seek_both() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    auto key{absl::GetFlag(FLAGS_key)};
+    const auto key_bytes = silkworm::from_hex(key);
+    if (key.empty() || !key_bytes.has_value()) {
+        std::cerr << "Parameter key is invalid: [" << key << "]\n";
+        std::cerr << "Use --key flag to specify the key in key-value dupsort table\n";
+        return -1;
+    }
+
+    auto subkey{absl::GetFlag(FLAGS_subkey)};
+    const auto subkey_bytes = silkworm::from_hex(subkey);
+    if (subkey.empty() || !subkey_bytes.has_value()) {
+        std::cerr << "Parameter subkey is invalid: [" << subkey << "]\n";
+        std::cerr << "Use --subkey flag to specify the subkey in key-value dupsort table\n";
+        return -1;
+    }
+
+    return kv_seek_both(target, table_name, key_bytes.value(), subkey_bytes.value());
+}
+
+int kv_seek() {
+    auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || target.find(":") == std::string::npos) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        return -1;
+    }
+
+    auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    auto key{absl::GetFlag(FLAGS_key)};
+    const auto key_bytes = silkworm::from_hex(key);
+    if (key.empty() || !key_bytes.has_value()) {
+        std::cerr << "Parameter key is invalid: [" << key << "]\n";
+        std::cerr << "Use --key flag to specify the key in key-value dupsort table\n";
+        return -1;
+    }
+
+    return kv_seek(target, table_name, key_bytes.value());
+}
+
+int main(int argc, char* argv[]) {
+    absl::SetProgramUsageMessage("Execute specified Silkrpc tool:\n"
+        "\tethbackend\t\t\tquery the Erigon/Silkworm ETHBACKEND remote interface\n"
+        "\tethbackend_async\t\tquery the Erigon/Silkworm ETHBACKEND remote interface\n"
+        "\tethbackend_coroutines\t\tquery the Erigon/Silkworm ETHBACKEND remote interface\n"
+        "\tkv_seek\t\t\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+        "\tkv_seek_async\t\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+        "\tkv_seek_async_callback\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+        "\tkv_seek_async_coroutines\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+        "\tkv_seek_both\t\t\tquery using SEEK_BOTH the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+    );
+    const auto positional_args = absl::ParseCommandLine(argc, argv);
+    if (positional_args.size() < 2) {
+        std::cerr << "No Silkrpc tool specified as first positional argument\n\n";
+        std::cerr << absl::ProgramUsageMessage();
+        return -1;
+    }
+
+    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_log_verbosity));
+
+    const std::string tool{positional_args[1]};
+    if (tool == "ethbackend_async") {
+        return ethbackend_async();
+    }
+    if (tool == "ethbackend_coroutines") {
+        return ethbackend_coroutines();
+    }
+    if (tool == "ethbackend") {
+        return ethbackend();
+    }
+    if (tool == "kv_seek_async_callback") {
+        return kv_seek_async_callback();
+    }
+    if (tool == "kv_seek_async_coroutines") {
+        return kv_seek_async_coroutines();
+    }
+    if (tool == "kv_seek_async") {
+        return kv_seek_async();
+    }
+    if (tool == "kv_seek_both") {
+        return kv_seek_both();
+    }
+    if (tool == "kv_seek") {
+        return kv_seek();
+    }
+
+    std::cerr << "Unknown tool " << tool <<  " specified as first argument\n\n";
+    std::cerr << absl::ProgramUsageMessage();
+    return -1;
+}

--- a/cmd/test/CMakeLists.txt
+++ b/cmd/test/CMakeLists.txt
@@ -25,7 +25,9 @@ if(CORE_TEST_ABSEIL_ENABLED)
   find_package(absl REQUIRED)
 endif()
 
+find_package(asio-grpc REQUIRED)
 find_package(Catch2 REQUIRED)
+find_package(GTest REQUIRED)
 find_package(Microsoft.GSL REQUIRED)
 
 # Silkworm Core Tests
@@ -61,7 +63,55 @@ if(NOT SILKWORM_CORE_ONLY)
   if(SILKWORM_SANITIZE)
     target_compile_definitions(node_test PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
   endif()
-  target_link_libraries(node_test silkworm_node silkworm_sync Catch2::Catch2)
+  target_link_libraries(node_test silkworm_node Catch2::Catch2)
+
+  # Silkworm RpcDaemon Tests
+  file(GLOB_RECURSE SILKWORM_RPCDAEMON_TESTS CONFIGURE_DEPENDS "${SILKWORM_MAIN_SRC_DIR}/silkrpc/*_test.cpp")
+  add_executable(rpcdaemon_test unit_test.cpp ${SILKWORM_RPCDAEMON_TESTS})
+  if(SILKWORM_SANITIZE)
+    target_compile_definitions(rpcdaemon_test PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
+  endif()
+  target_include_directories(rpcdaemon_test PRIVATE
+          ${SILKWORM_MAIN_DIR}
+          ${SILKWORM_MAIN_SRC_DIR}/interfaces
+          ${SILKWORM_MAIN_DIR}/third_party/evmone/evmc/include)
+  target_link_libraries(rpcdaemon_test silkworm_node silkrpc asio-grpc::asio-grpc Catch2::Catch2 GTest::gmock)
+
+  # TO BE REMOVED: START: temporarily disable warnings entirely to make rpcdaemon_test compile as it is
+  get_target_property(RPCDAEMON_TEST_COMPILE_OPTIONS rpcdaemon_test COMPILE_OPTIONS)
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wall")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Werror")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wextra")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wshadow")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wimplicit-fallthrough")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wsign-conversion")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wno-missing-field-initializers")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wnon-virtual-dtor")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-Wthread-safety")
+  list(REMOVE_ITEM RPCDAEMON_TEST_COMPILE_OPTIONS "-pedantic")
+  set_property(TARGET rpcdaemon_test PROPERTY COMPILE_OPTIONS ${RPCDAEMON_TEST_COMPILE_OPTIONS})
+  # TO BE REMOVED: END: temporarily disable warnings entirely to make rpcdaemon_test compile as it is
+
+  include(CTest)
+  include(Catch)
+  catch_discover_tests(rpcdaemon_test)
+
+  # Silkworm Sentry Tests
+  file(GLOB_RECURSE SENTRY_TEST_FILES CONFIGURE_DEPENDS "${SILKWORM_MAIN_SRC_DIR}/sentry/*_test.cpp")
+  add_executable(sentry_test unit_test.cpp ${SENTRY_TEST_FILES})
+  if(SILKWORM_SANITIZE)
+    target_compile_definitions(sentry_test PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
+  endif()
+  target_link_libraries(sentry_test silkworm_node silkworm_sentry Catch2::Catch2 Microsoft.GSL::GSL)
+
+  # Silkworm Sync Tests
+  file(GLOB_RECURSE SILKWORM_SYNC_TESTS CONFIGURE_DEPENDS "${SILKWORM_MAIN_SRC_DIR}/sync/*_test.cpp")
+  add_executable(sync_test unit_test.cpp ${SILKWORM_SYNC_TESTS})
+  if(SILKWORM_SANITIZE)
+    target_compile_definitions(sync_test PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
+  endif()
+  target_link_libraries(sync_test silkworm_node silkworm_sync Catch2::Catch2)
 
   # Ethereum Consensus Tests
   if(NOT CONAN_PACKAGE_MANAGER)
@@ -75,18 +125,4 @@ if(NOT SILKWORM_CORE_ONLY)
   # BE&KV Tests
   add_executable(backend_kv_test backend_kv_test.cpp)
   target_link_libraries(backend_kv_test PRIVATE silkworm_node CLI11::CLI11)
-
-  # Sentry Tests
-  file(GLOB_RECURSE SENTRY_TEST_FILES CONFIGURE_DEPENDS "${SILKWORM_MAIN_SRC_DIR}/sentry/*_test.cpp")
-  add_executable(sentry_test unit_test.cpp ${SENTRY_TEST_FILES})
-  if(SILKWORM_SANITIZE)
-    target_compile_definitions(sentry_test PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
-  endif()
-  target_link_libraries(sentry_test
-    silkworm_sentry
-    silkworm_node
-    Catch2::Catch2
-    Microsoft.GSL::GSL
-  )
-
 endif()

--- a/silkworm/silkrpc/CMakeLists.txt
+++ b/silkworm/silkrpc/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[[
-   Copyright 2020 The SilkRpc Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -79,7 +79,6 @@ add_library(silkrpc ${SILKRPC_SRC} ${SILKWORM_INTERFACE_SRC})
 
 # TO BE REMOVED: START: temporarily disable warnings entirely to make silkrpc compile as it is
 get_target_property(SILKRPC_COMPILE_OPTIONS silkrpc COMPILE_OPTIONS)
-message(STATUS "COMPILE_OPTIONS before: ${SILKRPC_COMPILE_OPTIONS}")
 list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-Wall")
 list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-Werror")
 list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-Wextra")
@@ -91,9 +90,8 @@ list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-Wno-missing-field-initializers")
 list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-Wnon-virtual-dtor")
 list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-Wthread-safety")
 list(REMOVE_ITEM SILKRPC_COMPILE_OPTIONS "-pedantic")
-# TO BE REMOVED: END: temporarily disable warnings entirely to make silkrpc compile as it is
-
 set_property(TARGET silkrpc PROPERTY COMPILE_OPTIONS ${SILKRPC_COMPILE_OPTIONS})
+# TO BE REMOVED: END: temporarily disable warnings entirely to make silkrpc compile as it is
 
 add_dependencies(silkrpc generate_ethbackend_grpc generate_kv_grpc generate_mining_grpc generate_txpool_grpc)
 target_include_directories(silkrpc PUBLIC

--- a/silkworm/silkrpc/commands/net_api_test.cpp
+++ b/silkworm/silkrpc/commands/net_api_test.cpp
@@ -30,7 +30,7 @@ using Catch::Matchers::Message;
 TEST_CASE("NetRpcApi::NetRpcApi", "[silkrpc][erigon_api]") {
     boost::asio::io_context io_context;
     auto channel{grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials())};
-    agrpc::GrpcContext grpc_context{std::make_unique<grpc::CompletionQueue>()};
+    agrpc::GrpcContext grpc_context;
     std::unique_ptr<ethbackend::BackEnd> backend{
         std::make_unique<ethbackend::RemoteBackEnd>(io_context, channel, grpc_context)
     };

--- a/silkworm/silkrpc/core/evm_trace_test.cpp
+++ b/silkworm/silkrpc/core/evm_trace_test.cpp
@@ -26,7 +26,7 @@
 #include <gmock/gmock.h>
 #include <silkpre/precompile.h>
 #include <silkworm/core/common/util.hpp>
-#include <silkworm/third_party/evmone/evmc/include/evmc/instructions.h>
+#include <evmc/instructions.h>
 
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>

--- a/silkworm/silkrpc/protocol/version_test.cpp
+++ b/silkworm/silkrpc/protocol/version_test.cpp
@@ -26,16 +26,16 @@
 #include <grpcpp/server_builder.h>
 
 #include <silkworm/interfaces/remote/ethbackend.grpc.pb.h>
-#include <silkworm/interfaces/remote/ethbackend_mock_fix24351.grpc.pb.h>
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
-#include <silkworm/interfaces/remote/kv_mock_fix24351.grpc.pb.h>
 #include <silkworm/interfaces/txpool/mining.grpc.pb.h>
-#include <silkworm/interfaces/txpool/mining_mock_fix24351.grpc.pb.h>
 #include <silkworm/interfaces/txpool/txpool.grpc.pb.h>
-#include <silkworm/interfaces/txpool/txpool_mock_fix24351.grpc.pb.h>
 #include <silkworm/interfaces/types/types.pb.h>
 
 #include <silkworm/silkrpc/common/log.hpp>
+#include <silkworm/silkrpc/test/interfaces/ethbackend_mock_fix24351.grpc.pb.h>
+#include <silkworm/silkrpc/test/interfaces/kv_mock_fix24351.grpc.pb.h>
+#include <silkworm/silkrpc/test/interfaces/mining_mock_fix24351.grpc.pb.h>
+#include <silkworm/silkrpc/test/interfaces/txpool_mock_fix24351.grpc.pb.h>
 
 namespace silkrpc {
 

--- a/silkworm/silkrpc/test/interfaces/ethbackend_mock_fix24351.grpc.pb.h
+++ b/silkworm/silkrpc/test/interfaces/ethbackend_mock_fix24351.grpc.pb.h
@@ -1,0 +1,40 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Manually created to overcome grpcpp issue 24351 (https://github.com/grpc/grpc/issues/24351)
+
+#include <silkworm/interfaces/remote/ethbackend_mock.grpc.pb.h>
+
+namespace remote {
+
+class FixIssue24351_MockETHBACKENDStub : public MockETHBACKENDStub {
+ public:
+  MOCK_METHOD3(AsyncEtherbase, ::grpc::ClientAsyncResponseReaderInterface< ::remote::EtherbaseReply>*(::grpc::ClientContext* context, const ::remote::EtherbaseRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncEtherbase, ::grpc::ClientAsyncResponseReaderInterface< ::remote::EtherbaseReply>*(::grpc::ClientContext* context, const ::remote::EtherbaseRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncNetVersion, ::grpc::ClientAsyncResponseReaderInterface< ::remote::NetVersionReply>*(::grpc::ClientContext* context, const ::remote::NetVersionRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncNetVersion, ::grpc::ClientAsyncResponseReaderInterface< ::remote::NetVersionReply>*(::grpc::ClientContext* context, const ::remote::NetVersionRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncProtocolVersion, ::grpc::ClientAsyncResponseReaderInterface< ::remote::ProtocolVersionReply>*(::grpc::ClientContext* context, const ::remote::ProtocolVersionRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncProtocolVersion, ::grpc::ClientAsyncResponseReaderInterface< ::remote::ProtocolVersionReply>*(::grpc::ClientContext* context, const ::remote::ProtocolVersionRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncClientVersion, ::grpc::ClientAsyncResponseReaderInterface< ::remote::ClientVersionReply>*(::grpc::ClientContext* context, const ::remote::ClientVersionRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncClientVersion, ::grpc::ClientAsyncResponseReaderInterface< ::remote::ClientVersionReply>*(::grpc::ClientContext* context, const ::remote::ClientVersionRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD2(Subscribe, ::grpc::ClientReaderInterface< ::remote::SubscribeReply>*(::grpc::ClientContext* context, const ::remote::SubscribeRequest& request));
+  MOCK_METHOD4(AsyncSubscribe, ::grpc::ClientAsyncReaderInterface< ::remote::SubscribeReply>*(::grpc::ClientContext* context, const ::remote::SubscribeRequest& request, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD3(PrepareAsyncSubscribe, ::grpc::ClientAsyncReaderInterface< ::remote::SubscribeReply>*(::grpc::ClientContext* context, const ::remote::SubscribeRequest& request, ::grpc::CompletionQueue* cq));
+};
+
+} // namespace remote

--- a/silkworm/silkrpc/test/interfaces/kv_mock_fix24351.grpc.pb.h
+++ b/silkworm/silkrpc/test/interfaces/kv_mock_fix24351.grpc.pb.h
@@ -1,0 +1,35 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Manually created to overcome grpcpp issue 24351 (https://github.com/grpc/grpc/issues/24351)
+
+#include <silkworm/interfaces/remote/kv_mock.grpc.pb.h>
+
+namespace remote {
+
+class FixIssue24351_MockKVStub : public remote::MockKVStub {
+ public:
+  MOCK_METHOD3(AsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD1(Tx, ::grpc::ClientReaderWriterInterface< ::remote::Cursor, ::remote::Pair>*(::grpc::ClientContext* context));
+  MOCK_METHOD3(AsyncTx, ::grpc::ClientAsyncReaderWriterInterface<::remote::Cursor, ::remote::Pair>*(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD2(PrepareAsyncTx, ::grpc::ClientAsyncReaderWriterInterface<::remote::Cursor, ::remote::Pair>*(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD2(ReceiveStateChanges, ::grpc::ClientReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request));
+  MOCK_METHOD4(AsyncReceiveStateChanges, ::grpc::ClientAsyncReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD3(PrepareAsyncReceiveStateChanges, ::grpc::ClientAsyncReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+};
+
+} // namespace remote

--- a/silkworm/silkrpc/test/interfaces/mining_mock_fix24351.grpc.pb.h
+++ b/silkworm/silkrpc/test/interfaces/mining_mock_fix24351.grpc.pb.h
@@ -1,0 +1,45 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Manually created to overcome grpcpp issue 24351 (https://github.com/grpc/grpc/issues/24351)
+
+#include <silkworm/interfaces/txpool/mining_mock.grpc.pb.h>
+
+namespace txpool {
+
+class FixIssue24351_MockMiningStub : public MockMiningStub {
+ public:
+  MOCK_METHOD3(AsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD4(AsyncOnPendingBlock, ::grpc::ClientAsyncReaderInterface< ::txpool::OnPendingBlockReply>*(::grpc::ClientContext* context, const ::txpool::OnPendingBlockRequest& request, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD3(PrepareAsyncOnPendingBlock, ::grpc::ClientAsyncReaderInterface< ::txpool::OnPendingBlockReply>*(::grpc::ClientContext* context, const ::txpool::OnPendingBlockRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD4(AsyncOnMinedBlock, ::grpc::ClientAsyncReaderInterface< ::txpool::OnMinedBlockReply>*(::grpc::ClientContext* context, const ::txpool::OnMinedBlockRequest& request, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD2(OnPendingLogs, ::grpc::ClientReaderInterface< ::txpool::OnPendingLogsReply>*(::grpc::ClientContext* context, const ::txpool::OnPendingLogsRequest& request));
+  MOCK_METHOD4(AsyncOnPendingLogs, ::grpc::ClientAsyncReaderInterface< ::txpool::OnPendingLogsReply>*(::grpc::ClientContext* context, const ::txpool::OnPendingLogsRequest& request, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD3(PrepareAsyncOnPendingLogs, ::grpc::ClientAsyncReaderInterface< ::txpool::OnPendingLogsReply>*(::grpc::ClientContext* context, const ::txpool::OnPendingLogsRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncGetWork, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::GetWorkReply>*(::grpc::ClientContext* context, const ::txpool::GetWorkRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncGetWork, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::GetWorkReply>*(::grpc::ClientContext* context, const ::txpool::GetWorkRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncSubmitWork, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::SubmitWorkReply>*(::grpc::ClientContext* context, const ::txpool::SubmitWorkRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncSubmitWork, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::SubmitWorkReply>*(::grpc::ClientContext* context, const ::txpool::SubmitWorkRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncSubmitHashRate, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::SubmitHashRateReply>*(::grpc::ClientContext* context, const ::txpool::SubmitHashRateRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncSubmitHashRate, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::SubmitHashRateReply>*(::grpc::ClientContext* context, const ::txpool::SubmitHashRateRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncHashRate, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::HashRateReply>*(::grpc::ClientContext* context, const ::txpool::HashRateRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncHashRate, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::HashRateReply>*(::grpc::ClientContext* context, const ::txpool::HashRateRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncMining, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::MiningReply>*(::grpc::ClientContext* context, const ::txpool::MiningRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncMining, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::MiningReply>*(::grpc::ClientContext* context, const ::txpool::MiningRequest& request, ::grpc::CompletionQueue* cq));
+};
+
+} // namespace txpool

--- a/silkworm/silkrpc/test/interfaces/txpool_mock_fix24351.grpc.pb.h
+++ b/silkworm/silkrpc/test/interfaces/txpool_mock_fix24351.grpc.pb.h
@@ -1,0 +1,39 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Manually created to overcome grpcpp issue 24351 (https://github.com/grpc/grpc/issues/24351)
+
+#include <silkworm/interfaces/txpool/txpool_mock.grpc.pb.h>
+
+namespace txpool {
+
+class FixIssue24351_MockTxpoolStub : public MockTxpoolStub {
+ public:
+  MOCK_METHOD3(AsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncVersion, ::grpc::ClientAsyncResponseReaderInterface< ::types::VersionReply>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncFindUnknown, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::TxHashes>*(::grpc::ClientContext* context, const ::txpool::TxHashes& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncFindUnknown, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::TxHashes>*(::grpc::ClientContext* context, const ::txpool::TxHashes& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncAdd, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::AddReply>*(::grpc::ClientContext* context, const ::txpool::AddRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncAdd, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::AddReply>*(::grpc::ClientContext* context, const ::txpool::AddRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncTransactions, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::TransactionsReply>*(::grpc::ClientContext* context, const ::txpool::TransactionsRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncTransactions, ::grpc::ClientAsyncResponseReaderInterface< ::txpool::TransactionsReply>*(::grpc::ClientContext* context, const ::txpool::TransactionsRequest& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD2(OnAdd, ::grpc::ClientReaderInterface< ::txpool::OnAddReply>*(::grpc::ClientContext* context, const ::txpool::OnAddRequest& request));
+  MOCK_METHOD4(AsyncOnAdd, ::grpc::ClientAsyncReaderInterface< ::txpool::OnAddReply>*(::grpc::ClientContext* context, const ::txpool::OnAddRequest& request, ::grpc::CompletionQueue* cq, void* tag));
+  MOCK_METHOD3(PrepareAsyncOnAdd, ::grpc::ClientAsyncReaderInterface< ::txpool::OnAddReply>*(::grpc::ClientContext* context, const ::txpool::OnAddRequest& request, ::grpc::CompletionQueue* cq));
+};
+
+} // namespace txpool
+

--- a/silkworm/silkrpc/txpool/miner_test.cpp
+++ b/silkworm/silkrpc/txpool/miner_test.cpp
@@ -28,10 +28,11 @@
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/interfaces/txpool/mining.grpc.pb.h>
-#include <silkworm/interfaces/txpool/mining_mock_fix24351.grpc.pb.h>
+#include <silkworm/silkrpc/test/interfaces/mining_mock_fix24351.grpc.pb.h>
 #include <silkworm/silkrpc/test/api_test_base.hpp>
 #include <silkworm/silkrpc/test/grpc_actions.hpp>
 #include <silkworm/silkrpc/test/grpc_responder.hpp>
+
 #include <silkworm/core/common/base.hpp>
 
 namespace silkrpc::txpool {

--- a/silkworm/silkrpc/txpool/transaction_pool_test.cpp
+++ b/silkworm/silkrpc/txpool/transaction_pool_test.cpp
@@ -29,10 +29,10 @@
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/interfaces/txpool/txpool.grpc.pb.h>
-#include <silkworm/interfaces/txpool/txpool_mock_fix24351.grpc.pb.h>
 #include <silkworm/silkrpc/test/api_test_base.hpp>
 #include <silkworm/silkrpc/test/grpc_actions.hpp>
 #include <silkworm/silkrpc/test/grpc_responder.hpp>
+#include <silkworm/silkrpc/test/interfaces/txpool_mock_fix24351.grpc.pb.h>
 
 namespace grpc {
 

--- a/silkworm/sync/internals/body_sequence_test.cpp
+++ b/silkworm/sync/internals/body_sequence_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE("body downloading", "[silkworm][sync][BodySequence]") {
     test::Context context;
     context.add_genesis_data();
 
-    auto& txn{context.txn()};
+    auto& txn{context.rw_txn()};
 
     // add header 1 to db
     std::string raw_header1 =
@@ -447,7 +447,7 @@ TEST_CASE("body downloading", "[silkworm][sync][BodySequence]") {
         BlockHeader header2;
         header2.number = 2;
         header2.parent_hash = header1_hash;
-        auto txn2 = context.env().start_write();
+        db::RWTxn txn2{context.env()};
         db::write_canonical_header_hash(txn2, header2.hash().bytes, 1);
         db::write_canonical_header(txn2, header2);
         db::write_header(txn2, header2, true);


### PR DESCRIPTION
This PR continues the `SilkRpc` project integration. The main changes are:

- add the `rpcdaemon` folder in `cmd` with all `SilkRpc` command-line tools
- add `rpcdaemon_test` unit test runner

Moreover, the following changes have been included while working at the unit test runners:

- add missing custom gRPC mock files necessary to overcome [gRPC issue #24351](https://github.com/grpc/grpc/issues/24351)
- fix missing unit test runner for `sync` module
- fix `rpcdaemon` unit tests
- fix copyright
- fix `sync` unit tests

This PR requires #906 