### PR TITLE
infra: future/promise compatible w/ different Asio completion tokens

### DIFF
--- a/silkworm/infra/concurrency/awaitable_future.hpp
+++ b/silkworm/infra/concurrency/awaitable_future.hpp
@@ -1,0 +1,101 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <stdexcept>
+
+#include <silkworm/infra/concurrency/coroutine.hpp>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/experimental/concurrent_channel.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/use_future.hpp>
+
+namespace silkworm::concurrency {
+
+namespace asio = boost::asio;
+
+template <typename T>
+using async_channel = asio::experimental::concurrent_channel<void(std::exception_ptr, T)>;
+
+// An awaitable-friendly future/promise
+
+template <typename T>
+class AwaitablePromise;
+
+template <typename T>
+class AwaitableFuture {
+  public:
+    AwaitableFuture(const AwaitableFuture&) = delete;
+    AwaitableFuture(AwaitableFuture&& orig) : channel_(std::move(orig.channel_)) {}
+
+    template <typename CompletionToken>
+    auto get(CompletionToken completion_token) {
+        return channel_->async_receive(completion_token);
+    }
+
+    T get() {
+        return channel_->async_receive(asio::use_future).get();
+    }
+
+  private:
+    friend class AwaitablePromise<T>;
+
+    explicit AwaitableFuture(std::shared_ptr<async_channel<T>> channel) : channel_(channel) {}
+
+    std::shared_ptr<async_channel<T>> channel_;
+};
+
+template <typename T>
+class AwaitablePromise {
+    inline static size_t one_shot_channel = 1;
+
+  public:
+    explicit AwaitablePromise(asio::any_io_executor&& executor) : channel_(std::make_shared<async_channel<T>>(executor, one_shot_channel)) {}
+    explicit AwaitablePromise(asio::any_io_executor& executor) : channel_(std::make_shared<async_channel<T>>(executor, one_shot_channel)) {}
+    explicit AwaitablePromise(asio::io_context& io_context) : channel_(std::make_shared<async_channel<T>>(io_context, one_shot_channel)) {}
+
+    AwaitablePromise(const AwaitablePromise&) = delete;
+    AwaitablePromise(AwaitablePromise&& orig) : channel_(std::move(orig.channel_)) {}
+
+    template <typename CompletionToken>
+    auto set_value(T value, CompletionToken completion_token) {
+        return channel_->async_send(nullptr, std::move(value), completion_token);
+    }
+    void set_value(T value) {
+        set_value(std::move(value), asio::detached);
+    }
+
+    template <typename CompletionToken>
+    auto set_exception(std::exception_ptr ptr, CompletionToken completion_token) {
+        return channel_->async_send(ptr, T{}, completion_token);
+    }
+    void set_exception(std::exception_ptr ptr) {
+        set_exception(ptr, asio::detached);
+    }
+
+    AwaitableFuture<T> get_future() { return AwaitableFuture<T>(channel_); }
+
+  private:
+    std::shared_ptr<async_channel<T>> channel_;
+};
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/awaitable_future.hpp
+++ b/silkworm/infra/concurrency/awaitable_future.hpp
@@ -91,7 +91,8 @@ class AwaitablePromise {
         return channel_->async_send(ptr, T{}, completion_token);
     }
     void set_exception(std::exception_ptr ptr) {
-        set_exception(ptr, asio::detached);
+        bool sent = channel_->try_send(ptr, T{});
+        if (!sent) throw std::runtime_error("AwaitablePromise::set_exception: channel is full");
     }
 
     AwaitableFuture<T> get_future() { return AwaitableFuture<T>(channel_); }

--- a/silkworm/infra/concurrency/awaitable_future.hpp
+++ b/silkworm/infra/concurrency/awaitable_future.hpp
@@ -80,8 +80,10 @@ class AwaitablePromise {
     auto set_value(T value, CompletionToken completion_token) {
         return channel_->async_send(nullptr, std::move(value), completion_token);
     }
+
     void set_value(T value) {
-        set_value(std::move(value), asio::detached);
+        bool sent = channel_->try_send(nullptr, std::move(value));
+        if (!sent) throw std::runtime_error("AwaitablePromise::set_value: channel is full");
     }
 
     template <typename CompletionToken>

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -145,9 +145,11 @@ TEST_CASE("awaitable future") {
         asio::co_spawn(
             io,
             [&]() -> asio::awaitable<void> {
-                co_await promise.set_value(42, asio::use_awaitable);
+                promise.set_value(42);
+                co_return;
             },
             asio::detached);
+
         io.run();
         concurrent.join();
 
@@ -162,7 +164,7 @@ TEST_CASE("awaitable future") {
             io,
             [&]() -> asio::awaitable<void> {
                 auto future = promise.get_future();
-                value = co_await future.get(asio::use_awaitable);
+                value = co_await future.get_async();
                 io.stop();
             },
             asio::detached);
@@ -180,8 +182,8 @@ TEST_CASE("awaitable future") {
         int value;
         asio::co_spawn(
             io,
-            [&]() -> asio::awaitable<void> {  // <====
-                value = co_await future.get(asio::use_awaitable);
+            [&]() -> asio::awaitable<void> {
+                value = co_await future.get_async();
                 io.stop();
             },
             asio::detached);
@@ -198,7 +200,7 @@ TEST_CASE("awaitable future") {
 
         int value;
         auto lambda = [&](AwaitableFuture<int>&& moved_future) -> asio::awaitable<void> {
-            value = co_await moved_future.get(asio::use_awaitable);
+            value = co_await moved_future.get_async();
             io.stop();
         };
 
@@ -218,7 +220,7 @@ TEST_CASE("awaitable future") {
             io,
             [&]() -> asio::awaitable<void> {
                 auto future = promise.get_future();
-                value = co_await future.get(asio::use_awaitable);
+                value = co_await future.get_async();
                 io.stop();
             },
             asio::detached);
@@ -226,7 +228,8 @@ TEST_CASE("awaitable future") {
         asio::co_spawn(
             io,
             [&]() -> asio::awaitable<void> {
-                co_await promise.set_value(42, asio::use_awaitable);
+                promise.set_value(42);
+                co_return;
             },
             asio::detached);
 

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -1,0 +1,153 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "awaitable_future.hpp"
+
+#include <catch2/catch.hpp>
+
+namespace silkworm {
+
+namespace asio = boost::asio;
+using concurrency::AwaitableFuture;
+using concurrency::AwaitablePromise;
+
+auto create_promise_and_set_value(asio::io_context& io, int value) {
+    concurrency::AwaitablePromise<int> promise{io};
+    promise.set_value(value);
+    return promise.get_future();
+}
+
+TEST_CASE("awaitable future") {
+    asio::io_context io;
+
+    std::jthread execution([&](std::stop_token stop_token) {
+        while (!stop_token.stop_requested())
+            io.run();
+    });
+
+    SECTION("blocking get - normal") {
+        AwaitablePromise<int> promise{io};
+        auto future = promise.get_future();
+
+        promise.set_value(42);
+        auto value = future.get();
+
+        CHECK(value == 42);
+
+        // The destructor of jthread calls request_stop() and join()
+    }
+
+    SECTION("blocking get - exception") {
+        AwaitablePromise<int> promise{io};
+        auto future = promise.get_future();
+
+        promise.set_exception(std::make_exception_ptr(new std::exception()));
+
+        CHECK_THROWS(future.get());
+    }
+
+    SECTION("blocking get - promise destroyed first (1)") {
+        auto future = create_promise_and_set_value(io, 42);
+
+        auto value = future.get();
+
+        CHECK(value == 42);
+    }
+
+    SECTION("blocking get - promise destroyed first (2)") {
+        auto future = [&]() {
+            concurrency::AwaitablePromise<int> promise{io};
+            auto future = promise.get_future();
+            promise.set_value(42);
+            return future;
+        }();
+
+        auto value = future.get();
+
+        CHECK(value == 42);
+    }
+
+    SECTION("blocking get - promise destroyed second") {
+        AwaitablePromise<int> promise{io};
+        int value;
+
+        std::jthread concurrent([&]() {
+            auto future = promise.get_future();
+            value = future.get();
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        promise.set_value(42);
+        concurrent.join();
+
+        CHECK(value == 42);
+    }
+
+    SECTION("awaitable get") {
+        AwaitablePromise<int> promise{io};
+        int value;
+
+        auto spawned_exec = asio::co_spawn(
+            io,
+            [&]() -> asio::awaitable<void> {
+                auto future = promise.get_future();
+                value = co_await future.get(asio::use_awaitable);
+            },
+            asio::use_future);
+
+        promise.set_value(42);
+        spawned_exec.get();
+
+        CHECK(value == 42);
+    }
+
+    SECTION("blocking set / awaitable get") {
+        AwaitablePromise<int> promise{io};
+        int value;
+
+        auto spawned_exec = asio::co_spawn(
+            io,
+            [&]() -> asio::awaitable<void> {
+                auto future = promise.get_future();
+                value = co_await future.get(asio::use_awaitable);
+            },
+            asio::use_future);
+
+        promise.set_value(42, asio::use_future).get();
+        spawned_exec.get();
+
+        CHECK(value == 42);
+    }
+
+    SECTION("awaiting forever on get") {
+        AwaitablePromise<int> promise{io};
+        int value = 0;
+
+        auto spawned_exec = asio::co_spawn(
+            io,
+            [&]() -> asio::awaitable<void> {
+                auto future = promise.get_future();
+                value = co_await future.get(asio::use_awaitable);
+            },
+            asio::use_future);
+
+        spawned_exec.wait_for(std::chrono::milliseconds(100));
+
+        CHECK(value == 0);
+    }
+}
+
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -63,7 +63,20 @@ TEST_CASE("awaitable future") {
         AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
-        promise.set_exception(std::make_exception_ptr(new std::exception()));
+        promise.set_exception(std::make_exception_ptr(std::exception()));
+
+        CHECK_THROWS(future.get());
+    }
+
+    SECTION("variation of setting exception instead of value") {
+        AwaitablePromise<int> promise{io};
+        auto future = promise.get_future();
+
+        try {
+            throw std::exception();
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
 
         CHECK_THROWS(future.get());
     }

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -105,7 +105,8 @@ TEST_CASE("awaitable future") {
         int value;
         std::thread concurrent([&](AwaitableFuture<int>&& future) {
             value = future.get();
-        }, std::move(future));
+        },
+                               std::move(future));
 
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -135,8 +135,8 @@ TEST_CASE("awaitable future") {
         std::thread concurrent([&](AwaitableFuture<int>&& moved_future) {
             auto spawned_exec = asio::co_spawn(
                 io,
-                [](int& value, AwaitableFuture<int>&& further_moved_future) -> asio::awaitable<void> {
-                    value = co_await further_moved_future.get(asio::use_awaitable);
+                [](int& value_ref, AwaitableFuture<int>&& further_moved_future) -> asio::awaitable<void> {
+                    value_ref = co_await further_moved_future.get(asio::use_awaitable);
                 }(value, std::move(moved_future)),
                 asio::use_future);
             spawned_exec.get();

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -135,8 +135,8 @@ TEST_CASE("awaitable future") {
         std::thread concurrent([&](AwaitableFuture<int>&& moved_future) {
             auto spawned_exec = asio::co_spawn(
                 io,
-                [](int& value, AwaitableFuture<int>&& moved_future) -> asio::awaitable<void> {
-                    value = co_await moved_future.get(asio::use_awaitable);
+                [](int& value, AwaitableFuture<int>&& further_moved_future) -> asio::awaitable<void> {
+                    value = co_await further_moved_future.get(asio::use_awaitable);
                 }(value, std::move(moved_future)),
                 asio::use_future);
             spawned_exec.get();

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -68,6 +68,14 @@ TEST_CASE("awaitable future") {
         CHECK_THROWS(future.get());
     }
 
+    SECTION("setting value two times") {
+        AwaitablePromise<int> promise{io};
+
+        promise.set_value(42);
+
+        CHECK_THROWS(promise.set_value(43));
+    }
+
     SECTION("returning the future from a function") {
         auto future = create_promise_and_set_value(io, 42);
 
@@ -206,7 +214,6 @@ TEST_CASE("awaitable future") {
             io,
             [&]() -> asio::awaitable<void> {
                 co_await promise.set_value(42, asio::use_awaitable);
-                io.stop();
             },
             asio::detached);
 


### PR DESCRIPTION
Add to Infra package a couple of classes that 
- mimic the interface and the structure of standard future/promise
- work well with asio, supporting different patterns of usage (coroutine/future/etc.)

Their implementation is copied from the existing Sentry's AwaitablePromise but unlike it they break the class into two halves as standard classes do by dividing the interface that the producer uses from the interface that the consumer uses. This makes it possible to decouple the two better and pass the future to a consumer in another component.
