### PR TITLE
node: make snapshot downloading and index building stoppable at boundaries

### DIFF
--- a/silkworm/infra/common/memory_mapped_file.cpp
+++ b/silkworm/infra/common/memory_mapped_file.cpp
@@ -90,6 +90,9 @@ void MemoryMappedFile::map_existing(bool read_only) {
     fd = INVALID_HANDLE_VALUE;
 }
 
+void MemoryMappedFile::advise_normal() {
+}
+
 void MemoryMappedFile::advise_random() {
 }
 
@@ -145,6 +148,10 @@ void MemoryMappedFile::map_existing(bool read_only) {
     length_ = static_cast<std::size_t>(stat_buffer.st_size);
 
     address_ = static_cast<uint8_t*>(mmap(fd, read_only));
+}
+
+void MemoryMappedFile::advise_normal() {
+    advise(MADV_NORMAL);
 }
 
 void MemoryMappedFile::advise_random() {

--- a/silkworm/infra/common/memory_mapped_file.hpp
+++ b/silkworm/infra/common/memory_mapped_file.hpp
@@ -74,6 +74,10 @@ class MemoryMappedFile {
     explicit MemoryMappedFile(const char* path, bool read_only = true);
     ~MemoryMappedFile();
 
+    [[nodiscard]] const char* path() const {
+        return path_;
+    }
+
     [[nodiscard]] uint8_t* address() const {
         return address_;
     }
@@ -82,6 +86,7 @@ class MemoryMappedFile {
         return length_;
     }
 
+    void advise_normal();
     void advise_random();
     void advise_sequential();
 

--- a/silkworm/node/snapshot/index.hpp
+++ b/silkworm/node/snapshot/index.hpp
@@ -21,7 +21,7 @@
 
 #include <silkworm/node/huffman/decompressor.hpp>
 #include <silkworm/node/recsplit/rec_split.hpp>
-#include <silkworm/node/snapshot/repository.hpp>
+#include <silkworm/node/snapshot/path.hpp>
 
 namespace silkworm {
 

--- a/silkworm/node/snapshot/repository.hpp
+++ b/silkworm/node/snapshot/repository.hpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/node/snapshot/index.hpp>
 #include <silkworm/node/snapshot/path.hpp>
 #include <silkworm/node/snapshot/settings.hpp>
 #include <silkworm/node/snapshot/snapshot.hpp>
@@ -57,7 +58,6 @@ class SnapshotRepository {
 
     void verify();
     void reopen_folder();
-    void build_missing_indexes();
 
     [[nodiscard]] std::filesystem::path path() const { return settings_.repository_dir; }
 
@@ -77,6 +77,8 @@ class SnapshotRepository {
     ViewResult view_header_segment(BlockNum number, const HeaderSnapshotWalker& walker);
     ViewResult view_body_segment(BlockNum number, const BodySnapshotWalker& walker);
     ViewResult view_tx_segment(BlockNum number, const TransactionSnapshotWalker& walker);
+
+    [[nodiscard]] std::vector<std::shared_ptr<Index>> missing_indexes() const;
 
     [[nodiscard]] BlockNum segment_max_block() const { return segment_max_block_; }
     [[nodiscard]] BlockNum idx_max_block() const { return idx_max_block_; }

--- a/silkworm/node/snapshot/sync.cpp
+++ b/silkworm/node/snapshot/sync.cpp
@@ -16,18 +16,23 @@
 
 #include "sync.hpp"
 
+#include <chrono>
 #include <latch>
 
 #include <magic_enum.hpp>
 
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/concurrency/thread_pool.hpp>
 #include <silkworm/node/db/stages.hpp>
 #include <silkworm/node/etl/collector.hpp>
 #include <silkworm/node/snapshot/config.hpp>
 #include <silkworm/node/snapshot/path.hpp>
 
 namespace silkworm {
+
+//! Interval between successive checks for either completion or stop requested
+static constexpr std::chrono::seconds kCheckCompletionInterval{1};
 
 SnapshotSync::SnapshotSync(const SnapshotSettings& settings, const ChainConfig& config)
     : settings_(settings),
@@ -136,8 +141,10 @@ bool SnapshotSync::download_snapshots(const std::vector<std::string>& snapshot_f
 
     client_thread_ = std::thread([&]() { client_.execute_loop(); });
 
-    // Wait for download completion of all snapshots
-    download_done.wait();
+    // Wait for download completion of all snapshots or stop request
+    while (not download_done.try_wait() and not is_stopping()) {
+        std::this_thread::sleep_for(kCheckCompletionInterval);
+    }
 
     SILK_INFO << "[Snapshots] sync completed: [" << num_snapshots << "/" << num_snapshots << "]";
 
@@ -146,22 +153,28 @@ bool SnapshotSync::download_snapshots(const std::vector<std::string>& snapshot_f
 
 bool SnapshotSync::index_snapshots(db::RWTxn& txn, const std::vector<std::string>& snapshot_file_names) {
     if (!settings_.enabled) {
-        log::Info() << "snapshot sync disabled, no index must be created";
+        log::Info() << "[Snapshots] snapshot sync disabled, no index must be created";
         return true;
     }
 
+    // Build any missing snapshot index if needed, then reopen
     if (repository_.idx_max_block() < repository_.segment_max_block()) {
-        repository_.build_missing_indexes();
+        log::Info() << "[Snapshots] missing indexes detected, rebuild started";
+        build_missing_indexes();
         repository_.reopen_folder();
     }
 
     const auto max_block_available = repository_.max_block_available();
+    log::Info() << "[Snapshots] max block available: " << max_block_available;
+
     const auto snapshot_config = snapshot::Config::lookup_known_config(config_.chain_id, snapshot_file_names);
     const auto configured_max_block_number = snapshot_config->max_block_number();
+    log::Info() << "[Snapshots] configured max block: " << configured_max_block_number;
     if (max_block_available < configured_max_block_number) {
         // Iterate on block header snapshots and write header-related tables
         etl::Collector hash2bn_collector{};
         intx::uint256 total_difficulty{0};
+        uint64_t block_count{0};
         repository_.for_each_header([&](const BlockHeader* header) -> bool {
             SILK_DEBUG << "Header number: " << header->number << " hash: " << to_hex(header->hash());
             const auto block_number = header->number;
@@ -178,6 +191,12 @@ bool SnapshotSync::index_snapshots(db::RWTxn& txn, const std::vector<std::string
             Bytes encoded_block_number{sizeof(uint64_t), '\0'};
             endian::store_big_u64(encoded_block_number.data(), block_number);
             hash2bn_collector.collect({block_hash.bytes, encoded_block_number});
+
+            if (++block_count % 1'000'000 == 0) {
+                log::Info() << "[Snapshots] processing block header: " << block_number << " count=" << block_count;
+                if (is_stopping()) return false;
+            }
+
             return true;
         });
         db::PooledCursor header_numbers_cursor{txn, db::table::kHeaderNumbers};
@@ -191,7 +210,7 @@ bool SnapshotSync::index_snapshots(db::RWTxn& txn, const std::vector<std::string
             return true;
         });
         if (view_result != SnapshotRepository::ViewResult::kWalkSuccess) {
-            log::Error() << "snapshot not found for block: " << max_block_available;
+            log::Error() << "[Snapshots] snapshot not found for block: " << max_block_available;
             return false;
         }
 
@@ -201,6 +220,7 @@ bool SnapshotSync::index_snapshots(db::RWTxn& txn, const std::vector<std::string
         db::write_head_header_hash(txn, canonical_hash);
 
         // Update progress for related stages
+        db::stages::write_stage_progress(txn, db::stages::kHeadersKey, max_block_available);
         db::stages::write_stage_progress(txn, db::stages::kBlockBodiesKey, max_block_available);
         db::stages::write_stage_progress(txn, db::stages::kBlockHashesKey, max_block_available);
         db::stages::write_stage_progress(txn, db::stages::kSendersKey, max_block_available);
@@ -211,11 +231,38 @@ bool SnapshotSync::index_snapshots(db::RWTxn& txn, const std::vector<std::string
     return true;
 }
 
-void SnapshotSync::stop() {
+bool SnapshotSync::stop() {
+    const bool result = Stoppable::stop();
     client_.stop();
     if (client_thread_.joinable()) {
         client_thread_.join();
     }
+    return result;
+}
+
+void SnapshotSync::build_missing_indexes() {
+    thread_pool workers;
+
+    // Determine the missing indexes and build them in parallel
+    const auto missing_indexes = repository_.missing_indexes();
+    for (const auto& index : missing_indexes) {
+        log::Info() << "[Snapshots] Build index: " << index->path().filename() << " start";
+        index->build();
+        log::Info() << "[Snapshots] Build index: " << index->path().filename() << " end";
+        /*workers.submit([index]() {
+            log::Info() << "[Snapshots] Build index: " << index->path().filename() << " start";
+            index->build();
+            log::Info() << "[Snapshots] Build index: " << index->path().filename() << " end";
+        });*/
+    }
+
+    // Wait for all missing indexes to be built or stop request
+    while (workers.get_tasks_total() and not is_stopping()) {
+        std::this_thread::sleep_for(kCheckCompletionInterval);
+    }
+    // Wait for any already-started-but-unfinished work in case of stop request
+    workers.paused = true;
+    workers.wait_for_tasks();
 }
 
 }  // namespace silkworm

--- a/silkworm/node/snapshot/sync.hpp
+++ b/silkworm/node/snapshot/sync.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <silkworm/core/chain/config.hpp>
+#include <silkworm/infra/concurrency/stoppable.hpp>
 #include <silkworm/node/bittorrent/client.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 #include <silkworm/node/snapshot/repository.hpp>
@@ -28,20 +29,21 @@
 
 namespace silkworm {
 
-class SnapshotSync {
+class SnapshotSync : public Stoppable {
   public:
     SnapshotSync(const SnapshotSettings& settings, const ChainConfig& config);
-    ~SnapshotSync();
+    ~SnapshotSync() override;
 
     [[nodiscard]] SnapshotRepository& repository() { return repository_; }
 
     bool download_and_index_snapshots(db::RWTxn& txn);
     bool download_snapshots(const std::vector<std::string>& snapshot_file_names);
     bool index_snapshots(db::RWTxn& txn, const std::vector<std::string>& snapshot_file_names);
-    void stop();
+    bool stop() override;
 
   private:
     void open_and_verify();
+    void build_missing_indexes();
 
     SnapshotSettings settings_;
     const ChainConfig& config_;


### PR DESCRIPTION
This PR introduces the following changes:

- make snapshot downloading and index building stoppable at boundaries
- split responsibilities between finding missing indexes and building them
- move snapshot index building from repository to sync