### PR TITLE
sentry: GRPC client

### DIFF
--- a/silkworm/node/backend/rpc/sentry_client.cpp
+++ b/silkworm/node/backend/rpc/sentry_client.cpp
@@ -40,18 +40,18 @@ boost::asio::awaitable<PeerCountResult> RemoteSentryClient::peer_count() {
     SILK_TRACE << "RemoteSentryClient::peer_count START address: " << address_uri_;
     sentry::PeerCountRequest request;
     sentry::PeerCountReply reply;
-    const auto status = co_await unary_rpc(&sentry::Sentry::Stub::AsyncPeerCount, stub_, request, reply, grpc_context_);
-    SILK_TRACE << "RemoteSentryClient::peer_count END address: " << address_uri_ << " " << status;
-    co_return PeerCountResult{status, reply};
+    co_await unary_rpc(&sentry::Sentry::Stub::AsyncPeerCount, stub_, request, reply, grpc_context_);
+    SILK_TRACE << "RemoteSentryClient::peer_count END address: " << address_uri_;
+    co_return reply;
 }
 
 boost::asio::awaitable<NodeInfoResult> RemoteSentryClient::node_info() {
     SILK_TRACE << "RemoteSentryClient::node_info START address: " << address_uri_;
     google::protobuf::Empty request;
     types::NodeInfoReply reply;
-    const auto status = co_await unary_rpc(&sentry::Sentry::Stub::AsyncNodeInfo, stub_, request, reply, grpc_context_);
-    SILK_TRACE << "RemoteSentryClient::node_info END address: " << address_uri_ << " " << status;
-    co_return NodeInfoResult{status, reply};
+    co_await unary_rpc(&sentry::Sentry::Stub::AsyncNodeInfo, stub_, request, reply, grpc_context_);
+    SILK_TRACE << "RemoteSentryClient::node_info END address: " << address_uri_;
+    co_return reply;
 }
 
 boost::asio::awaitable<SetStatusResult> RemoteSentryClient::set_status(SentryStatus sentry_status) {
@@ -70,9 +70,9 @@ boost::asio::awaitable<SetStatusResult> RemoteSentryClient::set_status(SentrySta
     }
     request.set_allocated_fork_data(forks);
     sentry::SetStatusReply reply;
-    const auto status = co_await unary_rpc(&sentry::Sentry::Stub::AsyncSetStatus, stub_, request, reply, grpc_context_);
-    SILK_TRACE << "RemoteSentryClient::set_status END address: " << address_uri_ << " " << status;
-    co_return SetStatusResult{status, reply};
+    co_await unary_rpc(&sentry::Sentry::Stub::AsyncSetStatus, stub_, request, reply, grpc_context_);
+    SILK_TRACE << "RemoteSentryClient::set_status END address: " << address_uri_;
+    co_return reply;
 }
 
 std::unique_ptr<SentryClient> RemoteSentryClientFactory::make_sentry_client(const std::string& address_uri) {

--- a/silkworm/node/backend/rpc/sentry_client.hpp
+++ b/silkworm/node/backend/rpc/sentry_client.hpp
@@ -19,7 +19,6 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include <tuple>
 #include <unordered_set>
 
 #include <silkworm/node/concurrency/coroutine.hpp>
@@ -51,9 +50,9 @@ struct SentryStatus {
 
 class SentryClient {
   public:
-    using SetStatusResult = std::pair<grpc::Status, sentry::SetStatusReply>;
-    using PeerCountResult = std::pair<grpc::Status, sentry::PeerCountReply>;
-    using NodeInfoResult = std::pair<grpc::Status, types::NodeInfoReply>;
+    using SetStatusResult = sentry::SetStatusReply;
+    using PeerCountResult = sentry::PeerCountReply;
+    using NodeInfoResult = types::NodeInfoReply;
 
     virtual ~SentryClient() = default;
 

--- a/silkworm/node/rpc/client/call.hpp
+++ b/silkworm/node/rpc/client/call.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 
@@ -59,6 +60,41 @@ boost::asio::awaitable<void> unary_rpc(
 
     grpc::Status status;
     co_await agrpc::finish(reader, reply, status, boost::asio::bind_executor(grpc_context, boost::asio::use_awaitable));
+
+    if (!status.ok()) {
+        throw GrpcStatusError(std::move(status));
+    }
+}
+
+template <class Stub, class Request, class Response>
+boost::asio::awaitable<void> streaming_rpc(
+    agrpc::detail::PrepareAsyncClientServerStreamingRequest<Stub, Request, grpc::ClientAsyncReader<Response>> rpc,
+    std::unique_ptr<Stub>& stub,
+    Request request,
+    agrpc::GrpcContext& grpc_context,
+    std::function<boost::asio::awaitable<void>(Response)> consumer) {
+    grpc::ClientContext client_context;
+    client_context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10));
+
+    std::unique_ptr<grpc::ClientAsyncReader<Response>> reader;
+    bool ok = co_await agrpc::request(
+        rpc,
+        stub,
+        client_context,
+        std::move(request),
+        reader,
+        boost::asio::bind_executor(grpc_context, boost::asio::use_awaitable));
+
+    while (ok) {
+        Response response;
+        ok = co_await agrpc::read(reader, response, boost::asio::bind_executor(grpc_context, boost::asio::use_awaitable));
+        if (ok) {
+            co_await consumer(std::move(response));
+        }
+    }
+
+    grpc::Status status;
+    co_await agrpc::finish(reader, status, boost::asio::bind_executor(grpc_context, boost::asio::use_awaitable));
 
     if (!status.ok()) {
         throw GrpcStatusError(std::move(status));

--- a/silkworm/node/rpc/client/call.hpp
+++ b/silkworm/node/rpc/client/call.hpp
@@ -16,27 +16,53 @@
 
 #pragma once
 
+#include <chrono>
+#include <memory>
 #include <stdexcept>
-#include <utility>  // for std::exchange in Boost 1.78, fixed in Boost 1.79
+
+#include <silkworm/node/concurrency/coroutine.hpp>
 
 #include <agrpc/detail/rpc.hpp>
 #include <agrpc/grpc_context.hpp>
 #include <agrpc/rpc.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <grpcpp/grpcpp.h>
 
 namespace silkworm::rpc {
 
-template <class Stub, class DerivedStub, class Request, class Response, class Responder>
-boost::asio::awaitable<grpc::Status> unary_rpc(agrpc::detail::ClientUnaryRequest<Stub, Request, Responder> rpc, DerivedStub& stub,
-                                               const Request& request, Response& reply, agrpc::GrpcContext& grpc_context) {
+class GrpcStatusError : public std::runtime_error {
+  public:
+    explicit GrpcStatusError(grpc::Status status)
+        : std::runtime_error(status.error_message()),
+          status_(std::move(status)) {}
+
+    [[nodiscard]] const grpc::Status& status() const { return status_; }
+
+  private:
+    grpc::Status status_;
+};
+
+template <class Stub, class Request, class Response>
+boost::asio::awaitable<void> unary_rpc(
+    agrpc::detail::ClientUnaryRequest<Stub, Request, grpc::ClientAsyncResponseReader<Response>> rpc,
+    std::unique_ptr<Stub>& stub,
+    const Request& request,
+    Response& reply,
+    agrpc::GrpcContext& grpc_context) {
     grpc::ClientContext client_context;
-    std::unique_ptr<grpc::ClientAsyncResponseReader<Response>> reader = agrpc::request(rpc, stub, client_context, request, grpc_context);
+    client_context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10));
+
+    std::unique_ptr<grpc::ClientAsyncResponseReader<Response>> reader =
+        agrpc::request(rpc, stub, client_context, request, grpc_context);
 
     grpc::Status status;
-    bool finish_ok = co_await agrpc::finish(reader, reply, status, boost::asio::bind_executor(grpc_context, boost::asio::use_awaitable));
-    if (!finish_ok) {
-        throw std::runtime_error{"unary RPC failed"};
+    co_await agrpc::finish(reader, reply, status, boost::asio::bind_executor(grpc_context, boost::asio::use_awaitable));
+
+    if (!status.ok()) {
+        throw GrpcStatusError(std::move(status));
     }
-    co_return status;
 }
 
 }  // namespace silkworm::rpc

--- a/silkworm/node/rpc/interfaces/types.cpp
+++ b/silkworm/node/rpc/interfaces/types.cpp
@@ -21,6 +21,7 @@
 #include <evmc/evmc.hpp>
 
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/node/rpc/common/conversion.hpp>
 
 namespace silkworm {
 
@@ -98,6 +99,10 @@ Hash hash_from_H256(const types::H256& orig) {
     return dest;
 }
 
+std::unique_ptr<types::H256> H256_from_hash(const Hash& orig) {
+    return rpc::H256_from_bytes32(orig);
+}
+
 constexpr uint64_t& lo_lo(intx::uint256& x) { return x[0]; }
 constexpr uint64_t& lo_hi(intx::uint256& x) { return x[1]; }
 constexpr uint64_t& hi_lo(intx::uint256& x) { return x[2]; }
@@ -113,6 +118,10 @@ intx::uint256 uint256_from_H256(const types::H256& orig) {
     lo_lo(dest) = orig.lo().lo();
 
     return dest;
+}
+
+std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig) {
+    return rpc::H256_from_uint256(orig);
 }
 
 }  // namespace silkworm

--- a/silkworm/node/rpc/interfaces/types.cpp
+++ b/silkworm/node/rpc/interfaces/types.cpp
@@ -24,7 +24,7 @@
 
 namespace silkworm {
 
-std::unique_ptr<types::H512> to_H512(const Bytes& orig) {
+std::unique_ptr<types::H512> H512_from_bytes(ByteView orig) {
     using types::H128, types::H256, types::H512, evmc::load64be;
 
     Bytes bytes(64, 0);

--- a/silkworm/node/rpc/interfaces/types.hpp
+++ b/silkworm/node/rpc/interfaces/types.hpp
@@ -24,8 +24,8 @@
 
 namespace silkworm {
 
-std::unique_ptr<types::H512> to_H512(const Bytes& orig);
 Bytes bytes_from_H512(const types::H512& orig);
+std::unique_ptr<types::H512> H512_from_bytes(ByteView orig);
 
 Hash hash_from_H256(const types::H256& orig);
 intx::uint256 uint256_from_H256(const types::H256& orig);

--- a/silkworm/sentry/api/api_common/service.hpp
+++ b/silkworm/sentry/api/api_common/service.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -24,7 +25,6 @@
 
 #include <boost/asio/awaitable.hpp>
 
-#include <silkworm/node/concurrency/channel.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/message.hpp>
 #include <silkworm/sentry/eth/status_data.hpp>
@@ -67,7 +67,9 @@ struct Service {
     virtual boost::asio::awaitable<void> peer_min_block(common::EccPublicKey public_key) = 0;
 
     // rpc Messages(MessagesRequest) returns (stream InboundMessage);
-    virtual boost::asio::awaitable<std::shared_ptr<concurrency::Channel<MessageFromPeer>>> messages(MessageIdSet message_id_filter) = 0;
+    virtual boost::asio::awaitable<void> messages(
+        MessageIdSet message_id_filter,
+        std::function<boost::asio::awaitable<void>(MessageFromPeer)> consumer) = 0;
 
     // rpc Peers(google.protobuf.Empty) returns (PeersReply);
     virtual boost::asio::awaitable<PeerInfos> peers() = 0;
@@ -85,7 +87,7 @@ struct Service {
     virtual boost::asio::awaitable<void> peer_useless(common::EccPublicKey public_key) = 0;
 
     // rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);
-    virtual boost::asio::awaitable<std::shared_ptr<concurrency::Channel<PeerEvent>>> peer_events() = 0;
+    virtual boost::asio::awaitable<void> peer_events(std::function<boost::asio::awaitable<void>(PeerEvent)> consumer) = 0;
 };
 
 }  // namespace silkworm::sentry::api::api_common

--- a/silkworm/sentry/api/router/direct_service.hpp
+++ b/silkworm/sentry/api/router/direct_service.hpp
@@ -37,14 +37,16 @@ class DirectService : api_common::Service {
     boost::asio::awaitable<PeerKeys> send_message_to_all(common::Message message) override;
     boost::asio::awaitable<PeerKeys> send_message_by_min_block(common::Message message, size_t max_peers) override;
     boost::asio::awaitable<void> peer_min_block(common::EccPublicKey public_key) override;
-    boost::asio::awaitable<std::shared_ptr<concurrency::Channel<api_common::MessageFromPeer>>> messages(api_common::MessageIdSet message_id_filter) override;
+    boost::asio::awaitable<void> messages(
+        api_common::MessageIdSet message_id_filter,
+        std::function<boost::asio::awaitable<void>(api_common::MessageFromPeer)> consumer) override;
 
     boost::asio::awaitable<api_common::PeerInfos> peers() override;
     boost::asio::awaitable<size_t> peer_count() override;
     boost::asio::awaitable<std::optional<api_common::PeerInfo>> peer_by_id(common::EccPublicKey public_key) override;
     boost::asio::awaitable<void> penalize_peer(common::EccPublicKey public_key) override;
     boost::asio::awaitable<void> peer_useless(common::EccPublicKey public_key) override;
-    boost::asio::awaitable<std::shared_ptr<concurrency::Channel<api_common::PeerEvent>>> peer_events() override;
+    boost::asio::awaitable<void> peer_events(std::function<boost::asio::awaitable<void>(api_common::PeerEvent)> consumer) override;
 
   private:
     ServiceRouter router_;

--- a/silkworm/sentry/common/enode_url.cpp
+++ b/silkworm/sentry/common/enode_url.cpp
@@ -18,6 +18,7 @@
 
 #include <regex>
 #include <sstream>
+#include <stdexcept>
 
 #include <boost/lexical_cast.hpp>
 

--- a/silkworm/sentry/rpc/client/sentry_client.cpp
+++ b/silkworm/sentry/rpc/client/sentry_client.cpp
@@ -1,0 +1,248 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "sentry_client.hpp"
+
+#include <stdexcept>
+
+#include <boost/asio/this_coro.hpp>
+#include <grpcpp/grpcpp.h>
+#include <p2psentry/sentry.grpc.pb.h>
+
+#include <silkworm/node/common/log.hpp>
+#include <silkworm/node/rpc/client/call.hpp>
+
+#include "../interfaces/eth_version.hpp"
+#include "../interfaces/message.hpp"
+#include "../interfaces/node_info.hpp"
+#include "../interfaces/peer_event.hpp"
+#include "../interfaces/peer_id.hpp"
+#include "../interfaces/peer_info.hpp"
+#include "../interfaces/sent_peer_ids.hpp"
+#include "../interfaces/status_data.hpp"
+
+namespace silkworm::sentry::rpc::client {
+
+using boost::asio::awaitable;
+namespace proto = ::sentry;
+using Stub = proto::Sentry::Stub;
+namespace sw_rpc = silkworm::rpc;
+using namespace api::api_common;
+
+static std::shared_ptr<grpc::Channel> make_grpc_channel(const std::string& address_uri) {
+    return grpc::CreateChannel(address_uri, grpc::InsecureChannelCredentials());
+}
+
+class SentryClientImpl final : public ISentryClient, private api::api_common::Service {
+  public:
+    explicit SentryClientImpl(const std::string& address_uri, agrpc::GrpcContext& grpc_context)
+        : stub_(proto::Sentry::NewStub(make_grpc_channel(address_uri))),
+          grpc_context_(grpc_context) {}
+
+    ~SentryClientImpl() override = default;
+
+    SentryClientImpl(const SentryClientImpl&) = delete;
+    SentryClientImpl& operator=(const SentryClientImpl&) = delete;
+
+    awaitable<void> service(std::function<awaitable<void>(api::api_common::Service&)> consumer) override {
+        return consumer(*this);
+    }
+
+  private:
+    // rpc SetStatus(StatusData) returns (SetStatusReply);
+    awaitable<void> set_status(eth::StatusData status_data) override {
+        proto::StatusData request = interfaces::proto_status_data_from_status_data(status_data);
+        proto::SetStatusReply reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncSetStatus, stub_, request, reply, grpc_context_);
+    }
+
+    // rpc HandShake(google.protobuf.Empty) returns (HandShakeReply);
+    awaitable<uint8_t> handshake() override {
+        google::protobuf::Empty request;
+        proto::HandShakeReply reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncHandShake, stub_, request, reply, grpc_context_);
+        uint8_t result = interfaces::eth_version_from_protocol(reply.protocol());
+        co_return result;
+    }
+
+    // rpc NodeInfo(google.protobuf.Empty) returns(types.NodeInfoReply);
+    awaitable<NodeInfo> node_info() override {
+        google::protobuf::Empty request;
+        types::NodeInfoReply reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncNodeInfo, stub_, request, reply, grpc_context_);
+        auto result = interfaces::node_info_from_proto_node_info(reply);
+        co_return result;
+    }
+
+    // rpc SendMessageById(SendMessageByIdRequest) returns (SentPeers);
+    awaitable<PeerKeys> send_message_by_id(common::Message message, common::EccPublicKey public_key) override {
+        proto::SendMessageByIdRequest request;
+        request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
+        request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
+
+        proto::SentPeers reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageById, stub_, request, reply, grpc_context_);
+        auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
+        co_return result;
+    }
+
+    // rpc SendMessageToRandomPeers(SendMessageToRandomPeersRequest) returns (SentPeers);
+    awaitable<PeerKeys> send_message_to_random_peers(common::Message message, size_t max_peers) override {
+        proto::SendMessageToRandomPeersRequest request;
+        request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
+        request.set_max_peers(max_peers);
+
+        proto::SentPeers reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageToRandomPeers, stub_, request, reply, grpc_context_);
+        auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
+        co_return result;
+    }
+
+    // rpc SendMessageToAll(OutboundMessageData) returns (SentPeers);
+    awaitable<PeerKeys> send_message_to_all(common::Message message) override {
+        proto::OutboundMessageData request = interfaces::outbound_data_from_message(message);
+        proto::SentPeers reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageToAll, stub_, request, reply, grpc_context_);
+        auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
+        co_return result;
+    }
+
+    // rpc SendMessageByMinBlock(SendMessageByMinBlockRequest) returns (SentPeers);
+    awaitable<PeerKeys> send_message_by_min_block(common::Message message, size_t max_peers) override {
+        proto::SendMessageByMinBlockRequest request;
+        request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
+        // TODO: set_min_block
+        // request.set_min_block()
+        request.set_max_peers(max_peers);
+
+        proto::SentPeers reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageByMinBlock, stub_, request, reply, grpc_context_);
+        auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
+        co_return result;
+    }
+
+    // rpc PeerMinBlock(PeerMinBlockRequest) returns (google.protobuf.Empty);
+    awaitable<void> peer_min_block(common::EccPublicKey public_key) override {
+        proto::PeerMinBlockRequest request;
+        request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
+        // TODO: set_min_block
+        // request.set_min_block()
+        google::protobuf::Empty reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerMinBlock, stub_, request, reply, grpc_context_);
+    }
+
+    // rpc Messages(MessagesRequest) returns (stream InboundMessage);
+    awaitable<void> messages(
+        MessageIdSet message_id_filter,
+        std::function<awaitable<void>(MessageFromPeer)> consumer) override {
+        proto::MessagesRequest request = interfaces::messages_request_from_message_id_set(message_id_filter);
+
+        std::function<awaitable<void>(proto::InboundMessage)> proto_consumer =
+            [consumer = std::move(consumer)](proto::InboundMessage message) -> awaitable<void> {
+            MessageFromPeer message_from_peer{
+                interfaces::message_from_inbound_message(message),
+                {interfaces::peer_public_key_from_id(message.peer_id())},
+            };
+            co_await consumer(std::move(message_from_peer));
+        };
+
+        co_await sw_rpc::streaming_rpc(
+            &Stub::PrepareAsyncMessages,
+            stub_,
+            std::move(request),
+            grpc_context_,
+            std::move(proto_consumer));
+    }
+
+    // rpc Peers(google.protobuf.Empty) returns (PeersReply);
+    awaitable<PeerInfos> peers() override {
+        google::protobuf::Empty request;
+        proto::PeersReply reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeers, stub_, request, reply, grpc_context_);
+        auto result = interfaces::peer_infos_from_proto_peers_reply(reply);
+        co_return result;
+    }
+
+    // rpc PeerCount(PeerCountRequest) returns (PeerCountReply);
+    awaitable<size_t> peer_count() override {
+        proto::PeerCountRequest request;
+        proto::PeerCountReply reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerCount, stub_, request, reply, grpc_context_);
+        auto result = static_cast<size_t>(reply.count());
+        co_return result;
+    }
+
+    // rpc PeerById(PeerByIdRequest) returns (PeerByIdReply);
+    awaitable<std::optional<PeerInfo>> peer_by_id(common::EccPublicKey public_key) override {
+        proto::PeerByIdRequest request;
+        request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
+        proto::PeerByIdReply reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerById, stub_, request, reply, grpc_context_);
+        auto result = interfaces::peer_info_opt_from_proto_peer_reply(reply);
+        co_return result;
+    }
+
+    // rpc PenalizePeer(PenalizePeerRequest) returns (google.protobuf.Empty);
+    awaitable<void> penalize_peer(common::EccPublicKey public_key) override {
+        proto::PenalizePeerRequest request;
+        request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
+        request.set_penalty(proto::PenaltyKind::Kick);
+        google::protobuf::Empty reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPenalizePeer, stub_, request, reply, grpc_context_);
+    }
+
+    // rpc PeerUseless(PeerUselessRequest) returns (google.protobuf.Empty);
+    awaitable<void> peer_useless(common::EccPublicKey public_key) override {
+        proto::PeerUselessRequest request;
+        request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
+        google::protobuf::Empty reply;
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerUseless, stub_, request, reply, grpc_context_);
+    }
+
+    // rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);
+    awaitable<void> peer_events(
+        std::function<awaitable<void>(PeerEvent)> consumer) override {
+        proto::PeerEventsRequest request;
+
+        std::function<awaitable<void>(proto::PeerEvent)> proto_consumer =
+            [consumer = std::move(consumer)](proto::PeerEvent event) -> awaitable<void> {
+            co_await consumer(interfaces::peer_event_from_proto_peer_event(event));
+        };
+
+        co_await sw_rpc::streaming_rpc(
+            &Stub::PrepareAsyncPeerEvents,
+            stub_,
+            std::move(request),
+            grpc_context_,
+            std::move(proto_consumer));
+    }
+
+    std::unique_ptr<Stub> stub_;
+    agrpc::GrpcContext& grpc_context_;
+};
+
+SentryClient::SentryClient(const std::string& address_uri, agrpc::GrpcContext& grpc_context)
+    : p_impl_(std::make_unique<SentryClientImpl>(address_uri, grpc_context)) {}
+
+SentryClient::~SentryClient() {
+    log::Trace() << "silkworm::sentry::rpc::client::SentryClient::~SentryClient";
+}
+
+awaitable<void> SentryClient::service(std::function<awaitable<void>(api::api_common::Service&)> consumer) {
+    return p_impl_->service(std::move(consumer));
+}
+
+}  // namespace silkworm::sentry::rpc::client

