### PR TITLE
rpcdaemon: improve ETHBACKEND gRPC client implementation

### DIFF
--- a/silkworm/infra/grpc/common/conversion.cpp
+++ b/silkworm/infra/grpc/common/conversion.cpp
@@ -44,6 +44,38 @@ constexpr uint64_t lo_hi(const intx::uint256& x) { return x[1]; }
 constexpr uint64_t hi_lo(const intx::uint256& x) { return x[2]; }
 constexpr uint64_t hi_hi(const intx::uint256& x) { return x[3]; }
 
+std::string string_from_H2048(const ::types::H2048& orig) {
+    const auto& hi_hi = orig.hi().hi();
+    const auto& hi_lo = orig.hi().lo();
+    const auto& lo_hi = orig.lo().hi();
+    const auto& lo_lo = orig.lo().lo();
+
+    std::string dest(256, 0);
+    dest.append(string_from_H512(hi_hi));
+    dest.append(string_from_H512(hi_lo));
+    dest.append(string_from_H512(lo_hi));
+    dest.append(string_from_H512(lo_lo));
+    return dest;
+}
+
+Bytes bytes_from_H2048(const ::types::H2048& h2048) {
+    Bytes bytes(256, '\0');
+    const auto& hi{h2048.hi()};
+    const auto& lo{h2048.lo()};
+    std::memcpy(&bytes[0], bytes_from_H1024(hi).data(), 128);
+    std::memcpy(&bytes[128], bytes_from_H1024(lo).data(), 128);
+    return bytes;
+}
+
+Bytes bytes_from_H1024(const ::types::H1024& h1024) {
+    Bytes bytes(128, '\0');
+    const auto& hi{h1024.hi()};
+    const auto& lo{h1024.lo()};
+    std::memcpy(&bytes[0], bytes_from_H512(hi).data(), 64);
+    std::memcpy(&bytes[64], bytes_from_H512(lo).data(), 64);
+    return bytes;
+}
+
 std::string string_from_H512(const types::H512& orig) {
     uint64_t hi_hi_hi = orig.hi().hi().hi();
     uint64_t hi_hi_lo = orig.hi().hi().lo();
@@ -68,21 +100,16 @@ std::string string_from_H512(const types::H512& orig) {
     return dest;
 }
 
-std::string string_from_H2048(const types::H2048& orig) {
-    const auto& hi_hi = orig.hi().hi();
-    const auto& hi_lo = orig.hi().lo();
-    const auto& lo_hi = orig.lo().hi();
-    const auto& lo_lo = orig.lo().lo();
-
-    std::string dest(256, 0);
-    dest.append(string_from_H512(hi_hi));
-    dest.append(string_from_H512(hi_lo));
-    dest.append(string_from_H512(lo_hi));
-    dest.append(string_from_H512(lo_lo));
-    return dest;
+Bytes bytes_from_H512(const ::types::H512& h512) {
+    Bytes bytes(64, '\0');
+    const auto& hi{h512.hi()};
+    const auto& lo{h512.lo()};
+    std::memcpy(&bytes[0], bytes_from_H256(hi).data(), 32);
+    std::memcpy(&bytes[32], bytes_from_H256(lo).data(), 32);
+    return bytes;
 }
 
-evmc::bytes32 bytes32_from_H256(const types::H256& orig) {
+evmc::bytes32 bytes32_from_H256(const ::types::H256& orig) {
     uint64_t hi_hi = orig.hi().hi();
     uint64_t hi_lo = orig.hi().lo();
     uint64_t lo_hi = orig.lo().hi();
@@ -97,7 +124,16 @@ evmc::bytes32 bytes32_from_H256(const types::H256& orig) {
     return dest;
 }
 
-intx::uint256 uint256_from_H256(const types::H256& orig) {
+Bytes bytes_from_H256(const ::types::H256& h256) {
+    silkworm::Bytes bytes(32, '\0');
+    const auto& hi{h256.hi()};
+    const auto& lo{h256.lo()};
+    std::memcpy(&bytes[0], bytes_from_H128(hi).data(), 16);
+    std::memcpy(&bytes[16], bytes_from_H128(lo).data(), 16);
+    return bytes;
+}
+
+intx::uint256 uint256_from_H256(const ::types::H256& orig) {
     uint64_t hi_hi = orig.hi().hi();
     uint64_t hi_lo = orig.hi().lo();
     uint64_t lo_hi = orig.lo().hi();
@@ -106,7 +142,7 @@ intx::uint256 uint256_from_H256(const types::H256& orig) {
     return {lo_lo, lo_hi, hi_lo, hi_hi};
 }
 
-evmc::address address_from_H160(const types::H160& orig) {
+evmc::address address_from_H160(const ::types::H160& orig) {
     uint64_t hi_hi = orig.hi().hi();
     uint64_t hi_lo = orig.hi().lo();
     uint32_t lo = orig.lo();
@@ -119,15 +155,61 @@ evmc::address address_from_H160(const types::H160& orig) {
     return dest;
 }
 
-std::unique_ptr<types::H512> H512_from_string(std::string_view orig) {
+Bytes bytes_from_H128(const ::types::H128& h128) {
+    Bytes bytes(16, '\0');
+    endian::store_big_u64(&bytes[0], h128.hi());
+    endian::store_big_u64(&bytes[8], h128.lo());
+    return bytes;
+}
+
+std::unique_ptr<::types::H2048> H2048_from_string(std::string_view orig) {
+    auto lo_lo = H512_from_string(orig);
+    auto lo_hi = H512_from_string(orig.substr(512));
+    auto hi_lo = H512_from_string(orig.substr(1024));
+    auto hi_hi = H512_from_string(orig.substr(1536));
+
+    auto hi = new ::types::H1024{};
+    auto lo = new ::types::H1024{};
+
+    hi->set_allocated_hi(hi_hi.release());
+    hi->set_allocated_lo(hi_lo.release());
+    lo->set_allocated_hi(lo_hi.release());
+    lo->set_allocated_lo(lo_lo.release());
+
+    auto dest = std::make_unique<::types::H2048>();
+    dest->set_allocated_hi(hi);  // takes ownership
+    dest->set_allocated_lo(lo);  // takes ownership
+
+    return dest;
+}
+
+std::unique_ptr<::types::H2048> H2048_from_bytes(ByteView bytes) {
+    auto dest = std::make_unique<::types::H2048>();
+    auto hi{H1024_from_bytes({bytes.data(), 128}).release()};
+    auto lo{H1024_from_bytes({bytes.data() + 128, 128}).release()};
+    dest->set_allocated_hi(hi);  // takes ownership
+    dest->set_allocated_lo(lo);  // takes ownership
+    return dest;
+}
+
+std::unique_ptr<::types::H1024> H1024_from_bytes(ByteView bytes) {
+    auto dest = std::make_unique<::types::H1024>();
+    auto hi{H512_from_bytes({bytes.data(), 64}).release()};
+    auto lo{H512_from_bytes({bytes.data() + 64, 64}).release()};
+    dest->set_allocated_hi(hi);  // takes ownership
+    dest->set_allocated_lo(lo);  // takes ownership
+    return dest;
+}
+
+std::unique_ptr<::types::H512> H512_from_string(std::string_view orig) {
     Bytes bytes(64, 0);
     uint8_t* data = bytes.data();
     std::memcpy(data, orig.data(), orig.length() < 64 ? orig.length() : 64);
 
-    auto hi_hi = new types::H128{};
-    auto hi_lo = new types::H128{};
-    auto lo_hi = new types::H128{};
-    auto lo_lo = new types::H128{};
+    auto hi_hi = new ::types::H128{};
+    auto hi_lo = new ::types::H128{};
+    auto lo_hi = new ::types::H128{};
+    auto lo_lo = new ::types::H128{};
     hi_hi->set_hi(endian::load_big_u64(data + 0));
     hi_hi->set_lo(endian::load_big_u64(data + 8));
     hi_lo->set_hi(endian::load_big_u64(data + 16));
@@ -137,82 +219,86 @@ std::unique_ptr<types::H512> H512_from_string(std::string_view orig) {
     lo_lo->set_hi(endian::load_big_u64(data + 48));
     lo_lo->set_lo(endian::load_big_u64(data + 56));
 
-    auto hi = new types::H256{};
-    auto lo = new types::H256{};
+    auto hi = new ::types::H256{};
+    auto lo = new ::types::H256{};
     hi->set_allocated_hi(hi_hi);  // takes ownership
     hi->set_allocated_lo(hi_lo);  // takes ownership
     lo->set_allocated_hi(lo_hi);  // takes ownership
     lo->set_allocated_lo(lo_lo);  // takes ownership
 
-    auto dest = std::make_unique<types::H512>();
+    auto dest = std::make_unique<::types::H512>();
     dest->set_allocated_hi(hi);  // takes ownership
     dest->set_allocated_lo(lo);  // takes ownership
 
     return dest;
 }
 
-std::unique_ptr<types::H256> H256_from_bytes32(const evmc::bytes32& orig) {
-    auto hi = new types::H128{};
-    auto lo = new types::H128{};
+std::unique_ptr<::types::H512> H512_from_bytes(ByteView bytes) {
+    auto dest = std::make_unique<::types::H512>();
+    auto hi{H256_from_bytes({bytes.data(), 32}).release()};
+    auto lo{H256_from_bytes({bytes.data() + 32, 32}).release()};
+    dest->set_allocated_hi(hi);  // takes ownership
+    dest->set_allocated_lo(lo);  // takes ownership
+    return dest;
+}
+
+std::unique_ptr<::types::H256> H256_from_bytes32(const evmc::bytes32& orig) {
+    auto hi = new ::types::H128{};
+    auto lo = new ::types::H128{};
     hi->set_hi(endian::load_big_u64(orig.bytes + 0));
     hi->set_lo(endian::load_big_u64(orig.bytes + 8));
     lo->set_hi(endian::load_big_u64(orig.bytes + 16));
     lo->set_lo(endian::load_big_u64(orig.bytes + 24));
 
-    auto dest = std::make_unique<types::H256>();
+    auto dest = std::make_unique<::types::H256>();
     dest->set_allocated_hi(hi);  // takes ownership
     dest->set_allocated_lo(lo);  // takes ownership
 
     return dest;
 }
 
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig) {
-    auto dest = std::make_unique<types::H256>();
+std::unique_ptr<::types::H256> H256_from_uint256(const intx::uint256& orig) {
+    auto dest = std::make_unique<::types::H256>();
 
-    auto hi = new types::H128{};
-    auto lo = new types::H128{};
+    auto hi = new ::types::H128{};
+    auto lo = new ::types::H128{};
 
     hi->set_hi(hi_hi(orig));
     hi->set_lo(hi_lo(orig));
     lo->set_hi(lo_hi(orig));
     lo->set_lo(lo_lo(orig));
 
-    dest->set_allocated_hi(hi);  // take ownership
-    dest->set_allocated_lo(lo);  // take ownership
+    dest->set_allocated_hi(hi);  // takes ownership
+    dest->set_allocated_lo(lo);  // takes ownership
 
-    return dest;  // transfer ownership
+    return dest;
 }
 
-std::unique_ptr<types::H160> H160_from_address(const evmc::address& orig) {
-    auto hi = new types::H128{};
+std::unique_ptr<::types::H256> H256_from_bytes(ByteView bytes) {
+    auto dest = std::make_unique<::types::H256>();
+    auto hi{H128_from_bytes({bytes.data(), 16}).release()};
+    auto lo{H128_from_bytes({bytes.data() + 16, 16}).release()};
+    dest->set_allocated_hi(hi);  // takes ownership
+    dest->set_allocated_lo(lo);  // takes ownership
+    return dest;
+}
+
+std::unique_ptr<::types::H160> H160_from_address(const evmc::address& orig) {
+    auto hi = new ::types::H128{};
     hi->set_hi(endian::load_big_u64(orig.bytes));
     hi->set_lo(endian::load_big_u64(orig.bytes + 8));
 
-    auto dest = std::make_unique<types::H160>();
+    auto dest = std::make_unique<::types::H160>();
     dest->set_allocated_hi(hi);  // takes ownership
     dest->set_lo(endian::load_big_u32(orig.bytes + 16));
 
     return dest;
 }
 
-std::unique_ptr<types::H2048> H2048_from_string(std::string_view orig) {
-    auto lo_lo = H512_from_string(orig);
-    auto lo_hi = H512_from_string(orig.substr(512));
-    auto hi_lo = H512_from_string(orig.substr(1024));
-    auto hi_hi = H512_from_string(orig.substr(1536));
-
-    auto hi = new types::H1024{};
-    auto lo = new types::H1024{};
-
-    hi->set_allocated_hi(hi_hi.release());
-    hi->set_allocated_lo(hi_lo.release());
-    lo->set_allocated_hi(lo_hi.release());
-    lo->set_allocated_lo(lo_lo.release());
-
-    auto dest = std::make_unique<types::H2048>();
-    dest->set_allocated_hi(hi);  // takes ownership
-    dest->set_allocated_lo(lo);  // takes ownership
-
+std::unique_ptr<::types::H128> H128_from_bytes(ByteView bytes) {
+    auto dest = std::make_unique<::types::H128>();
+    dest->set_hi(endian::load_big_u64(bytes.data()));
+    dest->set_lo(endian::load_big_u64(bytes.data() + 8));
     return dest;
 }
 

--- a/silkworm/infra/grpc/common/conversion.hpp
+++ b/silkworm/infra/grpc/common/conversion.hpp
@@ -43,58 +43,63 @@ namespace silkworm::rpc {
 // TODO (canepat) sentry_type_casts: better function naming, smart helpers
 // TODO (canepat) conversion: better module name and location
 
-//! Convert internal RPC H2048 type instance to std::string.
+//! Convert internal gRPC H2048 type instance to std::string.
 std::string string_from_H2048(const ::types::H2048& orig);
 
+//! Convert internal gRPC H2048 type instance to Bytes.
 Bytes bytes_from_H2048(const ::types::H2048& h2048);
 
+//! Convert internal gRPC H1024 type instance to Bytes.
 Bytes bytes_from_H1024(const ::types::H1024& h1024);
 
-//! Convert internal RPC H512 type instance to std::string.
+//! Convert internal gRPC H512 type instance to std::string.
 std::string string_from_H512(const ::types::H512& orig);
 
 Bytes bytes_from_H512(const ::types::H512& h512);
 
-//! Convert internal RPC H256 type instance to evmc::bytes32.
+//! Convert internal gRPC H256 type instance to evmc::bytes32.
 evmc::bytes32 bytes32_from_H256(const ::types::H256& orig);
 
-//! Convert internal RPC H256 type instance to intx::uint256.
+//! Convert internal gRPC H256 type instance to intx::uint256.
 intx::uint256 uint256_from_H256(const ::types::H256& orig);
 
+//! Convert internal gRPC H256 type instance to Bytes.
 Bytes bytes_from_H256(const ::types::H256& h256);
 
-//! Convert internal RPC H160 type instance to evmc::address.
+//! Convert internal gRPC H160 type instance to evmc::address.
 evmc::address address_from_H160(const ::types::H160& orig);
 
-//! Convert internal RPC H128 type instance to Bytes.
+//! Convert internal gRPC H128 type instance to Bytes.
 Bytes bytes_from_H128(const ::types::H128& h128);
 
-//! Convert std::array to internal RPC H2048 type instance.
+//! Convert std::string_view to internal gRPC H2048 type instance.
 std::unique_ptr<::types::H2048> H2048_from_string(std::string_view orig);
 
+//! Convert ByteView to internal gRPC H2048 type instance.
 std::unique_ptr<::types::H2048> H2048_from_bytes(ByteView bytes);
 
+//! Convert ByteView to internal gRPC H1024 type instance.
 std::unique_ptr<::types::H1024> H1024_from_bytes(ByteView bytes);
 
-//! Convert evmc::address to internal RPC H512 type instance.
+//! Convert evmc::address to internal gRPC H512 type instance.
 std::unique_ptr<::types::H512> H512_from_string(std::string_view orig);
 
-//! Convert ByteView to internal RPC H512 type instance.
+//! Convert ByteView to internal gRPC H512 type instance.
 std::unique_ptr<::types::H512> H512_from_bytes(ByteView bytes);
 
-//! Convert evmc::bytes32 to internal RPC H256 type instance.
+//! Convert evmc::bytes32 to internal gRPC H256 type instance.
 std::unique_ptr<::types::H256> H256_from_bytes32(const evmc::bytes32& orig);
 
-//! Convert intx::uint256 to internal RPC H256 type instance.
+//! Convert intx::uint256 to internal gRPC H256 type instance.
 std::unique_ptr<::types::H256> H256_from_uint256(const intx::uint256& orig);
 
-//! Convert ByteView to internal RPC H256 type instance.
+//! Convert ByteView to internal gRPC H256 type instance.
 std::unique_ptr<::types::H256> H256_from_bytes(ByteView bytes);
 
-//! Convert evmc::address to internal RPC H160 type instance.
+//! Convert evmc::address to internal gRPC H160 type instance.
 std::unique_ptr<::types::H160> H160_from_address(const evmc::address& orig);
 
-//! Convert ByteView to internal RPC H128 type instance.
+//! Convert ByteView to internal gRPC H128 type instance.
 std::unique_ptr<::types::H128> H128_from_bytes(ByteView bytes);
 
 }  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/common/conversion.hpp
+++ b/silkworm/infra/grpc/common/conversion.hpp
@@ -43,34 +43,58 @@ namespace silkworm::rpc {
 // TODO (canepat) sentry_type_casts: better function naming, smart helpers
 // TODO (canepat) conversion: better module name and location
 
-//! Convert internal RPC H512 type instance to std::string.
-std::string string_from_H512(const types::H512& orig);
-
 //! Convert internal RPC H2048 type instance to std::string.
-std::string string_from_H2048(const types::H2048& orig);
+std::string string_from_H2048(const ::types::H2048& orig);
+
+Bytes bytes_from_H2048(const ::types::H2048& h2048);
+
+Bytes bytes_from_H1024(const ::types::H1024& h1024);
+
+//! Convert internal RPC H512 type instance to std::string.
+std::string string_from_H512(const ::types::H512& orig);
+
+Bytes bytes_from_H512(const ::types::H512& h512);
 
 //! Convert internal RPC H256 type instance to evmc::bytes32.
-evmc::bytes32 bytes32_from_H256(const types::H256& orig);
+evmc::bytes32 bytes32_from_H256(const ::types::H256& orig);
 
 //! Convert internal RPC H256 type instance to intx::uint256.
-intx::uint256 uint256_from_H256(const types::H256& orig);
+intx::uint256 uint256_from_H256(const ::types::H256& orig);
+
+Bytes bytes_from_H256(const ::types::H256& h256);
 
 //! Convert internal RPC H160 type instance to evmc::address.
-evmc::address address_from_H160(const types::H160& orig);
+evmc::address address_from_H160(const ::types::H160& orig);
 
-//! Convert evmc::address to internal RPC H160 type instance.
-std::unique_ptr<types::H512> H512_from_string(std::string_view orig);
-
-//! Convert evmc::bytes32 to internal RPC H256 type instance.
-std::unique_ptr<types::H256> H256_from_bytes32(const evmc::bytes32& orig);
-
-//! Convert intx::uint256 to internal RPC H256 type instance.
-std::unique_ptr<types::H256> H256_from_uint256(const intx::uint256& orig);
-
-//! Convert evmc::address to internal RPC H160 type instance.
-std::unique_ptr<types::H160> H160_from_address(const evmc::address& orig);
+//! Convert internal RPC H128 type instance to Bytes.
+Bytes bytes_from_H128(const ::types::H128& h128);
 
 //! Convert std::array to internal RPC H2048 type instance.
-std::unique_ptr<types::H2048> H2048_from_string(std::string_view orig);
+std::unique_ptr<::types::H2048> H2048_from_string(std::string_view orig);
+
+std::unique_ptr<::types::H2048> H2048_from_bytes(ByteView bytes);
+
+std::unique_ptr<::types::H1024> H1024_from_bytes(ByteView bytes);
+
+//! Convert evmc::address to internal RPC H512 type instance.
+std::unique_ptr<::types::H512> H512_from_string(std::string_view orig);
+
+//! Convert ByteView to internal RPC H512 type instance.
+std::unique_ptr<::types::H512> H512_from_bytes(ByteView bytes);
+
+//! Convert evmc::bytes32 to internal RPC H256 type instance.
+std::unique_ptr<::types::H256> H256_from_bytes32(const evmc::bytes32& orig);
+
+//! Convert intx::uint256 to internal RPC H256 type instance.
+std::unique_ptr<::types::H256> H256_from_uint256(const intx::uint256& orig);
+
+//! Convert ByteView to internal RPC H256 type instance.
+std::unique_ptr<::types::H256> H256_from_bytes(ByteView bytes);
+
+//! Convert evmc::address to internal RPC H160 type instance.
+std::unique_ptr<::types::H160> H160_from_address(const evmc::address& orig);
+
+//! Convert ByteView to internal RPC H128 type instance.
+std::unique_ptr<::types::H128> H128_from_bytes(ByteView bytes);
 
 }  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/common/conversion_test.cpp
+++ b/silkworm/infra/grpc/common/conversion_test.cpp
@@ -114,6 +114,22 @@ TEST_CASE("address_from_H160", "[silkworm][rpc][util]") {
     }
 }
 
+TEST_CASE("bytes_from_H128", "[silkworm][rpc][util]") {
+    SECTION("empty H128", "[silkworm][rpc][util]") {
+        CHECK_NOTHROW(bytes_from_H128(::types::H128{}).empty());
+    }
+
+    SECTION("non-empty H128", "[silkworm][rpc][util]") {
+        ::types::H128* hi = new types::H128();
+        hi->set_lo(0x07);
+        hi->set_hi(0x7F);
+        auto h128_ptr = std::make_unique<::types::H128>();
+        h128_ptr->set_lo(0x07);
+        h128_ptr->set_hi(0x7F);
+        CHECK(bytes_from_H128(*h128_ptr) == *from_hex("0x000000000000007f0000000000000007"));
+    }
+}
+
 TEST_CASE("invertibility", "[silkworm][rpc][util]") {
     SECTION("H512<->string", "[silkworm][rpc][util]") {
         types::H128* hi_hi = new types::H128();

--- a/silkworm/infra/grpc/common/conversion_test.cpp
+++ b/silkworm/infra/grpc/common/conversion_test.cpp
@@ -53,10 +53,10 @@ TEST_CASE("string_from_H512", "[silkworm][rpc][util]") {
     }
 
     SECTION("non-empty H512", "[silkworm][rpc][util]") {
-        types::H128* hi_hi = new types::H128();
-        types::H128* hi_lo = new types::H128();
-        types::H128* lo_hi = new types::H128();
-        types::H128* lo_lo = new types::H128();
+        auto hi_hi = new types::H128();
+        auto hi_lo = new types::H128();
+        auto lo_hi = new types::H128();
+        auto lo_lo = new types::H128();
         hi_hi->set_hi(0x7F);
         hi_hi->set_lo(0x07);
         hi_lo->set_hi(0x6F);
@@ -65,8 +65,8 @@ TEST_CASE("string_from_H512", "[silkworm][rpc][util]") {
         lo_hi->set_lo(0x02);
         lo_lo->set_hi(0x1F);
         lo_lo->set_lo(0x01);
-        types::H256* hi = new types::H256{};
-        types::H256* lo = new types::H256{};
+        auto hi = new types::H256{};
+        auto lo = new types::H256{};
         hi->set_allocated_hi(hi_hi);
         hi->set_allocated_lo(hi_lo);
         lo->set_allocated_hi(lo_hi);
@@ -85,8 +85,8 @@ TEST_CASE("bytes32_from_H256", "[silkworm][rpc][util]") {
     }
 
     SECTION("non-empty H256", "[silkworm][rpc][util]") {
-        types::H128* hi = new types::H128();
-        types::H128* lo = new types::H128();
+        auto hi = new types::H128();
+        auto lo = new types::H128();
         hi->set_hi(0x7F);
         hi->set_lo(0x07);
         lo->set_hi(0x6F);
@@ -104,7 +104,7 @@ TEST_CASE("address_from_H160", "[silkworm][rpc][util]") {
     }
 
     SECTION("non-empty H160", "[silkworm][rpc][util]") {
-        types::H128* hi = new types::H128();
+        auto hi = new types::H128();
         hi->set_lo(0x07);
         hi->set_hi(0x7F);
         auto h160_ptr = std::make_unique<types::H160>();
@@ -120,9 +120,6 @@ TEST_CASE("bytes_from_H128", "[silkworm][rpc][util]") {
     }
 
     SECTION("non-empty H128", "[silkworm][rpc][util]") {
-        ::types::H128* hi = new types::H128();
-        hi->set_lo(0x07);
-        hi->set_hi(0x7F);
         auto h128_ptr = std::make_unique<::types::H128>();
         h128_ptr->set_lo(0x07);
         h128_ptr->set_hi(0x7F);
@@ -132,10 +129,10 @@ TEST_CASE("bytes_from_H128", "[silkworm][rpc][util]") {
 
 TEST_CASE("invertibility", "[silkworm][rpc][util]") {
     SECTION("H512<->string", "[silkworm][rpc][util]") {
-        types::H128* hi_hi = new types::H128();
-        types::H128* hi_lo = new types::H128();
-        types::H128* lo_hi = new types::H128();
-        types::H128* lo_lo = new types::H128();
+        auto hi_hi = new types::H128();
+        auto hi_lo = new types::H128();
+        auto lo_hi = new types::H128();
+        auto lo_lo = new types::H128();
         hi_hi->set_hi(0x7F);
         hi_hi->set_lo(0x07);
         hi_lo->set_hi(0x6F);
@@ -144,8 +141,8 @@ TEST_CASE("invertibility", "[silkworm][rpc][util]") {
         lo_hi->set_lo(0x02);
         lo_lo->set_hi(0x1F);
         lo_lo->set_lo(0x01);
-        types::H256* hi = new types::H256{};
-        types::H256* lo = new types::H256{};
+        auto hi = new types::H256{};
+        auto lo = new types::H256{};
         hi->set_allocated_hi(hi_hi);
         hi->set_allocated_lo(hi_lo);
         lo->set_allocated_hi(lo_hi);
@@ -163,8 +160,8 @@ TEST_CASE("invertibility", "[silkworm][rpc][util]") {
     }
 
     SECTION("H256<->bytes32", "[silkworm][rpc][util]") {
-        types::H128* hi = new types::H128();
-        types::H128* lo = new types::H128();
+        auto hi = new types::H128();
+        auto lo = new types::H128();
         hi->set_hi(0x7F);
         hi->set_lo(0x07);
         lo->set_hi(0x6F);
@@ -182,7 +179,7 @@ TEST_CASE("invertibility", "[silkworm][rpc][util]") {
     }
 
     SECTION("H160<->address", "[silkworm][rpc][util]") {
-        types::H128* hi = new types::H128();
+        auto hi = new types::H128();
         hi->set_hi(0x7F);
         auto h160_ptr1 = std::make_unique<types::H160>();
         h160_ptr1->set_lo(0xFF);

--- a/silkworm/silkrpc/commands/engine_api_test.cpp
+++ b/silkworm/silkrpc/commands/engine_api_test.cpp
@@ -46,7 +46,8 @@ class BackEndMock : public ethbackend::BackEnd {  // NOLINT
     MOCK_METHOD((awaitable<ExecutionPayload>), engine_get_payload_v1, (uint64_t));
     MOCK_METHOD((awaitable<PayloadStatus>), engine_new_payload_v1, (ExecutionPayload));
     MOCK_METHOD((awaitable<ForkChoiceUpdatedReply>), engine_forkchoice_updated_v1, (ForkChoiceUpdatedRequest));
-    MOCK_METHOD((awaitable<std::vector<NodeInfo>>), engine_node_info, ());
+    MOCK_METHOD((awaitable<NodeInfos>), engine_node_info, ());
+    MOCK_METHOD((awaitable<PeerInfos>), peers, ());
 };
 
 namespace {

--- a/silkworm/silkrpc/ethbackend/backend.hpp
+++ b/silkworm/silkrpc/ethbackend/backend.hpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/silkrpc/types/execution_payload.hpp>
 #include <silkworm/silkrpc/types/node_info.hpp>
+#include <silkworm/silkrpc/types/peer_info.hpp>
 
 namespace silkworm::rpc::ethbackend {
 
@@ -39,7 +40,8 @@ class BackEnd {
     virtual boost::asio::awaitable<ExecutionPayload> engine_get_payload_v1(uint64_t payload_id) = 0;
     virtual boost::asio::awaitable<PayloadStatus> engine_new_payload_v1(ExecutionPayload payload) = 0;
     virtual boost::asio::awaitable<ForkChoiceUpdatedReply> engine_forkchoice_updated_v1(ForkChoiceUpdatedRequest forkchoice_updated_request) = 0;
-    virtual boost::asio::awaitable<std::vector<NodeInfo>> engine_node_info() = 0;
+    virtual boost::asio::awaitable<NodeInfos> engine_node_info() = 0;
+    virtual boost::asio::awaitable<PeerInfos> peers() = 0;
 };
 
 }  // namespace silkworm::rpc::ethbackend

--- a/silkworm/silkrpc/ethbackend/remote_backend.hpp
+++ b/silkworm/silkrpc/ethbackend/remote_backend.hpp
@@ -34,49 +34,36 @@
 
 namespace silkworm::rpc::ethbackend {
 
+using boost::asio::awaitable;
+
 class RemoteBackEnd final : public BackEnd {
   public:
-    explicit RemoteBackEnd(boost::asio::io_context& context, std::shared_ptr<grpc::Channel> channel, agrpc::GrpcContext& grpc_context);
-
-    explicit RemoteBackEnd(boost::asio::io_context::executor_type executor, std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub,
+    explicit RemoteBackEnd(boost::asio::io_context& context, const std::shared_ptr<grpc::Channel>& channel,
                            agrpc::GrpcContext& grpc_context);
+    explicit RemoteBackEnd(boost::asio::io_context::executor_type executor,
+                           std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub,
+                           agrpc::GrpcContext& grpc_context);
+    ~RemoteBackEnd() override;
 
-    ~RemoteBackEnd();
-
-    boost::asio::awaitable<evmc::address> etherbase();
-    boost::asio::awaitable<uint64_t> protocol_version();
-    boost::asio::awaitable<uint64_t> net_version();
-    boost::asio::awaitable<std::string> client_version();
-    boost::asio::awaitable<uint64_t> net_peer_count();
-    boost::asio::awaitable<ExecutionPayload> engine_get_payload_v1(uint64_t payload_id);
-    boost::asio::awaitable<PayloadStatus> engine_new_payload_v1(ExecutionPayload payload);
-    boost::asio::awaitable<ForkChoiceUpdatedReply> engine_forkchoice_updated_v1(ForkChoiceUpdatedRequest forkchoice_updated_request);
-    boost::asio::awaitable<std::vector<NodeInfo>> engine_node_info();
+    awaitable<evmc::address> etherbase() override;
+    awaitable<uint64_t> protocol_version() override;
+    awaitable<uint64_t> net_version() override;
+    awaitable<std::string> client_version() override;
+    awaitable<uint64_t> net_peer_count() override;
+    awaitable<ExecutionPayload> engine_get_payload_v1(uint64_t payload_id) override;
+    awaitable<PayloadStatus> engine_new_payload_v1(ExecutionPayload payload) override;
+    awaitable<ForkChoiceUpdatedReply> engine_forkchoice_updated_v1(ForkChoiceUpdatedRequest forkchoice_updated_request) override;
+    awaitable<NodeInfos> engine_node_info() override;
+    awaitable<PeerInfos> peers() override;
 
   private:
-    evmc::address address_from_H160(const types::H160& h160);
-    silkworm::Bytes bytes_from_H128(const types::H128& h128);
-    types::H128* H128_from_bytes(const uint8_t* bytes);
-    types::H160* H160_from_address(const evmc::address& address);
-    types::H256* H256_from_bytes(const uint8_t* bytes);
-    silkworm::Bytes bytes_from_H256(const types::H256& h256);
-    intx::uint256 uint256_from_H256(const types::H256& h256);
-    types::H256* H256_from_uint256(const intx::uint256& n);
-    evmc::bytes32 bytes32_from_H256(const types::H256& h256);
-    types::H512* H512_from_bytes(const uint8_t* bytes);
-    silkworm::Bytes bytes_from_H512(types::H512& h512);
-    types::H1024* H1024_from_bytes(const uint8_t* bytes);
-    silkworm::Bytes bytes_from_H1024(types::H1024& h1024);
-    types::H2048* H2048_from_bytes(const uint8_t* bytes);
-    silkworm::Bytes bytes_from_H2048(types::H2048& h2048);
-
-    ExecutionPayload decode_execution_payload(const types::ExecutionPayload& execution_payload_grpc);
-    types::ExecutionPayload encode_execution_payload(const ExecutionPayload& execution_payload);
-    remote::EngineForkChoiceState* encode_forkchoice_state(const ForkChoiceState& forkchoice_state);
-    remote::EnginePayloadAttributes* encode_payload_attributes(const PayloadAttributes& payload_attributes);
-    remote::EngineForkChoiceUpdatedRequest encode_forkchoice_updated_request(const ForkChoiceUpdatedRequest& forkchoice_updated_request);
-    PayloadStatus decode_payload_status(const remote::EnginePayloadStatus& payload_status_grpc);
-    std::string decode_status_message(const remote::EngineStatus& status);
+    static ExecutionPayload decode_execution_payload(const types::ExecutionPayload& execution_payload_grpc);
+    static types::ExecutionPayload encode_execution_payload(const ExecutionPayload& execution_payload);
+    static remote::EngineForkChoiceState* encode_forkchoice_state(const ForkChoiceState& forkchoice_state);
+    static remote::EnginePayloadAttributes* encode_payload_attributes(const PayloadAttributes& payload_attributes);
+    static remote::EngineForkChoiceUpdatedRequest encode_forkchoice_updated_request(const ForkChoiceUpdatedRequest& forkchoice_updated_request);
+    static PayloadStatus decode_payload_status(const remote::EnginePayloadStatus& payload_status_grpc);
+    static std::string decode_status_message(const remote::EngineStatus& status);
 
     boost::asio::io_context::executor_type executor_;
     std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub_;

--- a/silkworm/silkrpc/txpool/transaction_pool.hpp
+++ b/silkworm/silkrpc/txpool/transaction_pool.hpp
@@ -66,7 +66,7 @@ using TransactionsInPool = std::vector<TransactionInfo>;
 
 class TransactionPool final {
   public:
-    explicit TransactionPool(boost::asio::io_context& context, std::shared_ptr<grpc::Channel> channel, agrpc::GrpcContext& grpc_context);
+    explicit TransactionPool(boost::asio::io_context& context, const std::shared_ptr<grpc::Channel>& channel, agrpc::GrpcContext& grpc_context);
 
     explicit TransactionPool(boost::asio::io_context::executor_type executor, std::unique_ptr<::txpool::Txpool::StubInterface> stub,
                              agrpc::GrpcContext& grpc_context);
@@ -74,20 +74,12 @@ class TransactionPool final {
     ~TransactionPool();
 
     boost::asio::awaitable<OperationResult> add_transaction(const silkworm::ByteView& rlp_tx);
-
     boost::asio::awaitable<std::optional<silkworm::Bytes>> get_transaction(const evmc::bytes32& tx_hash);
-
     boost::asio::awaitable<std::optional<uint64_t>> nonce(const evmc::address& address);
-
     boost::asio::awaitable<StatusInfo> get_status();
-
     boost::asio::awaitable<TransactionsInPool> get_transactions();
 
   private:
-    evmc::address address_from_H160(const types::H160& h160);
-    types::H160* H160_from_address(const evmc::address& address);
-    types::H128* H128_from_bytes(const uint8_t* bytes);
-
     boost::asio::io_context::executor_type executor_;
     std::unique_ptr<::txpool::Txpool::StubInterface> stub_;
     agrpc::GrpcContext& grpc_context_;

--- a/silkworm/silkrpc/types/peer_info.hpp
+++ b/silkworm/silkrpc/types/peer_info.hpp
@@ -21,21 +21,19 @@
 
 namespace silkworm::rpc {
 
-struct NodeInfoPorts {
-    uint64_t discovery;
-    uint64_t listener;
-};
-
-struct NodeInfo {
+struct PeerInfo {
     std::string id;
     std::string name;
     std::string enode;
     std::string enr;
-    std::string listener_addr;
-    std::string protocols;
-    NodeInfoPorts ports;
+    std::vector<std::string> caps;
+    std::string local_address;
+    std::string remote_address;
+    bool is_connection_inbound{false};
+    bool is_connection_trusted{false};
+    bool is_connection_static{false};
 };
 
-using NodeInfos = std::vector<NodeInfo>;
+using PeerInfos = std::vector<PeerInfo>;
 
 }  // namespace silkworm::rpc


### PR DESCRIPTION
This PR introduces the following changes:

- add ETHBACKEND Peers RPC client-side implementation
- move gRPC type conversion utilities into infra
- remove duplicated gRPC type conversion utilities