### PR TITLE
build: fix Windows MSVC build

### DIFF
--- a/cmake/profiles/windows_msvc_17_debug
+++ b/cmake/profiles/windows_msvc_17_debug
@@ -5,7 +5,7 @@ arch=x86_64
 arch_build=x86_64
 compiler=Visual Studio
 compiler.version=17
-compiler.runtime=MTd
+compiler.runtime=MDd
 build_type=Debug
 [options]
 [build_requires]

--- a/cmake/profiles/windows_msvc_17_release
+++ b/cmake/profiles/windows_msvc_17_release
@@ -5,7 +5,7 @@ arch=x86_64
 arch_build=x86_64
 compiler=Visual Studio
 compiler.version=17
-compiler.runtime=MT
+compiler.runtime=MD
 build_type=Release
 [options]
 [build_requires]

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -85,6 +85,21 @@ if(NOT MSVC)
     PREFIX "${GMP_INSTALL_DIR}"
     BUILD_BYPRODUCTS "${GMP_LIBRARY}"
   )
+else()
+  find_path(GMP_INCLUDE_DIR NAMES gmp.h)
+  find_library(GMP_LIBRARY mpir)
+  if(GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(gmp_library_type SHARED)
+  else()
+    set(gmp_library_type STATIC)
+  endif()
+  message(STATUS "GMP: ${GMP_LIBRARY}, ${GMP_INCLUDE_DIR}")
+  add_library(gmp ${gmp_library_type} IMPORTED)
+  set_target_properties(
+          gmp PROPERTIES
+          IMPORTED_LOCATION ${GMP_LIBRARY}
+          INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
+  )
 endif()
 
 # secp256k1


### PR DESCRIPTION
Fix Windows build:
- [x] repair cmake file providing instructions for gmp library
- [ ] install conan on CI job (next PR)
- [ ] switch default build system from Hunter to Conan (next PR)