### PR TITLE
rpcdaemon: add examples folder and API doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,4 +266,5 @@ add_subdirectory(silkworm)
 
 if(NOT SILKWORM_HAS_PARENT)
   add_subdirectory(cmd)
+  add_subdirectory(examples)
 endif()

--- a/cmd/rpcdaemon/CMakeLists.txt
+++ b/cmd/rpcdaemon/CMakeLists.txt
@@ -40,22 +40,6 @@ add_executable(silkrpc_toolbox
 target_include_directories(silkrpc_toolbox PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(silkrpc_toolbox absl::flags_parse gRPC::grpc++ protobuf::libprotobuf silkrpc)
 
-# TO BE REMOVED: START: temporarily disable warnings entirely to make silkrpc_toolbox compile as it is
-get_target_property(SILKRPCTOOLBOX_COMPILE_OPTIONS silkrpc_toolbox COMPILE_OPTIONS)
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wall")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Werror")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wextra")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wshadow")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wimplicit-fallthrough")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wsign-conversion")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wno-missing-field-initializers")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wnon-virtual-dtor")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-Wthread-safety")
-list(REMOVE_ITEM SILKRPCTOOLBOX_COMPILE_OPTIONS "-pedantic")
-set_property(TARGET silkrpc_toolbox PROPERTY COMPILE_OPTIONS ${SILKRPCTOOLBOX_COMPILE_OPTIONS})
-# TO BE REMOVED: END: temporarily disable warnings entirely to make silkrpc_toolbox compile as it is
-
 # Silkrpc daemon
 set(SILKRPC_DAEMON_LIBRARIES
     silkworm-buildinfo
@@ -69,19 +53,3 @@ endif()
 add_executable(silkrpcdaemon silkrpc_daemon.cpp ../common/common.cpp)
 target_include_directories(silkrpcdaemon PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(silkrpcdaemon PRIVATE ${SILKRPC_DAEMON_LIBRARIES})
-
-# TO BE REMOVED: START: temporarily disable warnings entirely to make silkrpcdaemon compile as it is
-get_target_property(SILKRPCDAEMON_COMPILE_OPTIONS silkrpcdaemon COMPILE_OPTIONS)
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wall")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Werror")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wextra")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wshadow")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wimplicit-fallthrough")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wsign-conversion")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wno-missing-field-initializers")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wnon-virtual-dtor")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-Wthread-safety")
-list(REMOVE_ITEM SILKRPCDAEMON_COMPILE_OPTIONS "-pedantic")
-set_property(TARGET silkrpcdaemon PROPERTY COMPILE_OPTIONS ${SILKRPCDAEMON_COMPILE_OPTIONS})
-# TO BE REMOVED: END: temporarily disable warnings entirely to make silkrpcdaemon compile as it is

