### PR TITLE
build: run undefined alongside address sanitizer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,14 +172,14 @@ jobs:
       - build
       - test
 
-  linux-clang-13-address-sanitizer:
+  linux-clang-15-address-sanitizer:
     environment:
       TOOLCHAIN: clang_libcxx
-      CLANG_VERSION: 13
+      CLANG_VERSION: 15
       BUILD_TYPE: Debug
       BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address,undefined
     docker:
-      - image: ethereum/cpp-build-env:18-clang-13
+      - image: ethereum/cpp-build-env:19-clang-15
     resource_class: xlarge
     steps:
       - checkout_with_submodules
@@ -330,6 +330,6 @@ workflows:
       - linux-gcc-11-conan
       - linux-gcc-11-thread-sanitizer
       - linux-clang-13-coverage
-      - linux-clang-13-address-sanitizer
+      - linux-clang-15-address-sanitizer
       - linux-wasm-build
       - linux-default-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,6 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout_with_submodules
-      - format
       - install_libcxx
       - build
       - run:
@@ -289,6 +288,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout_with_submodules
+      - format
       - run:
           name: "Install dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       TOOLCHAIN: clang_libcxx
       CLANG_VERSION: 13
       BUILD_TYPE: Debug
-      BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address
+      BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address,undefined
     docker:
       - image: ethereum/cpp-build-env:18-clang-13
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,6 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout_with_submodules
-      - format
       - install_libcxx
       - build
       - test
@@ -199,6 +198,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout_with_submodules
+      - format
       - install_libcxx
       - build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout_with_submodules
+      - format
       - install_libcxx
       - build
       - run:
@@ -288,7 +289,6 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout_with_submodules
-      - format
       - run:
           name: "Install dependencies"
           command: |

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -14,14 +14,16 @@
    limitations under the License.
 ]]
 
-set(SILKWORM_SANITIZE_COMPILER_OPTIONS -fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -fno-sanitize-recover=all)
-
-# cmake-format: off
+set(SILKWORM_SANITIZE_COMPILER_OPTIONS -fno-omit-frame-pointer -fno-sanitize-recover=all
+                                       -fsanitize=${SILKWORM_SANITIZE}
+)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
   message("MSVC_VERSION = ${MSVC_VERSION}")
   message("MSVC_CXX_ARCHITECTURE_ID = ${MSVC_CXX_ARCHITECTURE_ID}")
+
+  # cmake-format: off
 
   add_definitions(-D_WIN32_WINNT=0x0602)  # Min Windows 8
   add_definitions(-DVC_EXTRALEAN)         # Process windows headers faster ...
@@ -79,6 +81,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /VERBOSE /TIME")    # Debug linker
   endif()
 
+# cmake-format: on
+
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
   if(SILKWORM_SANITIZE)
@@ -121,8 +125,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
 
 else()
 
-  message(WARNING "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues")
+  message(
+    WARNING
+      "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues"
+  )
 
 endif()
-
-# cmake-format: on

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -79,6 +79,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
+  if(SILKWORM_SANITIZE)
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+  endif()
+
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-g1)
   endif()
@@ -92,6 +97,11 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+  endif()
+
+  if(SILKWORM_SANITIZE)
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE --rtlib=compiler-rt)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -109,11 +119,6 @@ else()
 
   message(WARNING "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues")
 
-endif()
-
-if(SILKWORM_SANITIZE)
-  add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
-  add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
 endif()
 
 # cmake-format: on

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -79,11 +79,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-  if(SILKWORM_SANITIZE)
-    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
-    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
-  endif()
-
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-g1)
   endif()
@@ -97,11 +92,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
-  endif()
-
-  if(SILKWORM_SANITIZE)
-    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
-    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -119,6 +109,11 @@ else()
 
   message(WARNING "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues")
 
+endif()
+
+if(SILKWORM_SANITIZE)
+  add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+  add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
 endif()
 
 # cmake-format: on

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -14,6 +14,8 @@
    limitations under the License.
 ]]
 
+set(SILKWORM_SANITIZE_COMPILER_OPTIONS -fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -fno-sanitize-recover=all)
+
 # cmake-format: off
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -80,8 +82,9 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
   if(SILKWORM_SANITIZE)
-    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
-    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
+    add_compile_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
+    add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
+    add_definitions(-DSILKWORM_SANITIZE)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -100,8 +103,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   endif()
 
   if(SILKWORM_SANITIZE)