--- a/silkworm/sentry/rpc/client/sentry_client.hpp
+++ b/silkworm/sentry/rpc/client/sentry_client.hpp
@@ -1,0 +1,65 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <silkworm/node/concurrency/coroutine.hpp>
+
+#include <agrpc/detail/forward.hpp>
+#include <boost/asio/awaitable.hpp>
+
+#include <silkworm/sentry/api/api_common/service.hpp>
+
+namespace silkworm::sentry::rpc::client {
+
+// TODO: move to a common place for all clients
+struct ISentryClient {
+    virtual ~ISentryClient() = 0;
+
+    virtual boost::asio::awaitable<void> service(std::function<boost::asio::awaitable<void>(api::api_common::Service&)> consumer) = 0;
+
+    template <typename TResult>
+    boost::asio::awaitable<TResult> service(std::function<boost::asio::awaitable<TResult>(api::api_common::Service&)> consumer) {
+        std::optional<TResult> result;
+        co_await service([consumer = std::move(consumer), &result](api::api_common::Service& service) -> boost::asio::awaitable<void> {
+            *result = co_await consumer(service);
+        });
+        co_return std::move(*result);
+    }
+};
+
+class SentryClientImpl;
+
+class SentryClient : public ISentryClient {
+  public:
+    explicit SentryClient(const std::string& address_uri, agrpc::GrpcContext& grpc_context);
+    ~SentryClient() override;
+
+    SentryClient(const SentryClient&) = delete;
+    SentryClient& operator=(const SentryClient&) = delete;
+
+    boost::asio::awaitable<void> service(std::function<boost::asio::awaitable<void>(api::api_common::Service&)> consumer) override;
+
+  private:
+    std::unique_ptr<SentryClientImpl> p_impl_;
+};
+
+}  // namespace silkworm::sentry::rpc::client

