### PR TITLE
rpcdaemon: add glaze submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,3 +41,6 @@
 [submodule "third_party/expected"]
 	path = third_party/expected
 	url = https://github.com/TartanLlama/expected.git
+[submodule "third_party/glaze"]
+	path = third_party/glaze
+	url = https://github.com/stephenberry/glaze

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ if(NOT SILKWORM_CORE_ONLY)
     
 endif()
 
+add_subdirectory(third_party/glaze)
+
 # evmone with dependencies
 if(SILKWORM_WASM_API)
   add_compile_definitions(EVMC_LOADER_MOCK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,10 @@ if(NOT SILKWORM_CORE_ONLY)
   # CBOR
   add_subdirectory(third_party/cbor-cpp)
     
+  # GLAZE
+  add_subdirectory(third_party/glaze)
 endif()
 
-add_subdirectory(third_party/glaze)
 
 # evmone with dependencies
 if(SILKWORM_WASM_API)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,6 @@ if(NOT SILKWORM_CORE_ONLY)
   add_subdirectory(third_party/glaze)
 endif()
 
-
 # evmone with dependencies
 if(SILKWORM_WASM_API)
   add_compile_definitions(EVMC_LOADER_MOCK)

--- a/silkworm/silkrpc/CMakeLists.txt
+++ b/silkworm/silkrpc/CMakeLists.txt
@@ -75,5 +75,6 @@ add_dependencies(silkrpc generate_ethbackend_grpc generate_kv_grpc generate_mini
 target_include_directories(silkrpc PUBLIC
         ${SILKWORM_MAIN_DIR}
         ${SILKWORM_MAIN_SRC_DIR}/interfaces
+        ${SILKWORM_MAIN_DIR}/third_party/glaze/include
         ${SILKWORM_MAIN_DIR}/third_party/evmone/lib)
 target_link_libraries(silkrpc PUBLIC ${SILKRPC_LIBRARIES})


### PR DESCRIPTION
This PR add a new submodule for [glaze](https://github.com/stephenberry/glaze), a fast JSON library which is showing promising performance figures in `eth_getLogs` tests.