### PR TITLE
sync: fix stats loop termination for Sentry client when disconnected

### DIFF
--- a/silkworm/sync/sentry_client.cpp
+++ b/silkworm/sync/sentry_client.cpp
@@ -145,6 +145,9 @@ void SentryClient::execution_loop() {
     // (we would redo set_status & hand-shake too)
     log::Warning("SentryClient") << "execution loop is stopping...";
     stop();
+
+    connected_ = true;
+    connected_.notify_all();
 }
 
 void SentryClient::stats_receiving_loop() {


### PR DESCRIPTION
This PR fixes the receiving stats loop in synchronous Sentry client, which hangs at termination if not connected to the Sentry component