### PR TITLE
node: add to_current_next_multi + to_next_first_multi API in memory mutation

### DIFF
--- a/silkworm/node/db/memory_mutation_cursor.cpp
+++ b/silkworm/node/db/memory_mutation_cursor.cpp
@@ -391,6 +391,9 @@ CursorResult MemoryMutationCursor::next_by_type(MemoryMutationCursor::NextType t
         case NextType::kNoDup: {
             return cursor_->to_next_first_multi(throw_notfound);
         }
+        default: {
+            SILKWORM_ASSERT(false);
+        }
     }
 }
 

--- a/silkworm/node/db/memory_mutation_cursor.cpp
+++ b/silkworm/node/db/memory_mutation_cursor.cpp
@@ -392,7 +392,7 @@ CursorResult MemoryMutationCursor::next_by_type(MemoryMutationCursor::NextType t
             return cursor_->to_next_first_multi(throw_notfound);
         }
         default: {
-            SILKWORM_ASSERT(false);
+            return CursorResult{{}, {}, false};
         }
     }
 }

--- a/silkworm/node/db/memory_mutation_cursor.hpp
+++ b/silkworm/node/db/memory_mutation_cursor.hpp
@@ -91,6 +91,7 @@ class MemoryMutationCursor : public RWCursorDupSort {
   private:
     static inline void throw_error_nodata();
     static inline void throw_error_notfound();
+    static inline CursorResult throw_or_error_result(bool throw_notfound);
 
     enum class NextType {
         kNormal,

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -604,12 +604,12 @@ TEST_CASE("MemoryMutationCursor: current", "[silkworm][node][db][memory_mutation
             REQUIRE(mutation_cursor1.to_last());
             const auto result3 = mutation_cursor1.current();
             CHECK(result3.done);
-            CHECK(result3.key == "AA");
-            CHECK(result3.value == "00");
+            CHECK(result3.key == "BB");
+            CHECK(result3.value == "11");
             const auto result4 = mutation_cursor1.current();
             CHECK(result4.done);
-            CHECK(result4.key == "AA");
-            CHECK(result4.value == "00");
+            CHECK(result4.key == "BB");
+            CHECK(result4.value == "11");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor2.to_first());
@@ -621,11 +621,15 @@ TEST_CASE("MemoryMutationCursor: current", "[silkworm][node][db][memory_mutation
             CHECK(result6.done);
             CHECK(result6.key == "AA");
             CHECK(result6.value == "00");
-            /*REQUIRE(mutation_cursor2.to_last());
-            result2 = mutation_cursor2.current();
-            check_cursor_result(result2, {"BB", "22"});
-            result2 = mutation_cursor2.current();
-            check_cursor_result(result2, {"BB", "22"});*/
+            REQUIRE(mutation_cursor2.to_last());
+            const auto result7 = mutation_cursor2.current();
+            CHECK(result7.done);
+            CHECK(result7.key == "BB");
+            CHECK(result7.value == "22");
+            const auto result8 = mutation_cursor2.current();
+            CHECK(result8.done);
+            CHECK(result8.key == "BB");
+            CHECK(result8.value == "22");
         }
     }
 }

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -589,7 +589,7 @@ TEST_CASE("MemoryMutationCursor: multi-value interleaved", "[silkworm][node][db]
     CHECK(db_result.key == "key3");
     CHECK(db_result.value == "value3.1");
     mem_result = mem_cursor->to_current_next_multi(/*throw_notfound=*/false);
-    //CHECK(!mem_result.done);
+    // CHECK(!mem_result.done);
 
     db_result = db_cursor->to_current_next_multi(/*throw_notfound=*/false);
     CHECK(db_result.done);
@@ -597,18 +597,18 @@ TEST_CASE("MemoryMutationCursor: multi-value interleaved", "[silkworm][node][db]
     CHECK(db_result.value == "value3.3");
     mem_result = mem_cursor->to_next_first_multi(/*throw_notfound=*/false);
     CHECK(mem_result.done);
-    //CHECK(mem_result.key == "key3");
-    //CHECK(mem_result.value == "value3.1");
+    // CHECK(mem_result.key == "key3");
+    // CHECK(mem_result.value == "value3.1");
 
     db_result = db_cursor->to_current_next_multi(/*throw_notfound=*/false);
     CHECK(!db_result.done);
     mem_result = mem_cursor->to_current_next_multi(/*throw_notfound=*/false);
     CHECK(mem_result.done);
-    //CHECK(mem_result.key == "key3");
-    //CHECK(mem_result.value == "value3.3");
+    // CHECK(mem_result.key == "key3");
+    // CHECK(mem_result.value == "value3.3");
 
     mem_result = mem_cursor->to_current_next_multi(/*throw_notfound=*/false);
-    //CHECK(!mem_result.done);
+    // CHECK(!mem_result.done);
 }
 
 #endif  // SILKWORM_SANITIZE

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -98,16 +98,6 @@ struct MemoryMutationCursorTest {
 const MapConfig kNonexistentTestMap{"NonexistentTable"};
 const MapConfig kNonexistentTestMultiMap{"NonexistentMultiTable", mdbx::key_mode::usual, mdbx::value_mode::multi};
 
-using Pair = mdbx::pair;
-
-static void check_cursor_result(CursorResult result, Pair kv_pair) {
-    CHECK(result);
-    if (result) {
-        CHECK(result.key == kv_pair.key);
-        CHECK(result.value == kv_pair.value);
-    }
-}
-
 TEST_CASE("MemoryMutationCursor: initialization", "[silkworm][node][db][memory_mutation_cursor]") {
     MemoryMutationCursorTest test1;
     test1.fill_main_tables();
@@ -187,39 +177,59 @@ TEST_CASE("MemoryMutationCursor: to_first", "[silkworm][node][db][memory_mutatio
         SECTION(tag + ": to_first on existent table") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             const auto result1 = mutation_cursor1.to_first();
-            check_cursor_result(result1, {"AA", "00"});
+            CHECK(result1.done);
+            CHECK(result1.key == "AA");
+            CHECK(result1.value == "00");
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMap};
             const auto result2 = mutation_cursor2.to_first(/*throw_notfound=*/true);
-            check_cursor_result(result2, {"AA", "00"});
+            CHECK(result2.done);
+            CHECK(result2.key == "AA");
+            CHECK(result2.value == "00");
             MemoryMutationCursor mutation_cursor3{test->mutation, kTestMap};
             const auto result3 = mutation_cursor3.to_first(/*throw_notfound=*/false);
-            check_cursor_result(result3, {"AA", "00"});
+            CHECK(result3.done);
+            CHECK(result3.key == "AA");
+            CHECK(result3.value == "00");
 
             MemoryMutationCursor mutation_cursor4{test->mutation, kTestMultiMap};
             const auto result4 = mutation_cursor4.to_first();
-            check_cursor_result(result4, {"AA", "00"});
+            CHECK(result4.done);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "00");
 
             MemoryMutationCursor mutation_cursor5{test->mutation, kTestMultiMap};
             const auto result5 = mutation_cursor5.to_first(/*throw_notfound=*/true);
-            check_cursor_result(result5, {"AA", "00"});
+            CHECK(result5.done);
+            CHECK(result5.key == "AA");
+            CHECK(result5.value == "00");
 
             MemoryMutationCursor mutation_cursor6{test->mutation, kTestMultiMap};
             const auto result6 = mutation_cursor6.to_first(/*throw_notfound=*/false);
-            check_cursor_result(result6, {"AA", "00"});
+            CHECK(result6.done);
+            CHECK(result6.key == "AA");
+            CHECK(result6.value == "00");
         }
 
         SECTION(tag + ": to_first operation is idempotent") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
-            auto result1 = mutation_cursor1.to_first();
-            check_cursor_result(result1, {"AA", "00"});
-            result1 = mutation_cursor1.to_first();
-            check_cursor_result(result1, {"AA", "00"});
+            const auto result1 = mutation_cursor1.to_first();
+            CHECK(result1.done);
+            CHECK(result1.key == "AA");
+            CHECK(result1.value == "00");
+            const auto result2 = mutation_cursor1.to_first();
+            CHECK(result2.done);
+            CHECK(result2.key == "AA");
+            CHECK(result2.value == "00");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
-            auto result2 = mutation_cursor2.to_first();
-            check_cursor_result(result2, {"AA", "00"});
-            result2 = mutation_cursor2.to_first();
-            check_cursor_result(result2, {"AA", "00"});
+            const auto result3 = mutation_cursor2.to_first();
+            CHECK(result3.done);
+            CHECK(result3.key == "AA");
+            CHECK(result3.value == "00");
+            const auto result4 = mutation_cursor2.to_first();
+            CHECK(result4.done);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "00");
         }
     }
 }