--- a/silkworm/sentry/rpc/interfaces/eth_version.cpp
+++ b/silkworm/sentry/rpc/interfaces/eth_version.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
    limitations under the License.
 */
 
-#pragma once
-
-#include <string>
-
-#include <silkworm/interfaces/types/types.pb.h>
-#include <silkworm/sentry/common/ecc_public_key.hpp>
+#include "eth_version.hpp"
 
 namespace silkworm::sentry::rpc::interfaces {
 
-sentry::common::EccPublicKey peer_public_key_from_id(const ::types::H512& peer_id);
-::types::H512 peer_id_from_public_key(const sentry::common::EccPublicKey& key);
+namespace proto = ::sentry;
 
-sentry::common::EccPublicKey peer_public_key_from_id_string(const std::string& peer_id_str);
-std::string peer_id_string_from_public_key(const sentry::common::EccPublicKey& key);
+uint8_t eth_version_from_protocol(proto::Protocol protocol) {
+    assert(proto::Protocol_MIN == proto::Protocol::ETH65);
+    return static_cast<uint8_t>(protocol) + 65;
+}
+
+proto::Protocol protocol_from_eth_version(uint8_t version) {
+    assert(proto::Protocol_MIN == proto::Protocol::ETH65);
+    return static_cast<proto::Protocol>(version - 65);
+}
 
 }  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/eth_version.hpp