-    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE)
-    add_link_options(-fno-omit-frame-pointer -fsanitize=${SILKWORM_SANITIZE} -DSILKWORM_SANITIZE --rtlib=compiler-rt)
+    add_compile_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
+    add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS} --rtlib=compiler-rt)
+    add_definitions(-DSILKWORM_SANITIZE)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -14,10 +14,6 @@
    limitations under the License.
 ]]
 
-set(SILKWORM_SANITIZE_COMPILER_OPTIONS -fno-omit-frame-pointer -fno-sanitize-recover=all
-                                       -fsanitize=${SILKWORM_SANITIZE}
-)
-
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
   message("MSVC_VERSION = ${MSVC_VERSION}")
@@ -85,12 +81,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-  if(SILKWORM_SANITIZE)
-    add_compile_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
-    add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
-    add_definitions(-DSILKWORM_SANITIZE)
-  endif()
-
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-g1)
   endif()
@@ -104,12 +94,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
-  endif()
-
-  if(SILKWORM_SANITIZE)
-    add_compile_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
-    add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
-    add_definitions(-DSILKWORM_SANITIZE)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -130,4 +114,13 @@ else()
       "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues"
   )
 
+endif()
+
+if(SILKWORM_SANITIZE)
+  set(SILKWORM_SANITIZE_COMPILER_OPTIONS -fno-omit-frame-pointer -fno-sanitize-recover=all
+                                         -fsanitize=${SILKWORM_SANITIZE}
+  )
+  add_compile_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
+  add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
+  add_definitions(-DSILKWORM_SANITIZE)
 endif()

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -108,7 +108,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
 
   if(SILKWORM_SANITIZE)
     add_compile_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
-    add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS} --rtlib=compiler-rt)
+    add_link_options(${SILKWORM_SANITIZE_COMPILER_OPTIONS})
     add_definitions(-DSILKWORM_SANITIZE)
   endif()
 

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -81,7 +81,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /VERBOSE /TIME")    # Debug linker
   endif()
 
-# cmake-format: on
+  # cmake-format: on
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 

--- a/silkworm/core/crypto/sha256.c
+++ b/silkworm/core/crypto/sha256.c
@@ -456,7 +456,7 @@ static void cpuid(int info[4], int InfoType) {
     __cpuid_count(InfoType, 0, info[0], info[1], info[2], info[3]);
 }
 
