### PR TITLE
sentry: reconnecting GRPC client with retries

### DIFF
--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -21,9 +21,11 @@
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/use_future.hpp>
 #include <boost/process/environment.hpp>
+#include <grpcpp/grpcpp.h>
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/node/common/log.hpp>
 #include <silkworm/node/rpc/common/util.hpp>
 #include <silkworm/node/rpc/server/server_context_pool.hpp>
 #include <silkworm/sentry/common/awaitable_wait_for_one.hpp>

--- a/cmd/test/CMakeLists.txt
+++ b/cmd/test/CMakeLists.txt
@@ -111,4 +111,7 @@ if(NOT SILKWORM_CORE_ONLY)
   # BE&KV Tests
   add_executable(backend_kv_test "backend_kv_test.cpp;${CMD_COMMON_SRC}")
   target_link_libraries(backend_kv_test PRIVATE silkworm_node CLI11::CLI11)
+
+  add_executable(sentry_client_test "sentry_client_test.cpp")
+  target_link_libraries(sentry_client_test PRIVATE silkworm_sentry)
 endif()

--- a/cmd/test/sentry_client_test.cpp
+++ b/cmd/test/sentry_client_test.cpp
@@ -33,22 +33,18 @@ class DummyServerCompletionQueue : public grpc::ServerCompletionQueue {
 
 boost::asio::awaitable<void> run(ISentryClient& client) {
     auto service = client.service();
-    while (true) {
-        try {
-            auto eth_version = co_await service->handshake();
-            log::Info() << "handshake success!";
-            log::Info() << "protocol: eth/" << int(eth_version);
+    try {
+        auto eth_version = co_await service->handshake();
+        log::Info() << "handshake success!";
+        log::Info() << "protocol: eth/" << int(eth_version);
 
-            auto node_info = co_await service->node_info();
-            log::Info() << "client_id: " << node_info.client_id;
+        auto node_info = co_await service->node_info();
+        log::Info() << "client_id: " << node_info.client_id;
 
-            auto peer_count = co_await service->peer_count();
-            log::Info() << "peer_count: " << peer_count;
-
-            break;
-        } catch (const rpc::GrpcStatusError& ex) {
-            log::Error() << ex.what();
-        }
+        auto peer_count = co_await service->peer_count();
+        log::Info() << "peer_count: " << peer_count;
+    } catch (const rpc::GrpcStatusError& ex) {
+        log::Error() << ex.what();
     }
 }
 

--- a/cmd/test/sentry_client_test.cpp
+++ b/cmd/test/sentry_client_test.cpp
@@ -1,0 +1,89 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/use_future.hpp>
+#include <grpcpp/grpcpp.h>
+
+#include <silkworm/node/common/log.hpp>
+#include <silkworm/node/rpc/client/call.hpp>
+#include <silkworm/node/rpc/common/util.hpp>
+#include <silkworm/node/rpc/server/server_context_pool.hpp>
+#include <silkworm/sentry/rpc/client/sentry_client.hpp>
+#include <silkworm/sentry/sentry.hpp>
+
+using namespace silkworm::sentry::rpc::client;
+using namespace silkworm;
+
+class DummyServerCompletionQueue : public grpc::ServerCompletionQueue {
+};
+
+boost::asio::awaitable<void> run(ISentryClient& client) {
+    auto service = client.service();
+    while (true) {
+        try {
+            auto eth_version = co_await service->handshake();
+            log::Info() << "handshake success!";
+            log::Info() << "protocol: eth/" << int(eth_version);
+
+            auto node_info = co_await service->node_info();
+            log::Info() << "client_id: " << node_info.client_id;
+
+            auto peer_count = co_await service->peer_count();
+            log::Info() << "peer_count: " << peer_count;
+
+            break;
+        } catch (const rpc::GrpcStatusError& ex) {
+            log::Error() << ex.what();
+        }
+    }
+}
+
+int main() {
+    log::Settings log_settings;
+    log_settings.log_verbosity = log::Level::kDebug;
+    log::init(log_settings);
+    log::set_thread_name("main");
+    // TODO(canepat): this could be an option in Silkworm logging facility
+    silkworm::rpc::Grpc2SilkwormLogGuard log_guard;
+
+    sentry::Settings sentry_settings;
+
+    silkworm::rpc::ServerContextPool context_pool{
+        sentry_settings.num_contexts,
+        sentry_settings.wait_mode,
+        [] { return std::make_unique<DummyServerCompletionQueue>(); },
+    };
+
+    SentryClient client{
+        sentry_settings.api_address,
+        *context_pool.next_context().client_grpc_context(),
+    };
+
+    auto run_future = boost::asio::co_spawn(
+        context_pool.next_io_context(),
+        run(client),
+        boost::asio::use_future);
+
+    context_pool.start();
+
+    run_future.get();
+
+    context_pool.stop();
+    context_pool.join();
+
+    return 0;
+}

--- a/silkworm/node/backend/rpc/sentry_client.cpp
+++ b/silkworm/node/backend/rpc/sentry_client.cpp
@@ -39,8 +39,7 @@ RemoteSentryClient::RemoteSentryClient(agrpc::GrpcContext& grpc_context, const s
 boost::asio::awaitable<PeerCountResult> RemoteSentryClient::peer_count() {
     SILK_TRACE << "RemoteSentryClient::peer_count START address: " << address_uri_;
     sentry::PeerCountRequest request;
-    sentry::PeerCountReply reply;
-    co_await unary_rpc(&sentry::Sentry::Stub::AsyncPeerCount, stub_, request, reply, grpc_context_);
+    sentry::PeerCountReply reply = co_await unary_rpc(&sentry::Sentry::Stub::AsyncPeerCount, stub_, std::move(request), grpc_context_);
     SILK_TRACE << "RemoteSentryClient::peer_count END address: " << address_uri_;
     co_return reply;
 }
@@ -48,8 +47,7 @@ boost::asio::awaitable<PeerCountResult> RemoteSentryClient::peer_count() {
 boost::asio::awaitable<NodeInfoResult> RemoteSentryClient::node_info() {
     SILK_TRACE << "RemoteSentryClient::node_info START address: " << address_uri_;
     google::protobuf::Empty request;
-    types::NodeInfoReply reply;
-    co_await unary_rpc(&sentry::Sentry::Stub::AsyncNodeInfo, stub_, request, reply, grpc_context_);
+    types::NodeInfoReply reply = co_await unary_rpc(&sentry::Sentry::Stub::AsyncNodeInfo, stub_, std::move(request), grpc_context_);
     SILK_TRACE << "RemoteSentryClient::node_info END address: " << address_uri_;
     co_return reply;
 }
@@ -69,8 +67,7 @@ boost::asio::awaitable<SetStatusResult> RemoteSentryClient::set_status(SentrySta
         forks->add_time_forks(block);
     }
     request.set_allocated_fork_data(forks);
-    sentry::SetStatusReply reply;
-    co_await unary_rpc(&sentry::Sentry::Stub::AsyncSetStatus, stub_, request, reply, grpc_context_);
+    sentry::SetStatusReply reply = co_await unary_rpc(&sentry::Sentry::Stub::AsyncSetStatus, stub_, std::move(request), grpc_context_);
     SILK_TRACE << "RemoteSentryClient::set_status END address: " << address_uri_;
     co_return reply;
 }

--- a/silkworm/node/rpc/client/call.cpp
+++ b/silkworm/node/rpc/client/call.cpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "call.hpp"
+
+#include <silkworm/node/concurrency/async_thread.hpp>
+
+namespace silkworm::rpc::detail {
+
+bool is_disconnect_error(const GrpcStatusError& ex, grpc::Channel& channel) {
+    auto code = ex.status().error_code();
+    return (code == grpc::StatusCode::UNAVAILABLE) ||
+           ((code == grpc::StatusCode::DEADLINE_EXCEEDED) && (channel.GetState(false) != GRPC_CHANNEL_READY) && (channel.GetState(false) != GRPC_CHANNEL_SHUTDOWN));
+}
+
+boost::asio::awaitable<void> reconnect_channel(grpc::Channel& channel) {
+    bool is_stopped = false;
+
+    std::function<void()> run = [&] {
+        bool is_connected = false;
+        while (!is_connected && !is_stopped && (channel.GetState(false) != GRPC_CHANNEL_SHUTDOWN)) {
+            log::Info() << "Reconnecting grpc::Channel...";
+            auto deadline = gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), gpr_time_from_seconds(5, GPR_TIMESPAN));
+            is_connected = channel.WaitForConnected(deadline);
+        }
+    };
+
+    std::function<void()> stop = [&] {
+        is_stopped = true;
+    };
+
+    co_await concurrency::async_thread(std::move(run), std::move(stop));
+}
+
+}  // namespace silkworm::rpc::detail

--- a/silkworm/node/rpc/client/call.hpp
+++ b/silkworm/node/rpc/client/call.hpp
@@ -31,6 +31,8 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <grpcpp/grpcpp.h>
 
+#include <silkworm/node/common/log.hpp>
+
 namespace silkworm::rpc {
 
 class GrpcStatusError : public std::runtime_error {
@@ -100,6 +102,59 @@ boost::asio::awaitable<void> streaming_rpc(
 
     if (!status.ok()) {
         throw GrpcStatusError(std::move(status));
+    }
+}
+
+namespace detail {
+    bool is_disconnect_error(const GrpcStatusError& ex, grpc::Channel& channel);
+    boost::asio::awaitable<void> reconnect_channel(grpc::Channel& channel);
+}  // namespace detail
+
+template <class Stub, class Request, class Response>
+boost::asio::awaitable<Response> unary_rpc_with_retries(
+    agrpc::detail::ClientUnaryRequest<Stub, Request, grpc::ClientAsyncResponseReader<Response>> rpc,
+    std::unique_ptr<Stub>& stub,
+    Request request,
+    agrpc::GrpcContext& grpc_context,
+    grpc::Channel& channel) {
+    // loop until a successful return or cancellation
+    while (true) {
+        try {
+            co_return (co_await unary_rpc(rpc, stub, request, grpc_context));
+        } catch (const GrpcStatusError& ex) {
+            if (detail::is_disconnect_error(ex, channel)) {
+                log::Warning() << "GRPC call failed: " << ex.what();
+            } else {
+                throw;
+            }
+        }
+
+        co_await detail::reconnect_channel(channel);
+    }
+}
+
+template <class Stub, class Request, class Response>
+boost::asio::awaitable<void> streaming_rpc_with_retries(
+    agrpc::detail::PrepareAsyncClientServerStreamingRequest<Stub, Request, grpc::ClientAsyncReader<Response>> rpc,
+    std::unique_ptr<Stub>& stub,
+    Request request,
+    agrpc::GrpcContext& grpc_context,
+    grpc::Channel& channel,
+    std::function<boost::asio::awaitable<void>(Response)> consumer) {
+    // loop until a successful return or cancellation
+    while (true) {
+        try {
+            co_await streaming_rpc(rpc, stub, request, grpc_context, consumer);
+            break;
+        } catch (const GrpcStatusError& ex) {
+            if (detail::is_disconnect_error(ex, channel)) {
+                log::Warning() << "GRPC streaming call failed: " << ex.what();
+            } else {
+                throw;
+            }
+        }
+
+        co_await detail::reconnect_channel(channel);
     }
 }
 

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -81,8 +81,13 @@ set(LIBS
   silkworm-buildinfo
 )
 
+set(LIBS_INTERFACE
+  Boost::thread
+  silkworm_node
+)
+
 if(MSVC)
   list(APPEND LIBS ntdll.lib)
 endif(MSVC)
 
-target_link_libraries(${TARGET} PRIVATE ${LIBS})
+target_link_libraries(${TARGET} PRIVATE ${LIBS} INTERFACE ${LIBS_INTERFACE})

--- a/silkworm/sentry/rlpx/client.cpp
+++ b/silkworm/sentry/rlpx/client.cpp
@@ -55,11 +55,11 @@ awaitable<std::unique_ptr<Peer>> Client::connect(
         } catch (const boost::system::system_error& ex) {
             if (ex.code() == boost::system::errc::operation_canceled)
                 throw;
-            log::Debug() << "RLPx client connect exception: " << ex.what();
+            log::Warning() << "RLPx client connect exception: " << ex.what();
         }
         if (!is_connected) {
             stream = common::SocketStream{client_context};
-            log::Warning() << "Failed to connect to " << peer_url.to_string() << ", reconnecting...";
+            log::Info() << "Failed to connect to " << peer_url.to_string() << ", reconnecting...";
             co_await common::sleep(10s);
         }
     }

--- a/silkworm/sentry/rpc/client/sentry_client.cpp
+++ b/silkworm/sentry/rpc/client/sentry_client.cpp
@@ -65,15 +65,13 @@ class SentryClientImpl final : public api::api_common::Service {
     // rpc SetStatus(StatusData) returns (SetStatusReply);
     awaitable<void> set_status(eth::StatusData status_data) override {
         proto::StatusData request = interfaces::proto_status_data_from_status_data(status_data);
-        proto::SetStatusReply reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncSetStatus, stub_, request, reply, grpc_context_);
+        co_await sw_rpc::unary_rpc(&Stub::AsyncSetStatus, stub_, std::move(request), grpc_context_);
     }
 
     // rpc HandShake(google.protobuf.Empty) returns (HandShakeReply);
     awaitable<uint8_t> handshake() override {
         google::protobuf::Empty request;
-        proto::HandShakeReply reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncHandShake, stub_, request, reply, grpc_context_);
+        proto::HandShakeReply reply = co_await sw_rpc::unary_rpc(&Stub::AsyncHandShake, stub_, std::move(request), grpc_context_);
         uint8_t result = interfaces::eth_version_from_protocol(reply.protocol());
         co_return result;
     }
@@ -81,8 +79,7 @@ class SentryClientImpl final : public api::api_common::Service {
     // rpc NodeInfo(google.protobuf.Empty) returns(types.NodeInfoReply);
     awaitable<NodeInfo> node_info() override {
         google::protobuf::Empty request;
-        types::NodeInfoReply reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncNodeInfo, stub_, request, reply, grpc_context_);
+        types::NodeInfoReply reply = co_await sw_rpc::unary_rpc(&Stub::AsyncNodeInfo, stub_, std::move(request), grpc_context_);
         auto result = interfaces::node_info_from_proto_node_info(reply);
         co_return result;
     }
@@ -93,8 +90,7 @@ class SentryClientImpl final : public api::api_common::Service {
         request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
 
-        proto::SentPeers reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageById, stub_, request, reply, grpc_context_);
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageById, stub_, std::move(request), grpc_context_);
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -105,8 +101,7 @@ class SentryClientImpl final : public api::api_common::Service {
         request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
         request.set_max_peers(max_peers);
 
-        proto::SentPeers reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageToRandomPeers, stub_, request, reply, grpc_context_);
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageToRandomPeers, stub_, std::move(request), grpc_context_);
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -114,8 +109,7 @@ class SentryClientImpl final : public api::api_common::Service {
     // rpc SendMessageToAll(OutboundMessageData) returns (SentPeers);
     awaitable<PeerKeys> send_message_to_all(common::Message message) override {
         proto::OutboundMessageData request = interfaces::outbound_data_from_message(message);
-        proto::SentPeers reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageToAll, stub_, request, reply, grpc_context_);
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageToAll, stub_, std::move(request), grpc_context_);
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -128,8 +122,7 @@ class SentryClientImpl final : public api::api_common::Service {
         // request.set_min_block()
         request.set_max_peers(max_peers);
 
-        proto::SentPeers reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageByMinBlock, stub_, request, reply, grpc_context_);
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc(&Stub::AsyncSendMessageByMinBlock, stub_, std::move(request), grpc_context_);
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -140,8 +133,7 @@ class SentryClientImpl final : public api::api_common::Service {
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
         // TODO: set_min_block
         // request.set_min_block()
-        google::protobuf::Empty reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerMinBlock, stub_, request, reply, grpc_context_);
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerMinBlock, stub_, std::move(request), grpc_context_);
     }
 
     // rpc Messages(MessagesRequest) returns (stream InboundMessage);