+++ b/silkworm/sentry/rpc/interfaces/eth_version.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,21 +16,11 @@
 
 #pragma once
 
-#include <intx/intx.hpp>
-#include <types/types.pb.h>
+#include <silkworm/interfaces/p2psentry/sentry.grpc.pb.h>
 
-#include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/hash.hpp>
+namespace silkworm::sentry::rpc::interfaces {
 
-namespace silkworm {
+uint8_t eth_version_from_protocol(::sentry::Protocol protocol);
+::sentry::Protocol protocol_from_eth_version(uint8_t version);
 
-Bytes bytes_from_H512(const types::H512& orig);
-std::unique_ptr<types::H512> H512_from_bytes(ByteView orig);
-
-Hash hash_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_hash(const Hash& orig);
-
-intx::uint256 uint256_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig);
-
-}  // namespace silkworm
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/message.cpp
+++ b/silkworm/sentry/rpc/interfaces/message.cpp
@@ -101,7 +101,7 @@ static proto::MessageId proto_message_id_from_eth_id(eth::MessageId eth_id) {
     }
 }
 
-uint8_t message_id(proto::MessageId proto_id) {
+uint8_t message_id_from_proto_message_id(proto::MessageId proto_id) {
     auto eth_id = eth_message_id(proto_id);
     assert(eth_id.has_value());
     if (!eth_id)
@@ -110,7 +110,7 @@ uint8_t message_id(proto::MessageId proto_id) {
     return (static_cast<uint8_t>(eth_id.value()) + eth::StatusMessage::kId);
 }
 
-static proto::MessageId proto_message_id(uint8_t message_id) {
+proto::MessageId proto_message_id_from_message_id(uint8_t message_id) {
     assert(message_id >= eth::StatusMessage::kId);
     if (message_id < eth::StatusMessage::kId)
         return proto::STATUS_66;
@@ -124,15 +124,46 @@ static Bytes bytes_from_string(const std::string& s) {
 
 sentry::common::Message message_from_outbound_data(const proto::OutboundMessageData& message_data) {
     return {
-        message_id(message_data.id()),
+        message_id_from_proto_message_id(message_data.id()),
+        bytes_from_string(message_data.data()),
+    };
+}
+
+proto::OutboundMessageData outbound_data_from_message(const sentry::common::Message& message) {
+    proto::OutboundMessageData result;
+    result.set_id(proto_message_id_from_message_id(message.id));
+    result.set_data(message.data.data(), message.data.size());
+    return result;
+}
+
+sentry::common::Message message_from_inbound_message(const ::sentry::InboundMessage& message_data) {
+    return {
+        message_id_from_proto_message_id(message_data.id()),
         bytes_from_string(message_data.data()),
     };
 }
 
 proto::InboundMessage inbound_message_from_message(const sentry::common::Message& message) {
     proto::InboundMessage result;
-    result.set_id(proto_message_id(message.id));
+    result.set_id(proto_message_id_from_message_id(message.id));
     result.set_data(message.data.data(), message.data.size());
+    return result;
+}
+
+api::api_common::MessageIdSet message_id_set_from_messages_request(const proto::MessagesRequest& request) {
+    api::api_common::MessageIdSet filter;
+    for (int i = 0; i < request.ids_size(); i++) {
+        auto id = request.ids(i);
+        filter.insert(message_id_from_proto_message_id(id));
+    }
+    return filter;
+}
+
+proto::MessagesRequest messages_request_from_message_id_set(const api::api_common::MessageIdSet& message_ids) {
+    proto::MessagesRequest result;
+    for (auto id : message_ids) {
+        result.add_ids(proto_message_id_from_message_id(id));
+    }
     return result;
 }
 

--- a/silkworm/sentry/rpc/interfaces/message.hpp
+++ b/silkworm/sentry/rpc/interfaces/message.hpp
@@ -17,14 +17,21 @@
 #pragma once
 
 #include <silkworm/interfaces/p2psentry/sentry.grpc.pb.h>
+#include <silkworm/sentry/api/api_common/message_id_set.hpp>
 #include <silkworm/sentry/common/message.hpp>
 
 namespace silkworm::sentry::rpc::interfaces {
 
 sentry::common::Message message_from_outbound_data(const ::sentry::OutboundMessageData& message_data);
+::sentry::OutboundMessageData outbound_data_from_message(const sentry::common::Message& message);
 
+sentry::common::Message message_from_inbound_message(const ::sentry::InboundMessage& message);
 ::sentry::InboundMessage inbound_message_from_message(const sentry::common::Message& message);
 
-uint8_t message_id(::sentry::MessageId proto_id);
+uint8_t message_id_from_proto_message_id(::sentry::MessageId message_id);
+::sentry::MessageId proto_message_id_from_message_id(uint8_t message_id);
+
+api::api_common::MessageIdSet message_id_set_from_messages_request(const ::sentry::MessagesRequest& request);
+::sentry::MessagesRequest messages_request_from_message_id_set(const api::api_common::MessageIdSet& message_ids);
 
 }  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/node_info.cpp
+++ b/silkworm/sentry/rpc/interfaces/node_info.cpp
@@ -1,0 +1,77 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "node_info.hpp"
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <boost/asio/ip/address.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+#include <silkworm/sentry/common/enode_url.hpp>
+
+#include "peer_id.hpp"
+
+namespace silkworm::sentry::rpc::interfaces {
+
+boost::asio::ip::tcp::endpoint parse_endpoint(const std::string& address) {
+    auto delimiter_pos = address.find_last_of(':');
+    if ((delimiter_pos == std::string::npos) || (delimiter_pos == address.size() - 1)) {
+        throw std::invalid_argument("address has no port specified");
+    }
+
+    auto ip_str = address.substr(0, delimiter_pos);
+    auto port_str = address.substr(delimiter_pos + 1);
+
+    auto ip = boost::asio::ip::make_address(ip_str);
+    auto port = static_cast<uint16_t>(std::stoi(port_str));
+    return {ip, port};
+}
+
+api::api_common::NodeInfo node_info_from_proto_node_info(const types::NodeInfoReply& info) {
+    return api::api_common::NodeInfo{
+        sentry::common::EnodeUrl{info.enode()},
+        peer_public_key_from_id_string(info.id()),
+        info.name(),
+        parse_endpoint(info.listeneraddr()),
+        static_cast<uint16_t>(info.ports().listener()),
+    };
+}
+
+types::NodeInfoReply proto_node_info_from_node_info(const api::api_common::NodeInfo& info) {
+    types::NodeInfoReply reply;
+    reply.set_id(peer_id_string_from_public_key(info.node_public_key));
+    reply.set_name(info.client_id);
+    reply.set_enode(info.node_url.to_string());
+
+    // TODO: NodeInfo.enr
+    // reply.set_enr("TODO");
+
+    reply.mutable_ports()->set_listener(info.rlpx_server_port);
+
+    // TODO: NodeInfo.discovery_port
+    // reply.mutable_ports()->set_discovery(0);
+
+    std::ostringstream rlpx_server_listen_endpoint_str;
+    rlpx_server_listen_endpoint_str << info.rlpx_server_listen_endpoint;
+    reply.set_listeneraddr(rlpx_server_listen_endpoint_str.str());
+
+    return reply;
+}
+
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/node_info.hpp
+++ b/silkworm/sentry/rpc/interfaces/node_info.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,21 +16,12 @@
 
 #pragma once
 
-#include <intx/intx.hpp>
-#include <types/types.pb.h>
+#include <silkworm/interfaces/types/types.pb.h>
+#include <silkworm/sentry/api/api_common/node_info.hpp>
 
-#include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/hash.hpp>
+namespace silkworm::sentry::rpc::interfaces {
 
-namespace silkworm {
+api::api_common::NodeInfo node_info_from_proto_node_info(const types::NodeInfoReply& info);
+types::NodeInfoReply proto_node_info_from_node_info(const api::api_common::NodeInfo& info);
 
-Bytes bytes_from_H512(const types::H512& orig);
-std::unique_ptr<types::H512> H512_from_bytes(ByteView orig);
-
-Hash hash_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_hash(const Hash& orig);
-
-intx::uint256 uint256_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig);
-
-}  // namespace silkworm
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/peer_event.cpp
+++ b/silkworm/sentry/rpc/interfaces/peer_event.cpp
@@ -1,0 +1,60 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "peer_event.hpp"
+
+#include "peer_id.hpp"
+
+namespace silkworm::sentry::rpc::interfaces {
+
+namespace proto = ::sentry;
+
+api::api_common::PeerEvent peer_event_from_proto_peer_event(const proto::PeerEvent& event) {
+    api::api_common::PeerEventId event_id;
+    switch (event.event_id()) {
+        case proto::PeerEvent_PeerEventId_Connect:
+            event_id = api::api_common::PeerEventId::kAdded;
+            break;
+        case proto::PeerEvent_PeerEventId_Disconnect:
+            event_id = api::api_common::PeerEventId::kRemoved;
+            break;
+        default:
+            assert(false);
+    }
+
+    return api::api_common::PeerEvent{
+        {peer_public_key_from_id(event.peer_id())},
+        event_id,
+    };
+}
+
+proto::PeerEvent proto_peer_event_from_peer_event(const api::api_common::PeerEvent& event) {
+    proto::PeerEvent reply;
+    if (event.peer_public_key) {
+        reply.mutable_peer_id()->CopyFrom(peer_id_from_public_key(event.peer_public_key.value()));
+    }
+    switch (event.event_id) {
+        case api::api_common::PeerEventId::kAdded:
+            reply.set_event_id(proto::PeerEvent_PeerEventId_Connect);
+            break;
+        case api::api_common::PeerEventId::kRemoved:
+            reply.set_event_id(proto::PeerEvent_PeerEventId_Disconnect);
+            break;
+    }
+    return reply;
+}
+
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/peer_event.cpp
+++ b/silkworm/sentry/rpc/interfaces/peer_event.cpp
@@ -32,6 +32,7 @@ api::api_common::PeerEvent peer_event_from_proto_peer_event(const proto::PeerEve
             event_id = api::api_common::PeerEventId::kRemoved;
             break;
         default:
+            event_id = api::api_common::PeerEventId::kRemoved;  // Avoid -Wsometimes-uninitialized
             assert(false);
     }
 

--- a/silkworm/sentry/rpc/interfaces/peer_event.hpp
+++ b/silkworm/sentry/rpc/interfaces/peer_event.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,21 +16,12 @@
 
 #pragma once
 
-#include <intx/intx.hpp>
-#include <types/types.pb.h>
+#include <silkworm/interfaces/p2psentry/sentry.grpc.pb.h>
+#include <silkworm/sentry/api/api_common/peer_event.hpp>
 
-#include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/hash.hpp>
+namespace silkworm::sentry::rpc::interfaces {
 
-namespace silkworm {
+api::api_common::PeerEvent peer_event_from_proto_peer_event(const ::sentry::PeerEvent& event);
+::sentry::PeerEvent proto_peer_event_from_peer_event(const api::api_common::PeerEvent& event);
 
-Bytes bytes_from_H512(const types::H512& orig);
-std::unique_ptr<types::H512> H512_from_bytes(ByteView orig);
-
-Hash hash_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_hash(const Hash& orig);
-
-intx::uint256 uint256_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig);
-
-}  // namespace silkworm
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/peer_id.cpp
+++ b/silkworm/sentry/rpc/interfaces/peer_id.cpp
@@ -23,7 +23,7 @@ namespace silkworm::sentry::rpc::interfaces {
 namespace proto_types = ::types;
 
 proto_types::H512 peer_id_from_public_key(const sentry::common::EccPublicKey& key) {
-    return *to_H512(key.serialized());
+    return *H512_from_bytes(key.serialized());
 }
 
 std::string peer_id_string_from_public_key(const sentry::common::EccPublicKey& key) {

--- a/silkworm/sentry/rpc/interfaces/peer_id.cpp
+++ b/silkworm/sentry/rpc/interfaces/peer_id.cpp
@@ -22,16 +22,20 @@ namespace silkworm::sentry::rpc::interfaces {
 
 namespace proto_types = ::types;
 
+sentry::common::EccPublicKey peer_public_key_from_id(const ::types::H512& peer_id) {
+    return sentry::common::EccPublicKey::deserialize(bytes_from_H512(peer_id));
+}
+
 proto_types::H512 peer_id_from_public_key(const sentry::common::EccPublicKey& key) {
     return *H512_from_bytes(key.serialized());
 }
 
-std::string peer_id_string_from_public_key(const sentry::common::EccPublicKey& key) {
-    return key.hex();
+sentry::common::EccPublicKey peer_public_key_from_id_string(const std::string& peer_id_str) {
+    return sentry::common::EccPublicKey::deserialize_hex(peer_id_str);
 }
 
-sentry::common::EccPublicKey peer_public_key_from_id(const ::types::H512& peer_id) {
-    return sentry::common::EccPublicKey::deserialize(bytes_from_H512(peer_id));
+std::string peer_id_string_from_public_key(const sentry::common::EccPublicKey& key) {
+    return key.hex();
 }
 
 }  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/peer_info.cpp
+++ b/silkworm/sentry/rpc/interfaces/peer_info.cpp
@@ -1,0 +1,112 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "peer_info.hpp"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <boost/asio/ip/tcp.hpp>
+
+#include <silkworm/sentry/common/enode_url.hpp>
+
+#include "peer_id.hpp"
+
+namespace silkworm::sentry::rpc::interfaces {
+
+boost::asio::ip::tcp::endpoint parse_endpoint(const std::string& address);
+
+api::api_common::PeerInfo peer_info_from_proto_peer_info(const types::PeerInfo& info) {
+    std::vector<std::string> capabilities;
+    capabilities.reserve(static_cast<size_t>(info.caps_size()));
+    for (auto& cap : info.caps()) {
+        capabilities.push_back(cap);
+    }
+
+    return api::api_common::PeerInfo{
+        sentry::common::EnodeUrl{info.enode()},
+        peer_public_key_from_id_string(info.id()),
+        parse_endpoint(info.connlocaladdr()),
+        parse_endpoint(info.connremoteaddr()),
+        info.connisinbound(),
+        info.connisstatic(),
+        info.name(),
+        capabilities,
+    };
+}
+
+types::PeerInfo proto_peer_info_from_peer_info(const api::api_common::PeerInfo& peer) {
+    types::PeerInfo info;
+    info.set_id(peer_id_string_from_public_key(peer.peer_public_key));
+    info.set_name(peer.client_id);
+    info.set_enode(peer.url.to_string());
+
+    // TODO: PeerInfo.enr
+    // info.set_enr("TODO");
+
+    for (auto& capability : peer.capabilities) {
+        info.add_caps(capability);
+    }
+
+    std::ostringstream local_endpoint_str;
+    local_endpoint_str << peer.local_endpoint;
+    info.set_connlocaladdr(local_endpoint_str.str());
+
+    std::ostringstream remote_endpoint_str;
+    remote_endpoint_str << peer.remote_endpoint;
+    info.set_connremoteaddr(remote_endpoint_str.str());
+
+    info.set_connisinbound(peer.is_inbound);
+    info.set_connistrusted(false);
+    info.set_connisstatic(peer.is_static);
+    return info;
+}
+
+api::api_common::PeerInfos peer_infos_from_proto_peers_reply(const ::sentry::PeersReply& reply) {
+    api::api_common::PeerInfos result;
+    for (auto& peer : reply.peers()) {
+        result.push_back(peer_info_from_proto_peer_info(peer));
+    }
+    return result;
+}
+
+::sentry::PeersReply proto_peers_reply_from_peer_infos(const api::api_common::PeerInfos& peers) {
+    ::sentry::PeersReply reply;
+    for (auto& peer : peers) {
+        reply.add_peers()->CopyFrom(proto_peer_info_from_peer_info(peer));
+    }
+    return reply;
+}
+
+std::optional<api::api_common::PeerInfo> peer_info_opt_from_proto_peer_reply(const ::sentry::PeerByIdReply& reply) {
+    if (reply.has_peer()) {
+        auto result = peer_info_from_proto_peer_info(reply.peer());
+        return {result};
+    } else {
+        return std::nullopt;
+    }
+}
+
+::sentry::PeerByIdReply proto_peer_reply_from_peer_info_opt(const std::optional<api::api_common::PeerInfo>& peer_opt) {
+    ::sentry::PeerByIdReply reply;
+    if (peer_opt) {
+        reply.mutable_peer()->CopyFrom(proto_peer_info_from_peer_info(peer_opt.value()));
+    }
+    return reply;
+}
+
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/peer_info.hpp
+++ b/silkworm/sentry/rpc/interfaces/peer_info.hpp
@@ -1,0 +1,36 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+
+#include <silkworm/interfaces/p2psentry/sentry.grpc.pb.h>
+#include <silkworm/interfaces/types/types.pb.h>
+#include <silkworm/sentry/api/api_common/peer_info.hpp>
+
+namespace silkworm::sentry::rpc::interfaces {
+
+api::api_common::PeerInfo peer_info_from_proto_peer_info(const types::PeerInfo& info);
+types::PeerInfo proto_peer_info_from_peer_info(const api::api_common::PeerInfo& info);
+
+api::api_common::PeerInfos peer_infos_from_proto_peers_reply(const ::sentry::PeersReply& reply);
+::sentry::PeersReply proto_peers_reply_from_peer_infos(const api::api_common::PeerInfos& infos);
+
+std::optional<api::api_common::PeerInfo> peer_info_opt_from_proto_peer_reply(const ::sentry::PeerByIdReply& reply);
+::sentry::PeerByIdReply proto_peer_reply_from_peer_info_opt(const std::optional<api::api_common::PeerInfo>& info_opt);
+
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/sent_peer_ids.cpp
+++ b/silkworm/sentry/rpc/interfaces/sent_peer_ids.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "sent_peer_ids.hpp"
+
+#include "peer_id.hpp"
+
+namespace silkworm::sentry::rpc::interfaces {
+
+namespace proto = ::sentry;
+
+proto::SentPeers sent_peers_ids_from_peer_keys(const std::vector<sentry::common::EccPublicKey>& keys) {
+    proto::SentPeers result;
+    for (auto& key : keys) {
+        result.add_peers()->CopyFrom(peer_id_from_public_key(key));
+    }
+    return result;
+}
+
+std::vector<sentry::common::EccPublicKey> peer_keys_from_sent_peers_ids(const proto::SentPeers& peer_ids) {
+    std::vector<sentry::common::EccPublicKey> result;
+    result.reserve(static_cast<size_t>(peer_ids.peers_size()));
+    for (auto& peer_id : peer_ids.peers()) {
+        result.push_back(peer_public_key_from_id(peer_id));
+    }
+    return result;
+}
+
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/sent_peer_ids.hpp
+++ b/silkworm/sentry/rpc/interfaces/sent_peer_ids.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,21 +16,14 @@
 
 #pragma once
 
-#include <intx/intx.hpp>
-#include <types/types.pb.h>
+#include <vector>
 
-#include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/hash.hpp>
+#include <silkworm/interfaces/p2psentry/sentry.grpc.pb.h>
+#include <silkworm/sentry/common/ecc_public_key.hpp>
 
-namespace silkworm {
+namespace silkworm::sentry::rpc::interfaces {
 
-Bytes bytes_from_H512(const types::H512& orig);
-std::unique_ptr<types::H512> H512_from_bytes(ByteView orig);
+::sentry::SentPeers sent_peers_ids_from_peer_keys(const std::vector<sentry::common::EccPublicKey>& keys);
+std::vector<sentry::common::EccPublicKey> peer_keys_from_sent_peers_ids(const ::sentry::SentPeers& peer_ids);
 
-Hash hash_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_hash(const Hash& orig);
-
-intx::uint256 uint256_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig);
-
-}  // namespace silkworm
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/status_data.cpp
+++ b/silkworm/sentry/rpc/interfaces/status_data.cpp
@@ -1,0 +1,94 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "status_data.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/node/rpc/interfaces/types.hpp>
+#include <silkworm/sentry/eth/fork_id.hpp>
+
+namespace silkworm::sentry::rpc::interfaces {
+
+namespace proto = ::sentry;
+
+eth::StatusData status_data_from_proto(const proto::StatusData& data, uint8_t eth_version) {
+    Bytes genesis_hash{hash_from_H256(data.fork_data().genesis())};
+
+    auto& data_forks = data.fork_data().height_forks();
+    std::vector<BlockNum> fork_block_numbers;
+    fork_block_numbers.resize(static_cast<size_t>(data_forks.size()));
+    std::copy(data_forks.cbegin(), data_forks.cend(), fork_block_numbers.begin());
+
+    // TODO: handle time_forks
+    // data.fork_data().time_forks()
+
+    // TODO: handle max_block_time
+    // data.max_block_time()
+
+    // TODO: handle passive_peers
+    // data.passive_peers()
+
+    auto message = eth::StatusMessage{
+        eth_version,
+        data.network_id(),
+        uint256_from_H256(data.total_difficulty()),
+        Bytes{hash_from_H256(data.best_hash())},
+        genesis_hash,
+        eth::ForkId{genesis_hash, fork_block_numbers, data.max_block_height()},
+    };
+
+    return eth::StatusData{
+        std::move(fork_block_numbers),
+        data.max_block_height(),
+        std::move(message),
+    };
+}
+
+static proto::Forks make_proto_forks(ByteView genesis_hash, const std::vector<BlockNum>& fork_block_numbers) {
+    proto::Forks forks;
+    forks.mutable_genesis()->CopyFrom(*H512_from_bytes(genesis_hash));
+
+    for (auto block_number : fork_block_numbers) {
+        forks.add_height_forks(block_number);
+    }
+
+    // TODO: handle time_forks
+    // forks.add_time_forks(block);
+
+    return forks;
+}
+
+proto::StatusData proto_status_data_from_status_data(const eth::StatusData& data) {
+    proto::StatusData result;
+    result.set_network_id(data.message.network_id);
+    result.mutable_total_difficulty()->CopyFrom(*H256_from_uint256(data.message.total_difficulty));
+    result.mutable_best_hash()->CopyFrom(*H256_from_hash(Hash{data.message.best_block_hash}));
+    result.mutable_fork_data()->CopyFrom(make_proto_forks(data.message.genesis_hash, data.fork_block_numbers));
+    result.set_max_block_height(data.head_block_num);
+
+    // TODO: set max_block_time
+    // result.set_max_block_time()
+
+    // TODO: set passive_peers
+    // result.set_passive_peers()
+
+    return result;
+}
+
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/interfaces/status_data.hpp
+++ b/silkworm/sentry/rpc/interfaces/status_data.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,21 +16,12 @@
 
 #pragma once
 
-#include <intx/intx.hpp>
-#include <types/types.pb.h>
+#include <silkworm/interfaces/p2psentry/sentry.grpc.pb.h>
+#include <silkworm/sentry/eth/status_data.hpp>
 
-#include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/hash.hpp>
+namespace silkworm::sentry::rpc::interfaces {
 
-namespace silkworm {
+eth::StatusData status_data_from_proto(const ::sentry::StatusData& data, uint8_t eth_version);
+::sentry::StatusData proto_status_data_from_status_data(const eth::StatusData& data);
 
-Bytes bytes_from_H512(const types::H512& orig);
-std::unique_ptr<types::H512> H512_from_bytes(ByteView orig);
-
-Hash hash_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_hash(const Hash& orig);
-
-intx::uint256 uint256_from_H256(const types::H256& orig);
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig);
-
-}  // namespace silkworm
+}  // namespace silkworm::sentry::rpc::interfaces

--- a/silkworm/sentry/rpc/server/server.cpp
+++ b/silkworm/sentry/rpc/server/server.cpp
@@ -30,7 +30,7 @@
 
 #include "server_calls.hpp"
 
-namespace silkworm::sentry::rpc {
+namespace silkworm::sentry::rpc::server {
 
 using namespace silkworm::log;
 using AsyncService = ::sentry::Sentry::AsyncService;
@@ -115,11 +115,11 @@ Server::Server(
     : p_impl_(std::make_unique<ServerImpl>(config, std::move(router))) {}
 
 Server::~Server() {
-    log::Trace() << "silkworm::sentry::rpc::Server::~Server";
+    log::Trace() << "silkworm::sentry::rpc::server::Server::~Server";
 }
 
 boost::asio::awaitable<void> Server::async_run() {
     return p_impl_->async_run();
 }
 
-}  // namespace silkworm::sentry::rpc
+}  // namespace silkworm::sentry::rpc::server

--- a/silkworm/sentry/rpc/server/server.hpp
+++ b/silkworm/sentry/rpc/server/server.hpp
@@ -25,7 +25,7 @@
 #include <silkworm/node/rpc/server/server_config.hpp>
 #include <silkworm/sentry/api/router/service_router.hpp>
 
-namespace silkworm::sentry::rpc {
+namespace silkworm::sentry::rpc::server {
 
 class ServerImpl;
 
@@ -45,4 +45,4 @@ class Server final {
     std::unique_ptr<ServerImpl> p_impl_;
 };
 
-}  // namespace silkworm::sentry::rpc
+}  // namespace silkworm::sentry::rpc::server

--- a/silkworm/sentry/rpc/server/server_calls.hpp
+++ b/silkworm/sentry/rpc/server/server_calls.hpp
@@ -41,10 +41,10 @@
 #include <silkworm/sentry/common/promise.hpp>
 #include <silkworm/sentry/eth/fork_id.hpp>
 
-#include "interfaces/message.hpp"
-#include "interfaces/peer_id.hpp"
+#include "../interfaces/message.hpp"
+#include "../interfaces/peer_id.hpp"
 
-namespace silkworm::sentry::rpc {
+namespace silkworm::sentry::rpc::server {
 
 using boost::asio::awaitable;
 using boost::asio::io_context;
@@ -427,4 +427,4 @@ class PeerEventsCall : public sw_rpc::server::ServerStreamingCall<proto::PeerEve
     }
 };
 
-}  // namespace silkworm::sentry::rpc
+}  // namespace silkworm::sentry::rpc::server

--- a/silkworm/sentry/sentry.cpp
+++ b/silkworm/sentry/sentry.cpp
@@ -37,7 +37,7 @@
 #include "rlpx/client.hpp"
 #include "rlpx/protocol.hpp"
 #include "rlpx/server.hpp"
-#include "rpc/server.hpp"
+#include "rpc/server/server.hpp"
 #include "status_manager.hpp"
 
 namespace silkworm::sentry {
@@ -87,7 +87,7 @@ class SentryImpl final {
     std::shared_ptr<MessageReceiver> message_receiver_;
     std::shared_ptr<PeerManagerApi> peer_manager_api_;
 
-    rpc::Server rpc_server_;
+    rpc::server::Server rpc_server_;
 };
 
 static silkworm::rpc::ServerConfig make_server_config(const Settings& settings) {

--- a/silkworm/sync/internals/sentry_type_casts_test.cpp
+++ b/silkworm/sync/internals/sentry_type_casts_test.cpp
@@ -42,7 +42,7 @@ TEST_CASE("H256/512 to/from conversions") {
             Bytes orig_string(len, 0);
             generate_n(orig_string.begin(), len, [] { return static_cast<char>(rand() % 255); });
 
-            Bytes transf_string = bytes_from_H512(*to_H512(orig_string));
+            Bytes transf_string = bytes_from_H512(*H512_from_bytes(orig_string));
 
             orig_string.resize(64, 0);  // transf_string is always of 64 bytes with trailing zeros if needed
             REQUIRE(orig_string == transf_string);

--- a/silkworm/sync/rpc/peer_by_id.cpp
+++ b/silkworm/sync/rpc/peer_by_id.cpp
@@ -20,7 +20,7 @@ namespace silkworm::rpc {
 
 PeerById::PeerById(const PeerId& peerId)
     : UnaryCall("PeerById", &sentry::Sentry::Stub::PeerById, {}) {
-    request_.set_allocated_peer_id(to_H512(peerId).release());
+    request_.set_allocated_peer_id(H512_from_bytes(peerId).release());
 }
 
 }  // namespace silkworm::rpc

--- a/silkworm/sync/rpc/peer_min_block.cpp
+++ b/silkworm/sync/rpc/peer_min_block.cpp
@@ -20,7 +20,7 @@ namespace silkworm::rpc {
 
 PeerMinBlock::PeerMinBlock(const PeerId& peerId, BlockNum minBlock)
     : UnaryCall("PeerMinBlock", &sentry::Sentry::Stub::PeerMinBlock, {}) {
-    request_.set_allocated_peer_id(to_H512(peerId).release());
+    request_.set_allocated_peer_id(H512_from_bytes(peerId).release());
     request_.set_min_block(minBlock);  // take ownership
 }
 

--- a/silkworm/sync/rpc/penalize_peer.cpp
+++ b/silkworm/sync/rpc/penalize_peer.cpp
@@ -20,7 +20,7 @@ namespace silkworm::rpc {
 
 PenalizePeer::PenalizePeer(const PeerId& peerId, Penalty penalty)
     : UnaryCall("PenalizePeer", &sentry::Sentry::Stub::PenalizePeer, {}) {
-    request_.set_allocated_peer_id(to_H512(peerId).release());
+    request_.set_allocated_peer_id(H512_from_bytes(peerId).release());
 
     auto raw_penalty = static_cast<sentry::PenaltyKind>(penalty);
     request_.set_penalty(raw_penalty);

--- a/silkworm/sync/rpc/send_message_by_id.cpp
+++ b/silkworm/sync/rpc/send_message_by_id.cpp
@@ -20,7 +20,7 @@ namespace silkworm::rpc {
 
 SendMessageById::SendMessageById(const PeerId& peerId, std::unique_ptr<sentry::OutboundMessageData> message)
     : UnaryCall("SendMessageById", &sentry::Sentry::Stub::SendMessageById, {}) {
-    request_.set_allocated_peer_id(to_H512(peerId).release());
+    request_.set_allocated_peer_id(H512_from_bytes(peerId).release());
     request_.set_allocated_data(message.release());  // take ownership
 }
 


### PR DESCRIPTION
* GRPC client
* refactor GRPC types conversion logic from server_calls.hpp
* refactor unary_rpc to throw on a bad grpc::Status
* refactoring: rename to_H512 to H512_from_bytes