@@ -253,36 +263,42 @@ TEST_CASE("MemoryMutationCursor: to_next", "[silkworm][node][db][memory_mutation
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first());
             const auto result1 = mutation_cursor1.to_next();
+            CHECK(result1.done);
             CHECK(result1.key == "BB");
             CHECK(result1.value == "11");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMap};
             REQUIRE(mutation_cursor2.to_first());
             const auto result2 = mutation_cursor2.to_next(/*throw_notfound=*/true);
+            CHECK(result2.done);
             CHECK(result2.key == "BB");
             CHECK(result2.value == "11");
 
             MemoryMutationCursor mutation_cursor3{test->mutation, kTestMap};
             REQUIRE(mutation_cursor3.to_first());
             const auto result3 = mutation_cursor3.to_next(/*throw_notfound=*/false);
+            CHECK(result3.done);
             CHECK(result3.key == "BB");
             CHECK(result3.value == "11");
 
             MemoryMutationCursor mutation_cursor4{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor4.to_first());
             const auto result4 = mutation_cursor4.to_next();
+            CHECK(result4.done);
             CHECK(result4.key == "AA");
             CHECK(result4.value == "11");
 
             MemoryMutationCursor mutation_cursor5{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor5.to_first());
             const auto result5 = mutation_cursor5.to_next(/*throw_notfound=*/true);