--- a/cmd/rpcdaemon/ethbackend_coroutines.cpp
+++ b/cmd/rpcdaemon/ethbackend_coroutines.cpp
@@ -77,7 +77,7 @@ int ethbackend_coroutines(const std::string& target) {
 
         // Etherbase
         silkrpc::ethbackend::RemoteBackEnd eth_backend{*io_context, channel, *grpc_context};
-        boost::asio::co_spawn(*io_context, ethbackend_etherbase(eth_backend), [&](std::exception_ptr exptr) {
+        boost::asio::co_spawn(*io_context, ethbackend_etherbase(eth_backend), [&](std::exception_ptr) {
             context_pool.stop();
         });
 

--- a/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
+++ b/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
@@ -56,7 +56,7 @@ boost::asio::awaitable<void> kv_seek(silkrpc::ethdb::Database& kv_db, const std:
     co_return;
 }
 
-int kv_seek_async_coroutines(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t timeout) {
+int kv_seek_async_coroutines(const std::string& target, const std::string& table_name, const silkworm::Bytes& key, uint32_t /*timeout*/) {
     try {
         // TODO(canepat): handle also secure channel for remote
         silkrpc::ChannelFactory create_channel = [&]() {
@@ -68,7 +68,7 @@ int kv_seek_async_coroutines(const std::string& target, const std::string& table
         auto io_context = context.io_context();
         auto& database = context.database();
 
-        boost::asio::co_spawn(*io_context, kv_seek(*database, table_name, key), [&](std::exception_ptr exptr) {
+        boost::asio::co_spawn(*io_context, kv_seek(*database, table_name, key), [&](std::exception_ptr) {
             context_pool.stop();
         });
 

--- a/cmd/rpcdaemon/silkrpc_toolbox.cpp
+++ b/cmd/rpcdaemon/silkrpc_toolbox.cpp
@@ -100,11 +100,6 @@ int kv_seek_async_callback() {
     }
 
     auto timeout{absl::GetFlag(FLAGS_timeout)};
-    if (timeout < 0) {
-        std::cerr << "Parameter timeout is invalid: [" << timeout << "]\n";
-        std::cerr << "Use --timeout flag to specify the timeout in msecs for Erigon KV gRPC calls\n";
-        return -1;
-    }
 
     return kv_seek_async_callback(target, table_name, key_bytes.value(), timeout);
 }
@@ -133,11 +128,6 @@ int kv_seek_async_coroutines() {
     }
 
     auto timeout{absl::GetFlag(FLAGS_timeout)};
-    if (timeout < 0) {
-        std::cerr << "Parameter timeout is invalid: [" << timeout << "]\n";
-        std::cerr << "Use --timeout flag to specify the timeout in msecs for Erigon KV gRPC calls\n";
-        return -1;
-    }
 
     return kv_seek_async_coroutines(target, table_name, key_bytes.value(), timeout);
 }
@@ -166,11 +156,6 @@ int kv_seek_async() {
     }
 
     auto timeout{absl::GetFlag(FLAGS_timeout)};
-    if (timeout < 0) {
-        std::cerr << "Parameter timeout is invalid: [" << timeout << "]\n";
-        std::cerr << "Use --timeout flag to specify the timeout in msecs for Erigon KV gRPC calls\n";
-        return -1;
-    }
 
     return kv_seek_async(target, table_name, key_bytes.value(), timeout);
 }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,33 @@
+#[[
+   Copyright 2020 The SilkRpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+if(MSVC)
+  add_link_options(/STACK:10000000)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  add_link_options(-Wl,-stack_size -Wl,0x1000000)
+endif()
+
+if(NOT SILKWORM_CORE_ONLY)
+
+  find_package(absl REQUIRED)
+  find_package(gRPC REQUIRED)
+  find_package(Protobuf REQUIRED)
+
+  add_executable(get_latest_block get_latest_block.cpp)
+  target_include_directories(get_latest_block PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(get_latest_block absl::flags_parse gRPC::grpc++_unsecure protobuf::libprotobuf silkrpc)
+
+endif()

--- a/examples/get_latest_block.cpp
+++ b/examples/get_latest_block.cpp
@@ -1,0 +1,107 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/silkrpc/config.hpp>
+
+#include <functional>
+#include <future>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+
+#include <absl/flags/flag.h>
+#include <absl/flags/parse.h>
+#include <absl/flags/usage.h>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/use_future.hpp>
+#include <grpcpp/grpcpp.h>
+#include <silkworm/core/common/util.hpp>
+
+#include <silkworm/silkrpc/concurrency/context_pool.hpp>
+#include <silkworm/silkrpc/common/constants.hpp>
+#include <silkworm/silkrpc/common/log.hpp>
+#include <silkworm/silkrpc/core/blocks.hpp>
+#include <silkworm/silkrpc/ethdb/transaction_database.hpp>
+#include <silkworm/silkrpc/ethdb/kv/remote_database.hpp>
+
+ABSL_FLAG(std::string, target, silkrpc::kDefaultTarget, "server location as string <address>:<port>");
+ABSL_FLAG(silkrpc::LogLevel, log_verbosity, silkrpc::LogLevel::Critical, "logging level");
+
+using silkrpc::LogLevel;
+
+boost::asio::awaitable<std::optional<uint64_t>> latest_block(silkrpc::ethdb::Database& db) {
+    std::optional<uint64_t> block_height;
+
+    const auto db_transaction = co_await db.begin();
+    try {
+        silkrpc::ethdb::TransactionDatabase tx_db_reader{*db_transaction};
+        block_height = co_await silkrpc::core::get_latest_block_number(tx_db_reader);
+    } catch (const std::exception& e) {
+        SILKRPC_ERROR << "exception: " << e.what() << "\n";
+    } catch (...) {
+        SILKRPC_ERROR << "unexpected exception\n";
+    }
+    co_await db_transaction->close();
+
+    co_return block_height;
+}
+
+std::optional<uint64_t> get_latest_block(boost::asio::io_context& io_context, silkrpc::ethdb::Database& db) {
+    auto result = boost::asio::co_spawn(io_context, latest_block(db), boost::asio::use_future);
+    return result.get();
+}
+
+int main(int argc, char* argv[]) {
+    absl::SetProgramUsageMessage("Seek Erigon/Silkworm Key-Value (KV) remote interface to database");
+    absl::ParseCommandLine(argc, argv);
+
+    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_log_verbosity));
+
+    try {
+        auto target{absl::GetFlag(FLAGS_target)};
+        if (target.empty() || target.find(":") == std::string::npos) {
+            std::cerr << "Parameter target is invalid: [" << target << "]\n";
+            std::cerr << "Use --target flag to specify the location of Turbo-Geth running instance\n";
+            return -1;
+        }
+
+        // TODO(canepat): handle also secure channel for remote
+        silkrpc::ChannelFactory create_channel = [&]() {
+            return grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+        };
+        // TODO(canepat): handle also local (shared-memory) database
+        silkrpc::ContextPool context_pool{1, create_channel};
+        auto& context = context_pool.next_context();
+        auto io_context = context.io_context();
+        auto& database = context.database();
+        auto context_pool_thread = std::thread([&]() { context_pool.run(); });
+
+        const auto latest_block_number = get_latest_block(*io_context, *database);
+        if (latest_block_number) {
+            std::cout << "latest_block_number: " << latest_block_number.value() << "\n" << std::flush;
+        }
+
+        context_pool.run();
+    } catch (const std::exception& e) {
+        std::cerr << "Exception: " << e.what() << "\n" << std::flush;
+    } catch (...) {
+        std::cerr << "Unexpected exception\n" << std::flush;
+    }
+
+    return 0;
+}

--- a/silkworm/silkrpc/API.md
+++ b/silkworm/silkrpc/API.md
@@ -1,0 +1,174 @@
+## RPC API Implementation Status
+
+The following table shows the current [JSON RPC API](https://eth.wiki/json-rpc/API) implementation status in `Silkrpc`.
+
+| Command                                    | Availability | Notes                                      |
+| :------------------------------------------| :----------: | -----------------------------------------: |
+| admin_nodeInfo                             | -            | not yet implemented                        |
+| admin_peers                                | -            | not yet implemented                        |
+|                                            |              |                                            |
+| web3_clientVersion                         | Yes          |                                            |
+| web3_sha3                                  | Yes          |                                            |
+|                                            |              |                                            |
+| net_listening                              | Yes          | hard-coded (needs ethbackend integration)  |
+| net_peerCount                              | Yes          |                                            |
+| net_version                                | Yes          |                                            |
+|                                            |              |                                            |
+| eth_blockNumber                            | Yes          |                                            |
+| eth_chainId                                | Yes          |                                            |
+| eth_protocolVersion                        | Yes          |                                            |
+| eth_syncing                                | Yes          |                                            |
+| eth_gasPrice                               | Yes          |                                            |
+| eth_maxPriorityFeePerGas                   | -            | not yet implemented                        |
+| eth_feeHistory                             | -            | not yet implemented                        |
+|                                            |              |                                            |
+| eth_getBlockByHash                         | Yes          |                                            |
+| eth_getBlockByNumber                       | Yes          |                                            |
+| eth_getBlockTransactionCountByHash         | Yes          |                                            |
+| eth_getBlockTransactionCountByNumber       | Yes          |                                            |
+| eth_getUncleByBlockHashAndIndex            | Yes          |                                            |
+| eth_getUncleByBlockNumberAndIndex          | Yes          |                                            |
+| eth_getUncleCountByBlockHash               | Yes          |                                            |
+| eth_getUncleCountByBlockNumber             | Yes          |                                            |
+|                                            |              |                                            |
+| eth_getTransactionByHash                   | Yes          | partially implemented                      |
+| eth_getRawTransactionByHash                | Yes          | partially implemented                      |
+| eth_getTransactionByBlockHashAndIndex      | Yes          |                                            |
+| eth_getRawTransactionByBlockHashAndIndex   | Yes          | partially implemented                      |
+| eth_getTransactionByBlockNumberAndIndex    | Yes          |                                            |
+| eth_getRawTransactionByBlockNumberAndIndex | Yes          | partially implemented                      |
+| eth_getTransactionReceipt                  | Yes          | partially implemented                      |
+| eth_getBlockReceipts                       | Yes          | same as parity_getBlockReceipts            |
+| eth_getTransactionReceiptsByBlockNumber    | -            | not yet implemented (eth_getBlockReceipts) |
+| eth_getTransactionReceiptsByBlockHash      | -            | not yet implemented (eth_getBlockReceipts) |
+|                                            |              |                                            |
+| eth_estimateGas                            | Yes          |                                            |
+| eth_getBalance                             | Yes          |                                            |
+| eth_getCode                                | Yes          |                                            |
+| eth_getTransactionCount                    | Yes          |                                            |
+| eth_getStorageAt                           | Yes          |                                            |
+| eth_call                                   | Yes          |                                            |
+| eth_callMany                               | -            | not yet implemented (see Erigon PR #4567)  |
+| eth_callBundle                             | Yes          |                                            |
+| eth_createAccessList                       | Yes          |                                            |
+|                                            |              |                                            |
+| eth_newFilter                              | -            | not yet implemented (see Erigon PR #4253)  |
+| eth_newBlockFilter                         | -            | not yet implemented                        |
+| eth_newPendingTransactionFilter            | -            | not yet implemented                        |
+| eth_getFilterChanges                       | -            | not yet implemented                        |
+| eth_uninstallFilter                        | -            | not yet implemented                        |
+| eth_getLogs                                | Yes          |                                            |
+|                                            |              |                                            |
+| eth_getAccount                             | -            | not yet implemented                        |
+| eth_accounts                               | No           | deprecated                                 |
+| eth_sendRawTransaction                     | Yes          | remote only                                |
+| eth_sendTransaction                        | -            | not yet implemented                        |
+| eth_sign                                   | No           | deprecated                                 |
+| eth_signTransaction                        | -            | deprecated                                 |
+| eth_signTypedData                          | -            | ????                                       |
+|                                            |              |                                            |
+| eth_getProof                               | -            | not yet implemented                        |
+|                                            |              |                                            |
+| eth_mining                                 | Yes          |                                            |
+| eth_coinbase                               | Yes          |                                            |
+| eth_hashrate                               | Yes          |                                            |
+| eth_submitHashrate                         | Yes          |                                            |
+| eth_getWork                                | Yes          |                                            |
+| eth_submitWork                             | Yes          |                                            |
+|                                            |              |                                            |
+| eth_subscribe                              | -            | not yet implemented (WebSockets only)      |
+| eth_unsubscribe                            | -            | not yet implemented (WebSockets only)      |
+|                                            |              |                                            |
+| engine_newPayloadV1                        | Yes          |                                            |
+| engine_newPayloadV2                        | -            | not yet implemented                        |
+| engine_forkchoiceUpdatedV1                 | Yes          |                                            |
+| engine_forkchoiceUpdatedV2                 | -            | not yet implemented                        |
+| engine_getPayloadV1                        | Yes          |                                            |
+| engine_getPayloadV2                        | -            | not yet implemented                        |
+| engine_exchangeTransitionConfigurationV1   | Yes          |                                            |
+|                                            |              |                                            |
+| debug_accountRange                         | Yes          |                                            |
+| debug_accountAt                            | -            | not yet implemented                        |
+| debug_getModifiedAccountsByHash            | Yes          |                                            |
+| debug_getModifiedAccountsByNumber          | Yes          |                                            |
+| debug_storageRangeAt                       | Yes          |                                            |
+| debug_traceBlockByHash                     | Yes          | uses JSON streaming                        |
+| debug_traceBlockByNumber                   | Yes          | uses JSON streaming                        |
+| debug_traceTransaction                     | Yes          | uses JSON streaming                        |
+| debug_traceCall                            | Yes          | uses JSON streaming                        |
+| debug_traceCallMany                        | -            | not yet implemented (see Erigon PR #4567)  |
+|                                            |              |                                            |
+| trace_call                                 | Yes          |                                            |
+| trace_callMany                             | Yes          |                                            |
+| trace_rawTransaction                       | Yes          |                                            |
+| trace_replayBlockTransactions              | Yes          |                                            |
+| trace_replayTransaction                    | Yes          |                                            |
+| trace_block                                | Yes          |                                            |
+| trace_filter                               | Yes          | uses JSON streaming                        |
+| trace_get                                  | Yes          |                                            |
+| trace_transaction                          | Yes          |                                            |
+|                                            |              |                                            |
+| txpool_content                             | Yes          |                                            |
+| txpool_status                              | Yes          |                                            |
+|                                            |              |                                            |
+| eth_getCompilers                           | No           | deprecated                                 |
+| eth_compileLLL                             | No           | deprecated                                 |
+| eth_compileSolidity                        | No           | deprecated                                 |
+| eth_compileSerpent                         | No           | deprecated                                 |
+|                                            |              |                                            |
+| db_putString                               | No           | deprecated                                 |
+| db_getString                               | No           | deprecated                                 |
+| db_putHex                                  | No           | deprecated                                 |
+| db_getHex                                  | No           | deprecated                                 |
+|                                            |              |                                            |
+| shh_post                                   | No           | deprecated                                 |
+| shh_version                                | No           | deprecated                                 |
+| shh_newIdentity                            | No           | deprecated                                 |
+| shh_hasIdentity                            | No           | deprecated                                 |
+| shh_newGroup                               | No           | deprecated                                 |
+| shh_addToGroup                             | No           | deprecated                                 |
+| shh_newFilter                              | No           | deprecated                                 |
+| shh_uninstallFilter                        | No           | deprecated                                 |
+| shh_getFilterChanges                       | No           | deprecated                                 |
+| shh_getMessages                            | No           | deprecated                                 |
+|                                            |              |                                            |
+| erigon_cumulativeChainTraffic              | Yes          |                                            |
+| erigon_getHeaderByHash                     | Yes          |                                            |
+| erigon_getHeaderByNumber                   | Yes          |                                            |
+| erigon_getBalanceChangesInBlock            | -            | not yet implemented                        |
+| erigon_getBlockByTimestamp                 | Yes          |                                            |
+| erigon_getBlockReceiptsByBlockHash         | -            | not yet implemented                        |
+| erigon_getLogsByHash                       | Yes          |                                            |
+| erigon_forks                               | Yes          |                                            |
+| erigon_watchTheBurn                        | Yes          |                                            |
+| erigon_nodeInfo                            | Yes          |                                            |
+| erigon_blockNumber                         | Yes          |                                            |
+| erigon_cacheCheck                          | -            | not yet implemented                        |
+| erigon_getLatestLogs                       | -            | not yet implemented                        |
+|                                            |              |                                            |
+| bor_getSnapshot                            | -            | not yet implemented                        |
+| bor_getAuthor                              | -            | not yet implemented                        |
+| bor_getSnapshotAtHash                      | -            | not yet implemented                        |
+| bor_getSigners                             | -            | not yet implemented                        |
+| bor_getSignersAtHash                       | -            | not yet implemented                        |
+| bor_getCurrentProposer                     | -            | not yet implemented                        |
+| bor_getCurrentValidators                   | -            | not yet implemented                        |
+| bor_getRootHash                            | -            | not yet implemented                        |
+|                                            |              |                                            |
+| parity_getBlockReceipts                    | Yes          | same as eth_getBlockReceipts               |
+| parity_listStorageKeys                     | Yes          |                                            |
+|                                            |              |                                            |
+| ots_getApiLevel                            | Yes          |                                            |
+| ots_getInternalOperations                  | -            | not yet implemented                        |
+| ots_searchTransactionsBefore               | -            | not yet implemented                        |
+| ots_searchTransactionsAfter                | -            | not yet implemented                        |
+| ots_getBlockDetails                        | Yes          |                                            |
+| ots_getBlockDetailsByHash                  | Yes          |                                            |
+| ots_getBlockTransactions                   | -            | not yet implemented                        |
+| ots_hasCode                                | Yes          |                                            |
+| ots_traceTransaction                       | -            | not yet implemented                        |
+| ots_getTransactionError                    | -            | not yet implemented                        |
+| ots_getTransactionBySenderAndNonce         | -            | not yet implemented                        |
+| ots_getContractCreator                     | -            | not yet implemented                        |
+
+This table is constantly updated. Please visit again.

--- a/silkworm/silkrpc/commands/ots_api.hpp
+++ b/silkworm/silkrpc/commands/ots_api.hpp
@@ -25,6 +25,7 @@
 #include <boost/asio/awaitable.hpp>
 #include <nlohmann/json.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 #include <silkworm/silkrpc/types/log.hpp>
@@ -38,14 +39,14 @@ namespace silkrpc::http { class RequestHandler; }
 namespace silkrpc::commands {
 
 class OtsRpcApi {
-public:
+  public:
     explicit OtsRpcApi(Context& context): database_(context.database()), state_cache_(context.state_cache()) {}
     virtual ~OtsRpcApi() = default;
 
     OtsRpcApi(const OtsRpcApi&) = delete;
     OtsRpcApi& operator=(const OtsRpcApi&) = delete;
 
-protected:
+  protected:
     boost::asio::awaitable<void> handle_ots_get_api_level(const nlohmann::json& request, nlohmann::json& reply);
     boost::asio::awaitable<void> handle_ots_has_code(const nlohmann::json& request, nlohmann::json& reply);
     boost::asio::awaitable<void> handle_ots_getBlockDetails(const nlohmann::json& request, nlohmann::json& reply);
@@ -56,10 +57,9 @@ protected:
     friend class silkrpc::http::RequestHandler;
 
   private:
-
-    IssuanceDetails get_issuance(const ChainConfig& chain_config, const silkworm::BlockWithHash& block);
-    intx::uint256 delegate_blockFees(const ChainConfig& chain_config, const silkworm::BlockWithHash& block, std::vector<Receipt> & receipts, const unsigned long block_number);
-
+    static IssuanceDetails get_issuance(const ChainConfig& chain_config, const silkworm::BlockWithHash& block);
+    static intx::uint256 get_block_fees(const ChainConfig& chain_config, const silkworm::BlockWithHash& block, std::vector<Receipt>& receipts, silkworm::BlockNum block_number);
 };
+
 } // namespace silkrpc::commands
 

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -342,13 +342,13 @@ void to_json(nlohmann::json& json, const BlockDetailsResponse& b) {
 
     std::vector<evmc::bytes32> ommer_hashes;
     ommer_hashes.reserve(b.block.ommers.size());
-    for (auto i{0}; i < b.block.ommers.size(); i++) {
-        ommer_hashes.emplace(ommer_hashes.end(), std::move(b.block.ommers[i].hash()));
+    for (std::size_t i{0}; i < b.block.ommers.size(); i++) {
+        ommer_hashes.emplace(ommer_hashes.end(), b.block.ommers[i].hash());
         SILKRPC_DEBUG << "ommer_hashes[" << i << "]: " << silkworm::to_hex({ommer_hashes[i].bytes, silkworm::kHashLength}) << "\n";
     }
     json["block"]["uncles"] = ommer_hashes;
 
-    if(b.issuance.total_reward > 0){
+    if (b.issuance.total_reward > 0){
         json["issuance"]["minerReward"] = silkrpc::to_quantity(b.issuance.miner_reward);
         json["issuance"]["ommersReward"] = silkrpc::to_quantity(b.issuance.ommers_reward);
         json["issuance"]["totalReward"] = silkrpc::to_quantity(b.issuance.total_reward);

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -348,7 +348,7 @@ void to_json(nlohmann::json& json, const BlockDetailsResponse& b) {
     }
     json["block"]["uncles"] = ommer_hashes;
 
-    if (b.issuance.total_reward > 0){
+    if (b.issuance.total_reward > 0) {
         json["issuance"]["minerReward"] = silkrpc::to_quantity(b.issuance.miner_reward);
         json["issuance"]["ommersReward"] = silkrpc::to_quantity(b.issuance.ommers_reward);
         json["issuance"]["totalReward"] = silkrpc::to_quantity(b.issuance.total_reward);


### PR DESCRIPTION
This PR continues the `SilkRpc` project integration. The main changes are:

- add the `examples` for usage of RpcDaemon as library
- add doc tracking JSON RPC API status progress

Moreover, this PR also removes warning suppression for RpcDaemon targets and fixes related errors