@@ -170,8 +162,7 @@ class SentryClientImpl final : public api::api_common::Service {
     // rpc Peers(google.protobuf.Empty) returns (PeersReply);
     awaitable<PeerInfos> peers() override {
         google::protobuf::Empty request;
-        proto::PeersReply reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncPeers, stub_, request, reply, grpc_context_);
+        proto::PeersReply reply = co_await sw_rpc::unary_rpc(&Stub::AsyncPeers, stub_, std::move(request), grpc_context_);
         auto result = interfaces::peer_infos_from_proto_peers_reply(reply);
         co_return result;
     }
@@ -179,8 +170,7 @@ class SentryClientImpl final : public api::api_common::Service {
     // rpc PeerCount(PeerCountRequest) returns (PeerCountReply);
     awaitable<size_t> peer_count() override {
         proto::PeerCountRequest request;
-        proto::PeerCountReply reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerCount, stub_, request, reply, grpc_context_);
+        proto::PeerCountReply reply = co_await sw_rpc::unary_rpc(&Stub::AsyncPeerCount, stub_, std::move(request), grpc_context_);
         auto result = static_cast<size_t>(reply.count());
         co_return result;
     }
@@ -189,8 +179,7 @@ class SentryClientImpl final : public api::api_common::Service {
     awaitable<std::optional<PeerInfo>> peer_by_id(common::EccPublicKey public_key) override {
         proto::PeerByIdRequest request;
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
-        proto::PeerByIdReply reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerById, stub_, request, reply, grpc_context_);
+        proto::PeerByIdReply reply = co_await sw_rpc::unary_rpc(&Stub::AsyncPeerById, stub_, std::move(request), grpc_context_);
         auto result = interfaces::peer_info_opt_from_proto_peer_reply(reply);
         co_return result;
     }
@@ -200,16 +189,14 @@ class SentryClientImpl final : public api::api_common::Service {
         proto::PenalizePeerRequest request;
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
         request.set_penalty(proto::PenaltyKind::Kick);
-        google::protobuf::Empty reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncPenalizePeer, stub_, request, reply, grpc_context_);
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPenalizePeer, stub_, std::move(request), grpc_context_);
     }
 
     // rpc PeerUseless(PeerUselessRequest) returns (google.protobuf.Empty);
     awaitable<void> peer_useless(common::EccPublicKey public_key) override {
         proto::PeerUselessRequest request;
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
-        google::protobuf::Empty reply;
-        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerUseless, stub_, request, reply, grpc_context_);
+        co_await sw_rpc::unary_rpc(&Stub::AsyncPeerUseless, stub_, std::move(request), grpc_context_);
     }
 
     // rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);


### PR DESCRIPTION
* add sentry_client_test cmd to test the client API
* refactor unary_rpc to return replies
* wrap unary_rpc/streaming_rpc with reconnect/retry logic