+            CHECK(result5.done);
             CHECK(result5.key == "AA");
             CHECK(result5.value == "11");
 
             MemoryMutationCursor mutation_cursor6{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor6.to_first());
             const auto result6 = mutation_cursor6.to_next(/*throw_notfound=*/false);
+            CHECK(result6.done);
             CHECK(result6.key == "AA");
             CHECK(result6.value == "11");
         }
@@ -291,6 +307,7 @@ TEST_CASE("MemoryMutationCursor: to_next", "[silkworm][node][db][memory_mutation
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first(/*throw_notfound=*/false));
             const auto result1 = mutation_cursor1.to_next(/*throw_notfound=*/false);
+            CHECK(result1.done);
             CHECK(result1.key == "BB");
             CHECK(result1.value == "11");
             const auto result2 = mutation_cursor1.to_next(/*throw_notfound=*/false);
@@ -302,9 +319,11 @@ TEST_CASE("MemoryMutationCursor: to_next", "[silkworm][node][db][memory_mutation
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor2.to_first(/*throw_notfound=*/false));
             const auto result4 = mutation_cursor2.to_next(/*throw_notfound=*/false);
+            CHECK(result4.done);
             CHECK(result4.key == "AA");
             CHECK(result4.value == "11");
             const auto result5 = mutation_cursor2.to_next(/*throw_notfound=*/false);
+            CHECK(result5.done);
             CHECK(result5.key == "AA");
             CHECK(result5.value == "22");
             REQUIRE(mutation_cursor2.to_last(/*throw_notfound=*/false));
@@ -343,57 +362,74 @@ TEST_CASE("MemoryMutationCursor: to_current_next_multi", "[silkworm][node][db][m
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first());
             const auto result1 = mutation_cursor1.to_current_next_multi();
-            check_cursor_result(result1, {"BB", "11"});
+            CHECK(result1.done);
+            CHECK(result1.key == "BB");
+            CHECK(result1.value == "11");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMap};
             REQUIRE(mutation_cursor2.to_first());
             const auto result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/true);
-            check_cursor_result(result2, {"BB", "11"});
+            CHECK(result2.done);
+            CHECK(result2.key == "BB");
+            CHECK(result2.value == "11");
 
             MemoryMutationCursor mutation_cursor3{test->mutation, kTestMap};
             REQUIRE(mutation_cursor3.to_first());
             const auto result3 = mutation_cursor3.to_current_next_multi(/*throw_notfound=*/false);
-            check_cursor_result(result3, {"BB", "11"});
+            CHECK(result3.done);
+            CHECK(result3.key == "BB");
+            CHECK(result3.value == "11");
 
             MemoryMutationCursor mutation_cursor4{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor4.to_first());
             const auto result4 = mutation_cursor4.to_current_next_multi();
-            check_cursor_result(result4, {"AA", "11"});
+            CHECK(result4.done);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "11");
 
             MemoryMutationCursor mutation_cursor5{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor5.to_first());
             const auto result5 = mutation_cursor5.to_current_next_multi(/*throw_notfound=*/true);