-__attribute__((constructor)) static void select_sha256_implementation() {
+__attribute__((constructor)) static void select_sha256_implementation(void) {
     int info[4];
     cpuid(info, 0);
     int nIds = info[0];
@@ -654,7 +654,7 @@ static void sha_256_arm_v8(uint32_t h[8], const void* input, size_t len) {
     vst1q_u32(&h[4], STATE1);
 }
 
-__attribute__((constructor)) static void select_sha256_implementation() {
+__attribute__((constructor)) static void select_sha256_implementation(void) {
 #if defined(__linux__)
     if ((getauxval(AT_HWCAP) & HWCAP_SHA2) != 0) {
         sha_256_best = sha_256_arm_v8;

--- a/silkworm/core/crypto/sha256.c
+++ b/silkworm/core/crypto/sha256.c
@@ -107,10 +107,10 @@ static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state* state) {
         return true;
     }
 
-    memcpy(chunk, state->p, state->len);
-    chunk += state->len;
     size_t space_in_chunk = CHUNK_SIZE - state->len;
     if (state->len) {  // avoid adding 0 to nullptr
+        memcpy(chunk, state->p, state->len);
+        chunk += state->len;
         state->p += state->len;
     }
     state->len = 0;

--- a/silkworm/core/execution/precompile.cpp
+++ b/silkworm/core/execution/precompile.cpp
@@ -528,7 +528,7 @@ bool is_precompile(const evmc::address& address, evmc_revision rev) noexcept {
     }
 
     const uint8_t num{address.bytes[kAddressLength - 1]};
-    if (num >= std::size(kContracts) || !kContracts[num]) {
+    if (!kContracts[num]) {
         return false;
     }
 

--- a/silkworm/core/execution/precompile.cpp
+++ b/silkworm/core/execution/precompile.cpp
@@ -528,7 +528,7 @@ bool is_precompile(const evmc::address& address, evmc_revision rev) noexcept {
     }
 
     const uint8_t num{address.bytes[kAddressLength - 1]};
-    if (!kContracts[num]) {
+    if (num >= std::size(kContracts) || !kContracts[num]) {
         return false;
     }
 

--- a/silkworm/core/trie/node.cpp
+++ b/silkworm/core/trie/node.cpp
@@ -52,7 +52,9 @@ Bytes Node::encode_for_storage() const {
         pos += kHashLength;
     }
 
-    std::memcpy(&buf[pos], hashes_.data(), hashes_.size() * kHashLength);
+    if (!hashes_.empty()) {
+        std::memcpy(&buf[pos], hashes_.data(), hashes_.size() * kHashLength);
+    }
     return buf;
 }
 

--- a/silkworm/core/trie/node.cpp
+++ b/silkworm/core/trie/node.cpp
@@ -96,7 +96,9 @@ DecodingResult Node::decode_from_storage(ByteView raw, Node& node) {
     }
 
     node.hashes_.resize(effective_num_hashes);
-    std::memcpy(node.hashes_.data(), raw.data(), raw.length());
+    if (effective_num_hashes) {
+        std::memcpy(node.hashes_.data(), raw.data(), raw.length());
+    }
     return {};
 }
 

--- a/silkworm/interfaces/CMakeLists.txt
+++ b/silkworm/interfaces/CMakeLists.txt
@@ -42,7 +42,12 @@ add_dependencies(
 # cmake-format: on
 
 if(NOT MSVC)
-  target_compile_options(silkworm_interfaces PRIVATE -Wno-sign-conversion -Wno-deprecated-pragma)
+  target_compile_options(silkworm_interfaces PRIVATE -Wno-sign-conversion)
+
+  check_cxx_compiler_flag("-Wno-deprecated-pragma" HAS_NO_DEPRECATED_PRAGMA)
+  if(HAS_NO_DEPRECATED_PRAGMA)
+    target_compile_options(silkworm_interfaces PRIVATE -Wno-deprecated-pragma)
+  endif()
 endif(NOT MSVC)
 
 # Suppress ASAN/TSAN in gRPC to avoid ODR violation when building Silkworm with sanitizers See

--- a/silkworm/interfaces/CMakeLists.txt
+++ b/silkworm/interfaces/CMakeLists.txt
@@ -42,7 +42,7 @@ add_dependencies(
 # cmake-format: on
 
 if(NOT MSVC)
-  target_compile_options(silkworm_interfaces PRIVATE -Wno-sign-conversion)
+  target_compile_options(silkworm_interfaces PRIVATE -Wno-sign-conversion -Wno-deprecated-pragma)
 endif(NOT MSVC)
 
 # Suppress ASAN/TSAN in gRPC to avoid ODR violation when building Silkworm with sanitizers See

--- a/silkworm/sync/messages/internal_message_test.cpp
+++ b/silkworm/sync/messages/internal_message_test.cpp
@@ -23,6 +23,7 @@
 
 namespace silkworm {
 
+// Switch off the null sanitizer because nullptr SentryClient is formally dereferenced in command->execute.
 [[clang::no_sanitize("null")]] TEST_CASE("internal message") {
     test::Context context;
     db::ROAccess dba(context.env());  // not used in the test execution

--- a/silkworm/sync/messages/internal_message_test.cpp
+++ b/silkworm/sync/messages/internal_message_test.cpp
@@ -19,14 +19,15 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/node/test/context.hpp>
+#include <silkworm/sync/internals/body_sequence.hpp>
 
 namespace silkworm {
 
-TEST_CASE("internal message") {
+[[clang::no_sanitize("null")]] TEST_CASE("internal message") {
     test::Context context;
     db::ROAccess dba(context.env());  // not used in the test execution
-    HeaderChain* hc = nullptr;        // not used in the test execution
-    BodySequence* bs = nullptr;       // not used in the test execution
+    HeaderChain hc(kMainnetConfig);   // not used in the test execution
+    BodySequence bs;                  // not used in the test execution
     SentryClient* sc = nullptr;       // not used in the test execution
 
     using result_t = std::vector<int>;
@@ -37,7 +38,7 @@ TEST_CASE("internal message") {
 
     REQUIRE(!command->completed_and_read());
 
-    command->execute(dba, *hc, *bs, *sc);
+    command->execute(dba, hc, bs, *sc);
 
     REQUIRE(!command->completed_and_read());
 


### PR DESCRIPTION
[Undefined Behavior Sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) can catch things like out-of-bounds array access.

Also fix/supress Clang 15 warnings.