### PR TITLE
node: snapshot full download

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -37,6 +37,7 @@
 #include <silkworm/infra/rpc/server/server_context_pool.hpp>
 #include <silkworm/node/backend/ethereum_backend.hpp>
 #include <silkworm/node/backend/remote/backend_kv_server.hpp>
+#include <silkworm/node/common/os.hpp>
 #include <silkworm/node/common/settings.hpp>
 #include <silkworm/node/db/genesis.hpp>
 #include <silkworm/node/db/stages.hpp>
@@ -285,6 +286,16 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], Silkworm
     server_settings.set_context_pool_settings(context_pool_settings);
 
     snapshot_settings.bittorrent_settings.repository_path = snapshot_settings.repository_dir;
+}
+
+//! Raise allowed max file descriptors in the current process
+void raise_max_file_descriptors() {
+    constexpr uint64_t kMaxFileDescriptors{10'240};
+
+    const bool set_fd_result = silkworm::os::set_max_file_descriptors(kMaxFileDescriptors);
+    if (!set_fd_result) {
+        throw std::runtime_error{"Cannot increase max file descriptor up to " + std::to_string(kMaxFileDescriptors)};
+    }
 }
 
 //! \brief Ensure database is ready to take off and consistent with command line arguments
@@ -578,6 +589,9 @@ int main(int argc, char* argv[]) {
         BlockExchange block_exchange{sync_sentry_client, sw_db::ROAccess{chaindata_db}, node_settings.chain_config.value()};
 
         if (snapshot_settings.enabled) {
+            // Raise file descriptor limit per process
+            raise_max_file_descriptors();
+
             sw_db::RWTxn rw_txn{chaindata_db};
 
             // Snapshot sync - download chain from peers using snapshot files

--- a/silkworm/node/huffman/decompressor.cpp
+++ b/silkworm/node/huffman/decompressor.cpp
@@ -314,14 +314,14 @@ void Decompressor::open() {
 
     // Read patterns from compressed file
     const auto pattern_dict_length = endian::load_big_u64(address + kWordsCountSize + kEmptyWordsCountSize);
-    SILK_INFO << "Decompress pattern dictionary length: " << pattern_dict_length;
+    SILK_DEBUG << "Decompress pattern dictionary length: " << pattern_dict_length;
 
     const std::size_t patterns_dict_offset{kWordsCountSize + kEmptyWordsCountSize + kDictionaryLengthSize};
     read_patterns(ByteView{address + patterns_dict_offset, pattern_dict_length});
 
     // Read positions from compressed file
     const auto position_dict_length = endian::load_big_u64(address + patterns_dict_offset + pattern_dict_length);
-    SILK_INFO << "Decompress position dictionary length: " << position_dict_length;
+    SILK_DEBUG << "Decompress position dictionary length: " << position_dict_length;
 
     const std::size_t positions_dict_offset{patterns_dict_offset + pattern_dict_length + kDictionaryLengthSize};
     read_positions(ByteView{address + positions_dict_offset, position_dict_length});
@@ -402,14 +402,14 @@ void Decompressor::read_patterns(ByteView dict) {
         throw std::runtime_error{"pattern stream not exhausted: " + std::to_string(raw_input.ByteCount() - coded_input.CurrentPosition())};
     }
 
-    SILK_INFO << "Pattern count: " << pattern_count << " highest depth: " << pattern_highest_depth;
+    SILK_DEBUG << "Pattern count: " << pattern_count << " highest depth: " << pattern_highest_depth;
 
     pattern_dict_ = std::make_unique<PatternTable>(pattern_highest_depth);
     if (dict.length() > 0) {
         pattern_dict_->build_condensed({patterns.begin(), pattern_count});
     }
 
-    SILK_INFO << "#codewords: " << pattern_dict_->num_codewords();
+    SILK_DEBUG << "#codewords: " << pattern_dict_->num_codewords();
     SILK_TRACE << *pattern_dict_;
 }
 
@@ -458,14 +458,14 @@ void Decompressor::read_positions(ByteView dict) {
         throw std::runtime_error{"position stream not exhausted: " + std::to_string(raw_input.ByteCount() - coded_input.CurrentPosition())};
     }
 
-    SILK_INFO << "Position count: " << position_count << " highest depth: " << position_highest_depth;
+    SILK_DEBUG << "Position count: " << position_count << " highest depth: " << position_highest_depth;
 
     position_dict_ = std::make_unique<PositionTable>(position_highest_depth);
     if (dict.length() > 0) {
         position_dict_->build({positions.begin(), position_count});
     }
 
-    SILK_INFO << "#positions: " << position_dict_->num_positions();
+    SILK_DEBUG << "#positions: " << position_dict_->num_positions();
     SILK_TRACE << *position_dict_;
 }
 

--- a/silkworm/node/huffman/decompressor.hpp
+++ b/silkworm/node/huffman/decompressor.hpp
@@ -171,7 +171,7 @@ class PositionTable : public DecodingTable {
 class Decompressor {
   public:
     //! The max number of patterns in decoding tables
-    constexpr static std::size_t kMaxTablePatterns = (1 << DecodingTable::kMaxTableBitLength) * 100;
+    constexpr static std::size_t kMaxTablePatterns = (1 << DecodingTable::kMaxTableBitLength) * 510;
 
     //! The max number of positions in decoding tables
     constexpr static std::size_t kMaxTablePositions = (1 << DecodingTable::kMaxTableBitLength) * 100;

--- a/silkworm/node/snapshot/path.hpp
+++ b/silkworm/node/snapshot/path.hpp
@@ -66,6 +66,8 @@ class SnapshotPath {
                                            BlockNum block_to,
                                            SnapshotType type);
 
+    [[nodiscard]] std::string filename() const { return path_.filename().string(); }
+
     [[nodiscard]] std::filesystem::path path() const { return path_; }
 
     [[nodiscard]] uint8_t version() const { return version_; }

--- a/silkworm/node/snapshot/repository.cpp
+++ b/silkworm/node/snapshot/repository.cpp
@@ -48,8 +48,8 @@ void SnapshotRepository::build_missing_indexes() {
 
     SnapshotPathList segment_files = get_segment_files();
     for (const auto& seg_file : segment_files) {
-        SILK_INFO << "Segment file: " << seg_file.path() << " has index: " << seg_file.index_file().path();
-        const auto& index_file = seg_file.index_file();
+        const auto index_file = seg_file.index_file();
+        SILK_INFO << "Segment file: " << seg_file.filename() << " has index: " << index_file.filename();
         if (!std::filesystem::exists(index_file.path())) {
             std::shared_ptr<Index> index;
             switch (seg_file.type()) {
@@ -69,13 +69,16 @@ void SnapshotRepository::build_missing_indexes() {
                     SILKWORM_ASSERT(false);
                 }
             }
-            if (index) {
-                workers.submit([&index]() {
-                    log::Info() << "[Snapshots] Build index: " << index->path().path().string() << " start";
+            log::Info() << "[Snapshots] Build index: " << index->path().filename() << " start";
+            index->build();
+            log::Info() << "[Snapshots] Build index: " << index->path().filename() << " end";
+            /*if (index) {
+                workers.submit([index = std::move(index)]() {
+                    log::Info() << "[Snapshots] Build index: " << index->path().filename() << " start";
                     index->build();
-                    log::Info() << "[Snapshots] Build index: " << index->path().path().string() << " end";
+                    log::Info() << "[Snapshots] Build index: " << index->path().filename() << " end";
                 });
-            }
+            }*/
         }
     }
 

--- a/silkworm/node/snapshot/sync.hpp
+++ b/silkworm/node/snapshot/sync.hpp
@@ -41,6 +41,8 @@ class SnapshotSync {
     void stop();
 
   private:
+    void open_and_verify();
+
     SnapshotSettings settings_;
     const ChainConfig& config_;
     SnapshotRepository repository_;


### PR DESCRIPTION
This PR introduces the following changes:

- increase max table patterns in snapshot decompressor
- add missing folder reopening in snapshot sync
- refactor raise max file descriptors in silkworm
- temporarily disable parallel index building
- demote log traces