-            check_cursor_result(result5, {"AA", "11"});
+            CHECK(result5.done);
+            CHECK(result5.key == "AA");
+            CHECK(result5.value == "11");
 
             MemoryMutationCursor mutation_cursor6{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor6.to_first());
             const auto result6 = mutation_cursor6.to_current_next_multi(/*throw_notfound=*/false);
-            check_cursor_result(result6, {"AA", "11"});
+            CHECK(result6.done);
+            CHECK(result6.key == "AA");
+            CHECK(result6.value == "11");
         }
 
         SECTION(tag + ": to_current_next_multi multiple operations") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first(/*throw_notfound=*/false));
-            auto result1 = mutation_cursor1.to_current_next_multi(/*throw_notfound=*/false);
-            check_cursor_result(result1, {"BB", "11"});
-            result1 = mutation_cursor1.to_current_next_multi(/*throw_notfound=*/false);
-            CHECK(!result1.done);
+            const auto result1 = mutation_cursor1.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(result1.done);
+            CHECK(result1.key == "BB");
+            CHECK(result1.value == "11");
+            const auto result2 = mutation_cursor1.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(!result2.done);
             REQUIRE(mutation_cursor1.to_last(/*throw_notfound=*/false));
-            result1 = mutation_cursor1.to_current_next_multi(/*throw_notfound=*/false);
-            CHECK(!result1.done);
+            const auto result3 = mutation_cursor1.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(!result3.done);
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor2.to_first(/*throw_notfound=*/false));
-            auto result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
-            check_cursor_result(result2, {"AA", "11"});
-            result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
-            check_cursor_result(result2, {"AA", "22"});
-            result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
-            CHECK(!result2.done);
-            REQUIRE((result2 = mutation_cursor2.to_last(/*throw_notfound=*/false)));
-            REQUIRE((result2.done && result2.key == "BB" && result2.value == "22"));
-            result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
-            CHECK(!result2.done);
+            const auto result4 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(result4.done);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "11");
+            const auto result5 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(result5.done);
+            CHECK(result5.key == "AA");
+            CHECK(result5.value == "22");
+            const auto result6 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(!result6.done);
+            REQUIRE(mutation_cursor2.to_last(/*throw_notfound=*/false));
+            const auto result7 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(!result7.done);
         }
     }
 }
@@ -426,41 +462,61 @@ TEST_CASE("MemoryMutationCursor: to_last", "[silkworm][node][db][memory_mutation
         SECTION(tag + ": to_last on existent table: OK") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             const auto result1 = mutation_cursor1.to_last();
-            check_cursor_result(result1, {"BB", "11"});
+            CHECK(result1.done);
+            CHECK(result1.key == "BB");
+            CHECK(result1.value == "11");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMap};
             const auto result2 = mutation_cursor2.to_last(/*throw_notfound=*/true);
-            check_cursor_result(result2, {"BB", "11"});
+            CHECK(result2.done);
+            CHECK(result2.key == "BB");
+            CHECK(result2.value == "11");
 
             MemoryMutationCursor mutation_cursor3{test->mutation, kTestMap};
             const auto result3 = mutation_cursor3.to_last(/*throw_notfound=*/false);
-            check_cursor_result(result3, {"BB", "11"});
+            CHECK(result3.done);
+            CHECK(result3.key == "BB");
+            CHECK(result3.value == "11");
 
             MemoryMutationCursor mutation_cursor4{test->mutation, kTestMultiMap};
             const auto result4 = mutation_cursor4.to_last();
-            check_cursor_result(result4, {"BB", "22"});
+            CHECK(result4.done);
+            CHECK(result4.key == "BB");
+            CHECK(result4.value == "22");
 
             MemoryMutationCursor mutation_cursor5{test->mutation, kTestMultiMap};
             const auto result5 = mutation_cursor5.to_last(/*throw_notfound=*/true);
-            check_cursor_result(result5, {"BB", "22"});
+            CHECK(result5.done);
+            CHECK(result5.key == "BB");
+            CHECK(result5.value == "22");
 
             MemoryMutationCursor mutation_cursor6{test->mutation, kTestMultiMap};
             const auto result6 = mutation_cursor6.to_last(/*throw_notfound=*/false);
-            check_cursor_result(result6, {"BB", "22"});
+            CHECK(result6.done);
+            CHECK(result6.key == "BB");
+            CHECK(result6.value == "22");
         }
 
         SECTION(tag + ": to_last operation is idempotent") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
