### PR TITLE
node: avoid explicit MDBX close when the RW transaction is still open

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -570,12 +570,9 @@ int main(int argc, char* argv[]) {
         asio_guard.reset();
         asio_thread.join();
 
-        log::Message() << "Closing database chaindata path: " << node_settings.data_directory->chaindata().path();
-        chaindata_db.close();
-        log::Message() << "Database closed";
+        log::Message() << "Exiting Silkworm";
 
         return 0;
-
     } catch (const CLI::ParseError& ex) {
         return cli.exit(ex);
     } catch (const std::runtime_error& ex) {

--- a/silkworm/infra/concurrency/signal_handler.cpp
+++ b/silkworm/infra/concurrency/signal_handler.cpp
@@ -116,7 +116,7 @@ void SignalHandler::handle(int sig_code) {
     bool expected{false};
     if (signalled_.compare_exchange_strong(expected, true)) {
         sig_code_ = sig_code;
-        std::fputs("Got ", stderr);
+        std::fputs("\nGot ", stderr);
         std::fputs(sig_name(sig_code), stderr);
         std::fputs(". Shutting down ...\n", stderr);
     }


### PR DESCRIPTION
It is incorrect to explicitly close mdbx::env_managed if one R/W transaction is still open because it will cause a runtime error in mdbx_lck_destroy (the R/W transaction is in ExecutionEngine instance).

Let mdbx::env_managed and ExecutionEngine destructors do the cleanup in correct order:
- mdbx::env_managed constructor (create MDBX environment)
- ExecutionEngine constructor (create read/write mdbx::txn)
...
- ExecutionEngine destructor (delete read/write mdbx::txn)
- mdbx::env_managed destructor (delete MDBX environment)