### PR TITLE
node: add to_first API implementation in memory mutation

### DIFF
--- a/silkworm/node/db/memory_mutation.cpp
+++ b/silkworm/node/db/memory_mutation.cpp
@@ -35,6 +35,11 @@ MemoryOverlay::MemoryOverlay(const std::filesystem::path& tmp_dir) {
         .max_size = 512_Mebi,
     };
     memory_env_ = db::open_env(memory_config);
+
+    // Create predefined tables for chaindata schema
+    RWTxn txn{memory_env_};
+    table::check_or_create_chaindata_tables(txn);
+    txn.commit_and_stop();
 }
 
 MemoryOverlay::MemoryOverlay(MemoryOverlay&& other) noexcept : memory_env_(std::move(other.memory_env_)) {}
@@ -63,7 +68,7 @@ bool MemoryMutation::is_table_cleared(const std::string& bucket_name) const {
     return cleared_tables_.contains(bucket_name);
 }
 
-bool MemoryMutation::is_entry_deleted(const std::string& bucket_name, const Bytes& key) const {
+bool MemoryMutation::is_entry_deleted(const std::string& bucket_name, const Slice& key) const {
     if (!deleted_entries_.contains(bucket_name)) {
         return false;
     }

--- a/silkworm/node/db/memory_mutation.hpp
+++ b/silkworm/node/db/memory_mutation.hpp
@@ -45,7 +45,7 @@ class MemoryMutation : public RWTxn {
     ~MemoryMutation() override;
 
     [[nodiscard]] bool is_table_cleared(const std::string& bucket_name) const;
-    [[nodiscard]] bool is_entry_deleted(const std::string& bucket_name, const Bytes& key) const;
+    [[nodiscard]] bool is_entry_deleted(const std::string& bucket_name, const Slice& key) const;
 
     [[nodiscard]] db::ROTxn* external_txn() const { return txn_; }
 
@@ -64,7 +64,7 @@ class MemoryMutation : public RWTxn {
     MemoryOverlay& memory_db_;
     db::ROTxn* txn_;
     std::map<std::string, db::PooledCursor> stateless_cursors_;
-    std::map<std::string, Bytes> deleted_entries_;
+    std::map<std::string, Slice> deleted_entries_;
     std::map<std::string, bool> cleared_tables_;
 };
 

--- a/silkworm/node/db/memory_mutation_cursor.cpp
+++ b/silkworm/node/db/memory_mutation_cursor.cpp
@@ -276,6 +276,9 @@ CursorResult MemoryMutationCursor::next_by_type(MemoryMutationCursor::NextType t
         case NextType::kNoDup: {
             return cursor_->to_next_first_multi(throw_notfound);
         }
+        default: {
+            return CursorResult{::mdbx::cursor{}, throw_notfound};
+        }
     }
 }
 

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -22,52 +22,133 @@
 
 namespace silkworm::db {
 
-TEST_CASE("MemoryMutationCursor", "[silkworm][node][db][memory_mutation_cursor]") {
+const MapConfig kTestMap{"TestTable"};
+const MapConfig kTestMultiMap{"TestMultiTable", mdbx::key_mode::usual, mdbx::value_mode::multi};
+
+static void fill_tables(RWTxn& rw_txn) {
+    db::PooledCursor rw_cursor1{rw_txn, kTestMap};
+    rw_cursor1.upsert(mdbx::slice{"AA"}, mdbx::slice{"00"});
+    rw_cursor1.upsert(mdbx::slice{"BB"}, mdbx::slice{"11"});
+    db::PooledCursor rw_cursor2{rw_txn, kTestMultiMap};
+    rw_cursor2.upsert(mdbx::slice{"AA"}, mdbx::slice{"00"});
+    rw_cursor2.upsert(mdbx::slice{"AA"}, mdbx::slice{"11"});
+    rw_cursor2.upsert(mdbx::slice{"AA"}, mdbx::slice{"22"});
+    rw_cursor2.upsert(mdbx::slice{"BB"}, mdbx::slice{"22"});
+    rw_txn.commit_and_renew();
+}
+
+static void alter_tables(RWTxn& rw_txn) {
+    db::PooledCursor rw_cursor1{rw_txn, kTestMap};
+    rw_cursor1.upsert(mdbx::slice{"CC"}, mdbx::slice{"22"});
+    db::PooledCursor rw_cursor2{rw_txn, kTestMultiMap};
+    rw_cursor2.upsert(mdbx::slice{"AA"}, mdbx::slice{"33"});
+    rw_cursor2.upsert(mdbx::slice{"BB"}, mdbx::slice{"33"});
+    rw_txn.commit_and_renew();
+}
+
+struct MemoryMutationCursorTest {
+    explicit MemoryMutationCursorTest() {
+        table::check_or_create_chaindata_tables(main_txn);
+        open_map(main_txn, kTestMap);
+        open_map(main_txn, kTestMultiMap);
+        main_txn.commit_and_renew();
+        open_map(mutation, kTestMap);
+        open_map(mutation, kTestMultiMap);
+        mutation.commit_and_renew();
+    }
+
+    void fill_main_tables() {
+        fill_tables(main_txn);
+    }
+
+    void fill_mutation_tables() {
+        fill_tables(mutation);
+    }
+
+    void alter_main_tables() {
+        alter_tables(main_txn);
+    }
+
+    void alter_mutation_tables() {
+        alter_tables(mutation);
+    }
+
     const TemporaryDirectory tmp_dir;
-    DataDirectory data_dir{tmp_dir.path() / "main_db"};
-    data_dir.deploy();
+    DataDirectory data_dir{tmp_dir.path() / "main_db", true};
     db::EnvConfig main_db_config{
         .path = data_dir.chaindata().path().string(),
         .create = true,
         .in_memory = true,
     };
-    auto main_env{db::open_env(main_db_config)};
+    mdbx::env_managed main_env{db::open_env(main_db_config)};
     RWTxn main_txn{main_env};
-    MemoryOverlay overlay{tmp_dir.path() / "silkworm_mem_db"};
+    MemoryOverlay overlay{tmp_dir.path()};
     MemoryMutation mutation{overlay, &main_txn};
-    const MapConfig svt_config{
-        .name = "SingleValueTable",
-    };
-    open_map(main_txn, svt_config);
-    open_map(mutation, svt_config);
+};
+
+TEST_CASE("MemoryMutationCursor", "[silkworm][node][db][memory_mutation_cursor]") {
+    MemoryMutationCursorTest test;
+    test.fill_main_tables();
 
     SECTION("Create one memory mutation cursor") {
-        CHECK_NOTHROW(MemoryMutationCursor{mutation, svt_config});
+        CHECK_NOTHROW(MemoryMutationCursor{test.mutation, kTestMap});
+        CHECK_NOTHROW(MemoryMutationCursor{test.mutation, kTestMultiMap});
     }
 
     SECTION("Create many memory mutation cursors") {
         std::vector<std::unique_ptr<MemoryMutationCursor>> memory_cursors;
         for (int i{0}; i < 10; ++i) {
-            CHECK_NOTHROW(memory_cursors.emplace_back(std::make_unique<MemoryMutationCursor>(mutation, svt_config)));
+            CHECK_NOTHROW(memory_cursors.emplace_back(std::make_unique<MemoryMutationCursor>(test.mutation, kTestMap)));
+            CHECK_NOTHROW(memory_cursors.emplace_back(std::make_unique<MemoryMutationCursor>(test.mutation, kTestMultiMap)));
         }
     }
 
     SECTION("Check initial values") {
-        MemoryMutationCursor mutation_cursor{mutation, svt_config};
+        MemoryMutationCursor mutation_cursor{test.mutation, kTestMap};
         CHECK_NOTHROW(!mutation_cursor.is_table_cleared());
-        CHECK_NOTHROW(!mutation_cursor.is_entry_deleted(Bytes{}));
+        CHECK_NOTHROW(!mutation_cursor.is_entry_deleted(Slice{}));
     }
 
-    MemoryMutationCursor mutation_cursor{mutation, svt_config};
-
-    SECTION("to_first") {
-        // TODO(canepat) placeholder: code to-be-tested not implemented yet
-        CHECK_THROWS_AS(mutation_cursor.to_first(), std::invalid_argument);
+    SECTION("Check predefined tables") {
+        for (const auto& table : table::kChainDataTables) {
+            MemoryMutationCursor mutation_cursor{test.mutation, table};
+            CHECK_NOTHROW(has_map(test.mutation, table.name));
+            CHECK_NOTHROW(!mutation_cursor.is_table_cleared());
+            CHECK_NOTHROW(!mutation_cursor.is_entry_deleted(Slice{}));
+        }
     }
 
-    SECTION("to_last") {
-        // TODO(canepat) placeholder: code to-be-tested not implemented yet
-        CHECK_THROWS_AS(mutation_cursor.to_last(), std::invalid_argument);
+    SECTION("Empty kTestMap: to_first") {
+        MemoryMutationCursor mutation_cursor{test.mutation, kTestMap};
+        const auto result = mutation_cursor.to_first();
+        CHECK(result);
+        if (result) {
+            CHECK(result.key == "AA");
+            CHECK(result.value == "00");
+        }
+        CHECK(mutation_cursor.to_first(false));
+    }
+
+    test.fill_mutation_tables();
+
+    SECTION("Check tables") {
+        for (const auto& table : {kTestMap, kTestMultiMap}) {
+            MemoryMutationCursor mutation_cursor{test.mutation, table};
+            CHECK_NOTHROW(mutation_cursor.to_first());
+            CHECK_NOTHROW(!mutation_cursor.is_table_cleared());
+            CHECK_NOTHROW(!mutation_cursor.is_entry_deleted(Slice{}));
+        }
+    }
+
+    SECTION("Non-empty kTestMap: to_first") {
+        MemoryMutationCursor mutation_cursor{test.mutation, kTestMap};
+        const auto result = mutation_cursor.to_first();
+        CHECK(result);
+        if (result) {
+            CHECK(result.key == "AA");
+            CHECK(result.value == "00");
+        }
+        CHECK(mutation_cursor.to_first(false));
     }
 }
 

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -26,7 +26,9 @@ const MapConfig kTestMap{"TestTable"};
 const MapConfig kTestMultiMap{"TestMultiTable", mdbx::key_mode::usual, mdbx::value_mode::multi};
 
 // Avoid false positive from TSAN on potential cycle lock acquisition
-[[gnu::no_sanitize_thread, clang::no_sanitize("thread")]] static mdbx::env_managed create_main_env(const db::EnvConfig& main_db_config) {
+#define DISABLE_TSAN [[gnu::no_sanitize_thread, clang::no_sanitize("thread")]]
+
+static mdbx::env_managed create_main_env(const db::EnvConfig& main_db_config) {
     auto main_env = db::open_env(main_db_config);
     RWTxn main_txn{main_env};
     table::check_or_create_chaindata_tables(main_txn);
@@ -58,13 +60,13 @@ static void alter_tables(RWTxn& rw_txn) {
 }
 
 struct MemoryMutationCursorTest {
-    explicit MemoryMutationCursorTest() {
+    DISABLE_TSAN explicit MemoryMutationCursorTest() {
         open_map(mutation, kTestMap);
         open_map(mutation, kTestMultiMap);
         mutation.commit_and_renew();
     }
 
-    void fill_main_tables() {
+    DISABLE_TSAN void fill_main_tables() {
         fill_tables(main_txn);
     }
 

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -25,6 +25,8 @@ namespace silkworm::db {
 const MapConfig kTestMap{"TestTable"};
 const MapConfig kTestMultiMap{"TestMultiTable", mdbx::key_mode::usual, mdbx::value_mode::multi};
 
+// Avoid false positive from TSAN on potential cycle lock acquisition
+[[gnu::no_sanitize_thread, clang::no_sanitize("thread")]]
 static mdbx::env_managed create_main_env(const db::EnvConfig& main_db_config) {
     auto main_env = db::open_env(main_db_config);
     RWTxn main_txn{main_env};

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -26,8 +26,7 @@ const MapConfig kTestMap{"TestTable"};
 const MapConfig kTestMultiMap{"TestMultiTable", mdbx::key_mode::usual, mdbx::value_mode::multi};
 
 // Avoid false positive from TSAN on potential cycle lock acquisition
-[[gnu::no_sanitize_thread, clang::no_sanitize("thread")]]
-static mdbx::env_managed create_main_env(const db::EnvConfig& main_db_config) {
+[[gnu::no_sanitize_thread, clang::no_sanitize("thread")]] static mdbx::env_managed create_main_env(const db::EnvConfig& main_db_config) {
     auto main_env = db::open_env(main_db_config);
     RWTxn main_txn{main_env};
     table::check_or_create_chaindata_tables(main_txn);

--- a/silkworm/node/db/memory_mutation_test.cpp
+++ b/silkworm/node/db/memory_mutation_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("MemoryMutation", "[silkworm][node][db][memory_mutation]") {
     };
     auto main_env{db::open_env(main_db_config)};
     RWTxn main_rw_txn{main_env};
-    MemoryOverlay overlay{tmp_dir.path() / "silkworm_mem_db"};
+    MemoryOverlay overlay{tmp_dir.path()};
 
     SECTION("Create one memory mutation") {
         CHECK_NOTHROW(MemoryMutation{overlay, &main_rw_txn});
@@ -65,7 +65,7 @@ TEST_CASE("MemoryMutation", "[silkworm][node][db][memory_mutation]") {
         MemoryMutation mutation{overlay, &main_rw_txn};
         CHECK_NOTHROW(mutation.external_txn() == &main_rw_txn);
         CHECK_NOTHROW(!mutation.is_table_cleared("TestTable"));
-        CHECK_NOTHROW(!mutation.is_entry_deleted("TestTable", Bytes{}));
+        CHECK_NOTHROW(!mutation.is_entry_deleted("TestTable", Slice{}));
     }
 
     SECTION("Cannot create two memory mutations") {

--- a/silkworm/node/db/memory_mutation_test.cpp
+++ b/silkworm/node/db/memory_mutation_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("MemoryOverlay", "[silkworm][node][db][memory_mutation]") {
         MemoryOverlay overlay{tmp_dir.path()};
         ::mdbx::txn_managed rw_txn;
         CHECK_NOTHROW((rw_txn = overlay.start_rw_tx()));
-        CHECK(rw_txn.env().is_empty());
+        CHECK(!rw_txn.env().is_empty());
     }
 
     SECTION("Cannot create more than one R/W transaction in a temporary database") {


### PR DESCRIPTION
This PR introduces the following changes to the memory mutation abstraction:

- `to_first` API implementation
- creation of schema tables
- priority resolution for db and memory cursor