### PR TITLE
node: add snapshots subfolder in data directory structure

### DIFF
--- a/silkworm/infra/common/directories.hpp
+++ b/silkworm/infra/common/directories.hpp
@@ -88,7 +88,8 @@ class TemporaryDirectory final : public Directory {
 //! <base_path>
 //! ├───chaindata   <-- Where main database is stored
 //! ├───etl-temp    <-- Where temporary files from etl collector are stored
-//! └───nodes       <-- Where database(s) for discovered nodes are stored
+//! ├───nodes       <-- Where database(s) for discovered nodes are stored
+//! └───snapshots   <-- Where snapshot files for blocks/transactions/... are stored
 class DataDirectory final : public Directory {
   public:
     //! \brief Creates an instance of Silkworm's data directory given an initial base path
@@ -98,7 +99,8 @@ class DataDirectory final : public Directory {
         : Directory(base_path, create),
           chaindata_(base_path / "chaindata", create),
           etl_(base_path / "etl-temp", create),
-          nodes_(base_path / "nodes", create) {}
+          nodes_(base_path / "nodes", create),
+          snapshots_(base_path / "snapshots", create) {}
 
     //! \brief Creates an instance of Silkworm's data directory starting from default storage path. (each host OS has
     //! its own)
@@ -140,11 +142,14 @@ class DataDirectory final : public Directory {
     [[nodiscard]] const Directory& etl() const { return etl_; }
     //! \brief Returns the "nodes" directory (where discovery nodes info are stored)
     [[nodiscard]] const Directory& nodes() const { return nodes_; }
+    //! \brief Returns the "snapshots" directory (where snapshot files are stored)
+    [[nodiscard]] const Directory& snapshots() const { return snapshots_; }
 
   private:
     Directory chaindata_;  // Database storage
     Directory etl_;        // Temporary etl files
     Directory nodes_;      // Nodes discovery databases
+    Directory snapshots_;  // Snapshot files
 };
 
 }  // namespace silkworm

--- a/silkworm/node/snapshot/path.hpp
+++ b/silkworm/node/snapshot/path.hpp
@@ -28,8 +28,6 @@
 
 namespace silkworm {
 
-constexpr const char* kDefaultSnapshotDir{"snapshots"};
-
 //! The scale factor to convert the block numbers to/from the values in snapshot file names
 constexpr int kFileNameBlockScaleFactor{1'000};
 

--- a/silkworm/node/snapshot/settings.hpp
+++ b/silkworm/node/snapshot/settings.hpp
@@ -18,18 +18,19 @@
 
 #include <filesystem>
 
+#include <silkworm/infra/common/directories.hpp>
 #include <silkworm/node/bittorrent/settings.hpp>
 #include <silkworm/node/snapshot/path.hpp>
 
 namespace silkworm {
 
 struct SnapshotSettings {
-    std::filesystem::path repository_dir{kDefaultSnapshotDir};  // Path to the snapshot repository on disk
-    bool enabled{true};                                         // Flag indicating if snapshots are enabled
-    bool no_downloader{false};                                  // Flag indicating if snapshots download is disabled
-    bool verify_on_startup{true};                               // Flag indicating if snapshots will be verified on startup
-    uint64_t segment_size{kDefaultSegmentSize};                 // The segment size measured as number of blocks
-    BitTorrentSettings bittorrent_settings;                     // The Bittorrent protocol settings
+    std::filesystem::path repository_dir{DataDirectory{}.snapshots().path()};  // Path to the snapshot repository on disk
+    bool enabled{true};                                                        // Flag indicating if snapshots are enabled
+    bool no_downloader{false};                                                 // Flag indicating if snapshots download is disabled
+    bool verify_on_startup{true};                                              // Flag indicating if snapshots will be verified on startup
+    uint64_t segment_size{kDefaultSegmentSize};                                // The segment size measured as number of blocks
+    BitTorrentSettings bittorrent_settings;                                    // The Bittorrent protocol settings
 };
 
 }  // namespace silkworm

--- a/silkworm/node/snapshot/sync.cpp
+++ b/silkworm/node/snapshot/sync.cpp
@@ -39,9 +39,11 @@ SnapshotSync::~SnapshotSync() {
 
 bool SnapshotSync::download_and_index_snapshots(db::RWTxn& txn) {
     if (!settings_.enabled) {
-        log::Info() << "snapshot sync disabled, no snapshot must be downloaded";
+        log::Info() << "[Snapshots] snapshot sync disabled, no snapshot must be downloaded";
         return true;
     }
+
+    log::Info() << "[Snapshots] snapshot repository: " << settings_.repository_dir.string();
 
     if (settings_.no_downloader) {
         repository_.reopen_folder();


### PR DESCRIPTION
This PR applies the following changes:

- add snapshots subfolder in data directory structure (e.g. chain data/etl-temp/nodes/snapshots)
- change default value for snapshot data directory
- improve logging to include tag and snapshot data directory 