-            auto result1 = mutation_cursor1.to_last();
-            check_cursor_result(result1, {"BB", "11"});
-            result1 = mutation_cursor1.to_last();
-            check_cursor_result(result1, {"BB", "11"});
+            const auto result1 = mutation_cursor1.to_last();
+            CHECK(result1.done);
+            CHECK(result1.key == "BB");
+            CHECK(result1.value == "11");
+            const auto result2 = mutation_cursor1.to_last();
+            CHECK(result2.done);
+            CHECK(result2.key == "BB");
+            CHECK(result2.value == "11");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
-            auto result2 = mutation_cursor2.to_last();
-            check_cursor_result(result2, {"BB", "22"});
-            result2 = mutation_cursor2.to_last();
-            check_cursor_result(result2, {"BB", "22"});
+            const auto result3 = mutation_cursor2.to_last();
+            CHECK(result3.done);
+            CHECK(result3.key == "BB");
+            CHECK(result3.value == "22");
+            const auto result4 = mutation_cursor2.to_last();
+            CHECK(result4.done);
+            CHECK(result4.key == "BB");
+            CHECK(result4.value == "22");
         }
     }
 }
@@ -494,53 +550,77 @@ TEST_CASE("MemoryMutationCursor: current", "[silkworm][node][db][memory_mutation
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first());
             const auto result1 = mutation_cursor1.current();
-            check_cursor_result(result1, {"AA", "00"});
+            CHECK(result1.done);
+            CHECK(result1.key == "AA");
+            CHECK(result1.value == "00");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMap};
             REQUIRE(mutation_cursor2.to_first());
             const auto result2 = mutation_cursor2.current(/*throw_notfound=*/true);
-            check_cursor_result(result2, {"AA", "00"});
+            CHECK(result2.done);
+            CHECK(result2.key == "AA");
+            CHECK(result2.value == "00");
 
             MemoryMutationCursor mutation_cursor3{test->mutation, kTestMap};
             REQUIRE(mutation_cursor3.to_first());
             const auto result3 = mutation_cursor3.current(/*throw_notfound=*/false);
-            check_cursor_result(result3, {"AA", "00"});
+            CHECK(result3.done);
+            CHECK(result3.key == "AA");
+            CHECK(result3.value == "00");
 
             MemoryMutationCursor mutation_cursor4{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor4.to_first());
             const auto result4 = mutation_cursor4.current();
-            check_cursor_result(result4, {"AA", "00"});
+            CHECK(result4.done);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "00");
 
             MemoryMutationCursor mutation_cursor5{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor5.to_first());
             const auto result5 = mutation_cursor5.current(/*throw_notfound=*/true);
-            check_cursor_result(result5, {"AA", "00"});
+            CHECK(result5.done);
+            CHECK(result5.key == "AA");
+            CHECK(result5.value == "00");
 
             MemoryMutationCursor mutation_cursor6{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor6.to_first());
             const auto result6 = mutation_cursor6.current(/*throw_notfound=*/false);
-            check_cursor_result(result6, {"AA", "00"});
+            CHECK(result6.done);
+            CHECK(result6.key == "AA");
+            CHECK(result6.value == "00");
         }
 
         SECTION(tag + ": current operation is idempotent") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first());
-            auto result1 = mutation_cursor1.current();
-            check_cursor_result(result1, {"AA", "00"});
-            result1 = mutation_cursor1.current();
-            check_cursor_result(result1, {"AA", "00"});
+            const auto result1 = mutation_cursor1.current();
+            CHECK(result1.done);
+            CHECK(result1.key == "AA");
+            CHECK(result1.value == "00");
+            const auto result2 = mutation_cursor1.current();
+            CHECK(result2.done);
+            CHECK(result2.key == "AA");
+            CHECK(result2.value == "00");
             REQUIRE(mutation_cursor1.to_last());
-            result1 = mutation_cursor1.current();
-            check_cursor_result(result1, {"AA", "00"});
-            result1 = mutation_cursor1.current();
-            check_cursor_result(result1, {"AA", "00"});
+            const auto result3 = mutation_cursor1.current();
+            CHECK(result3.done);
+            CHECK(result3.key == "AA");
+            CHECK(result3.value == "00");
+            const auto result4 = mutation_cursor1.current();
+            CHECK(result4.done);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "00");
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor2.to_first());
-            auto result2 = mutation_cursor2.current();
-            check_cursor_result(result2, {"AA", "00"});
-            result2 = mutation_cursor2.current();
-            check_cursor_result(result2, {"AA", "00"});
+            const auto result5 = mutation_cursor2.current();
+            CHECK(result5.done);
+            CHECK(result5.key == "AA");
+            CHECK(result5.value == "00");
+            const auto result6 = mutation_cursor2.current();
+            CHECK(result6.done);
+            CHECK(result6.key == "AA");
+            CHECK(result6.value == "00");
             /*REQUIRE(mutation_cursor2.to_last());
             result2 = mutation_cursor2.current();
             check_cursor_result(result2, {"BB", "22"});

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -290,28 +290,26 @@ TEST_CASE("MemoryMutationCursor: to_next", "[silkworm][node][db][memory_mutation
         SECTION(tag + ": to_next multiple operations") {
             MemoryMutationCursor mutation_cursor1{test->mutation, kTestMap};
             REQUIRE(mutation_cursor1.to_first(/*throw_notfound=*/false));
-            auto result1 = mutation_cursor1.to_next(/*throw_notfound=*/false);
+            const auto result1 = mutation_cursor1.to_next(/*throw_notfound=*/false);
             CHECK(result1.key == "BB");
             CHECK(result1.value == "11");
-            result1 = mutation_cursor1.to_next(/*throw_notfound=*/false);
-            CHECK(!result1.done);
+            const auto result2 = mutation_cursor1.to_next(/*throw_notfound=*/false);
+            CHECK(!result2.done);
             REQUIRE(mutation_cursor1.to_last(/*throw_notfound=*/false));
-            result1 = mutation_cursor1.to_next(/*throw_notfound=*/false);
-            CHECK(!result1.done);
+            const auto result3 = mutation_cursor1.to_next(/*throw_notfound=*/false);
+            CHECK(!result3.done);
 
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
             REQUIRE(mutation_cursor2.to_first(/*throw_notfound=*/false));
-            auto result2 = mutation_cursor2.to_next(/*throw_notfound=*/false);
-            CHECK(result2.key == "AA");
-            CHECK(result2.value == "11");
-            result2 = mutation_cursor2.to_next(/*throw_notfound=*/false);
-            CHECK(result2.key == "AA");
-            CHECK(result2.value == "22");
+            const auto result4 = mutation_cursor2.to_next(/*throw_notfound=*/false);
+            CHECK(result4.key == "AA");
+            CHECK(result4.value == "11");
+            const auto result5 = mutation_cursor2.to_next(/*throw_notfound=*/false);
+            CHECK(result5.key == "AA");
+            CHECK(result5.value == "22");
             REQUIRE(mutation_cursor2.to_last(/*throw_notfound=*/false));
-            result2 = mutation_cursor2.to_next(/*throw_notfound=*/false);
-            // CHECK(result2.done);
-            // CHECK(result2.key == "AA");
-            // CHECK(result2.value == "22");
+            const auto result6 = mutation_cursor2.to_next(/*throw_notfound=*/false);
+            CHECK(!result6.done);
         }
     }
 }
@@ -394,8 +392,8 @@ TEST_CASE("MemoryMutationCursor: to_current_next_multi", "[silkworm][node][db][m
             CHECK(!result2.done);
             REQUIRE((result2 = mutation_cursor2.to_last(/*throw_notfound=*/false)));
             REQUIRE((result2.done && result2.key == "BB" && result2.value == "22"));
-            // result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
-            // check_cursor_result(result2, {"BB", "22"});
+            result2 = mutation_cursor2.to_current_next_multi(/*throw_notfound=*/false);
+            CHECK(!result2.done);
         }
     }
 }
@@ -461,8 +459,8 @@ TEST_CASE("MemoryMutationCursor: to_last", "[silkworm][node][db][memory_mutation
             MemoryMutationCursor mutation_cursor2{test->mutation, kTestMultiMap};
             auto result2 = mutation_cursor2.to_last();
             check_cursor_result(result2, {"BB", "22"});
-            /*result2 = mutation_cursor2.to_last();
-            check_cursor_result(result2, {"BB", "22"});*/
+            result2 = mutation_cursor2.to_last();
+            check_cursor_result(result2, {"BB", "22"});
         }
     }
 }


### PR DESCRIPTION
This PR introduces the following changes to memory mutation abstraction:

- add `to_current_next_multi` API implementation
- add `to_next_first_multi` API implementation
- refactor unit tests to reduce execution time