### PR TITLE
infra: separation between concurrency::ContextPool and rpc::ServerContextPool

### DIFF
--- a/cmd/common/common.cpp
+++ b/cmd/common/common.cpp
@@ -79,19 +79,19 @@ void add_option_num_contexts(CLI::App& cli, uint32_t& num_contexts) {
 }
 
 //! \brief Set up parsing of the wait mode (e.g. block, sleep, spin...) in RPC execution contexts
-void add_option_wait_mode(CLI::App& cli, silkworm::rpc::WaitMode& wait_mode) {
-    std::map<std::string, silkworm::rpc::WaitMode> wait_mode_mapping{
-        {"backoff", silkworm::rpc::WaitMode::backoff},
-        {"blocking", silkworm::rpc::WaitMode::blocking},
-        {"busy_spin", silkworm::rpc::WaitMode::busy_spin},
-        {"sleeping", silkworm::rpc::WaitMode::sleeping},
-        {"yielding", silkworm::rpc::WaitMode::yielding},
+void add_option_wait_mode(CLI::App& cli, concurrency::WaitMode& wait_mode) {
+    std::map<std::string, concurrency::WaitMode> wait_mode_mapping{
+        {"backoff", concurrency::WaitMode::backoff},
+        {"blocking", concurrency::WaitMode::blocking},
+        {"busy_spin", concurrency::WaitMode::busy_spin},
+        {"sleeping", concurrency::WaitMode::sleeping},
+        {"yielding", concurrency::WaitMode::yielding},
     };
     cli.add_option("--wait.mode", wait_mode, "The waiting mode for execution loops during idle cycles")
         ->capture_default_str()
-        ->check(CLI::Range(silkworm::rpc::WaitMode::backoff, silkworm::rpc::WaitMode::busy_spin))
+        ->check(CLI::Range(concurrency::WaitMode::backoff, concurrency::WaitMode::busy_spin))
         ->transform(CLI::Transformer(wait_mode_mapping, CLI::ignore_case))
-        ->default_val(silkworm::rpc::WaitMode::blocking);
+        ->default_val(concurrency::WaitMode::blocking);
 }
 
 void add_context_pool_options(CLI::App& cli, concurrency::ContextPoolSettings& settings) {

--- a/silkworm/infra/concurrency/context_pool.cpp
+++ b/silkworm/infra/concurrency/context_pool.cpp
@@ -1,0 +1,85 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "context_pool.hpp"
+
+#include <thread>
+
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <magic_enum.hpp>
+
+namespace silkworm::concurrency {
+
+std::ostream& operator<<(std::ostream& out, const Context& c) {
+    out << "io_context: " << c.io_context() << " wait_mode: " << magic_enum::enum_name(c.wait_mode());
+    return out;
+}
+
+Context::Context(std::size_t context_id, WaitMode wait_mode)
+    : context_id_(context_id),
+      io_context_{std::make_shared<boost::asio::io_context>()},
+      work_{boost::asio::require(io_context_->get_executor(), boost::asio::execution::outstanding_work_t::tracked)},
+      wait_mode_(wait_mode) {}
+
+void Context::execute_loop() {
+    switch (wait_mode_) {
+        case WaitMode::backoff:
+            execute_loop_single_threaded(YieldingIdleStrategy{});  // TODO(canepat) replace with BackOffIdleStrategy
+            break;
+        case WaitMode::blocking:
+            execute_loop_multi_threaded();
+            break;
+        case WaitMode::yielding:
+            execute_loop_single_threaded(YieldingIdleStrategy{});
+            break;
+        case WaitMode::sleeping:
+            execute_loop_single_threaded(SleepingIdleStrategy{});
+            break;
+        case WaitMode::busy_spin:
+            execute_loop_single_threaded(BusySpinIdleStrategy{});
+            break;
+    }
+}
+
+void Context::stop() {
+    io_context_->stop();
+}
+
+template <typename WaitStrategy>
+void Context::execute_loop_single_threaded(WaitStrategy&& wait_strategy) {
+    SILK_DEBUG << "Single-thread execution loop start [" << std::this_thread::get_id() << "]";
+    while (!io_context_->stopped()) {
+        std::size_t work_count = io_context_->poll();
+        wait_strategy.idle(work_count);
+    }
+    SILK_DEBUG << "Single-thread execution loop end [" << std::this_thread::get_id() << "]";
+}
+
+void Context::execute_loop_multi_threaded() {
+    SILK_DEBUG << "Multi-thread execution loop start [" << std::this_thread::get_id() << "]";
+    const auto num_threads = std::thread::hardware_concurrency() / 2;
+    boost::asio::thread_pool pool{num_threads};
+    for (std::size_t i{0}; i < num_threads; ++i) {
+        boost::asio::post(pool, [&]() { io_context_->run(); });
+    }
+    pool.join();
+    SILK_DEBUG << "Multi-thread execution loop end [" << std::this_thread::get_id() << "]";
+}
+
+template class ContextPool<>;
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/context_pool.hpp
+++ b/silkworm/infra/concurrency/context_pool.hpp
@@ -1,0 +1,185 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <vector>
+
+#include <boost/asio/io_context.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/concurrency/context_pool_settings.hpp>
+#include <silkworm/infra/concurrency/idle_strategy.hpp>
+
+namespace silkworm::concurrency {
+
+//! Asynchronous scheduler running an execution loop.
+class Context {
+  public:
+    explicit Context(std::size_t context_id, WaitMode wait_mode = WaitMode::blocking);
+
+    [[nodiscard]] boost::asio::io_context* io_context() const noexcept { return io_context_.get(); }
+    [[nodiscard]] WaitMode wait_mode() const noexcept { return wait_mode_; }
+    [[nodiscard]] std::size_t id() const noexcept { return context_id_; }
+
+    //! Execute the scheduler loop until stopped.
+    void execute_loop();
+
+    //! Stop the execution loop.
+    void stop();
+
+  protected:
+    //! Execute single-threaded loop until stopped.
+    template <typename WaitStrategy>
+    void execute_loop_single_threaded(WaitStrategy&& wait_strategy);
+
+    //! Execute multi-threaded loop until stopped.
+    void execute_loop_multi_threaded();
+
+    //! The unique scheduler identifier.
+    std::size_t context_id_;
+
+    //! The asio asynchronous event loop scheduler.
+    std::shared_ptr<boost::asio::io_context> io_context_;
+
+    //! The work-tracking executor that keep the asio scheduler running.
+    boost::asio::execution::any_executor<> work_;
+
+    //! The waiting mode used by execution loops during idle cycles.
+    WaitMode wait_mode_;
+};
+
+std::ostream& operator<<(std::ostream& out, const Context& c);
+
+//! Pool of \ref Context instances running as separate reactive schedulers.
+template <typename T = Context>
+class ContextPool {
+  public:
+    explicit ContextPool(std::size_t pool_size) : next_index_{0} {
+        if (pool_size == 0) {
+            throw std::logic_error("ContextPool::ContextPool pool_size is 0");
+        }
+        contexts_.reserve(pool_size);
+    }
+    explicit ContextPool(ContextPoolSettings settings) : ContextPool(settings.num_contexts) {
+        for (size_t i{0}; i < settings.num_contexts; ++i) {
+            add_context(T{contexts_.size(), settings.wait_mode});
+        }
+    }
+    ~ContextPool() {
+        SILK_TRACE << "ContextPool::~ContextPool START " << this;
+        stop();
+        SILK_TRACE << "ContextPool::~ContextPool END " << this;
+    }
+
+    ContextPool(const ContextPool&) = delete;
+    ContextPool& operator=(const ContextPool&) = delete;
+
+    //! Add a new \ref T to the pool.
+    const T& add_context(T&& context) {
+        const auto num_contexts = contexts_.size();
+        contexts_.emplace_back(std::move(context));
+        SILK_DEBUG << "ContextPool::add_context context[" << num_contexts << "] " << contexts_[num_contexts];
+        return contexts_[num_contexts];
+    }
+
+    //! Start one execution thread for each context.
+    void start() {
+        SILK_TRACE << "ContextPool::start START";
+
+        // Create a pool of threads to run all the contexts (each context having 1 thread)
+        for (std::size_t i{0}; i < contexts_.size(); ++i) {
+            auto& context = contexts_[i];
+            context_threads_.create_thread([&, i = i]() {
+                log::set_thread_name(std::string("asio_ctx_s" + std::to_string(i)).c_str());
+                SILK_TRACE << "Thread start context[" << i << "] thread_id: " << std::this_thread::get_id();
+                context.execute_loop();
+                SILK_TRACE << "Thread end context[" << i << "] thread_id: " << std::this_thread::get_id();
+            });
+            SILK_DEBUG << "ContextPool::start context[" << i << "] started: " << context.io_context();
+        }
+
+        SILK_TRACE << "ContextPool::start END";
+    }
+
+    //! Wait for termination of all execution threads.
+    //!\warning This will block until \ref stop() is called.
+    void join() {
+        SILK_TRACE << "ContextPool::join START";
+
+        // Wait for all threads in the pool to exit.
+        SILK_DEBUG << "ContextPool::join joining...";
+        context_threads_.join();
+
+        SILK_TRACE << "ContextPool::join END";
+    }
+
+    //! Stop all execution threads. This does *NOT* wait for termination: use \ref join() for that.
+    void stop() {
+        SILK_TRACE << "ContextPool::stop START";
+
+        if (!stopped_.exchange(true)) {
+            // Explicitly stop all context runnable components
+            for (std::size_t i{0}; i < contexts_.size(); ++i) {
+                contexts_[i].stop();
+                SILK_DEBUG << "ContextPool::stop context[" << i << "] stopped: " << contexts_[i].io_context();
+            }
+        }
+
+        SILK_TRACE << "ContextPool::stop END";
+    }
+
+    //! Run one execution thread for each context waiting for termination of all execution threads.
+    //!\warning This will block until \ref stop() is called.
+    void run() {
+        start();
+        join();
+    }
+
+    [[nodiscard]] std::size_t num_contexts() const { return contexts_.size(); }
+
+    //! Use a round-robin scheme to choose the next context to use
+    const T& next_context() {
+        // Increment the next index first to make sure that different calling threads get different contexts.
+        size_t index = next_index_.fetch_add(1) % contexts_.size();
+        return contexts_[index];
+    }
+
+    boost::asio::io_context& next_io_context() {
+        const auto& context = next_context();
+        return *context.io_context();
+    }
+
+  private:
+    //! The pool of execution contexts.
+    std::vector<T> contexts_;
+
+    //! The pool of threads running the execution contexts.
+    boost::asio::detail::thread_group context_threads_;
+
+    //! The index for obtaining next context to use (round-robin).
+    std::atomic_size_t next_index_;
+
+    //! Flag indicating if pool has been stopped.
+    std::atomic_bool stopped_{false};
+};
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/context_pool_settings.hpp
+++ b/silkworm/infra/concurrency/context_pool_settings.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <silkworm/infra/grpc/server/wait_strategy.hpp>
+#include <silkworm/infra/concurrency/idle_strategy.hpp>
 
 namespace silkworm::concurrency {
 
@@ -24,7 +24,7 @@ struct ContextPoolSettings {
     // initialized in the constructor based on hardware_concurrency
     uint32_t num_contexts{0};
 
-    silkworm::rpc::WaitMode wait_mode{silkworm::rpc::WaitMode::blocking};
+    WaitMode wait_mode{WaitMode::blocking};
 
     ContextPoolSettings();
 };

--- a/silkworm/infra/concurrency/context_pool_test.cpp
+++ b/silkworm/infra/concurrency/context_pool_test.cpp
@@ -1,0 +1,152 @@
+/*
+   Copyright 2022 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "context_pool.hpp"
+
+#include <atomic>
+#include <stdexcept>
+#include <thread>
+
+#include <boost/asio/executor_work_guard.hpp>
+#include <catch2/catch.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/test/log.hpp>
+
+namespace silkworm::concurrency {
+
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
+#ifndef SILKWORM_SANITIZE
+TEST_CASE("Context", "[silkworm][rpc][server_context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+    Context ctx{0};
+
+    SECTION("ServerContext") {
+        CHECK(ctx.io_context() != nullptr);
+    }
+
+    SECTION("execute_loop") {
+        boost::asio::executor_work_guard work = boost::asio::make_work_guard(*ctx.io_context());
+        std::atomic_bool context_thread_failed{false};
+        std::thread context_thread{[&]() {
+            try {
+                ctx.execute_loop();
+            } catch (...) {
+                context_thread_failed = true;
+            }
+        }};
+        ctx.stop();
+        context_thread.join();
+        CHECK(!context_thread_failed);
+    }
+
+    SECTION("stop") {
+        boost::asio::executor_work_guard work = boost::asio::make_work_guard(*ctx.io_context());
+        std::thread context_thread{[&]() { ctx.execute_loop(); }};
+        CHECK(!ctx.io_context()->stopped());
+        ctx.stop();
+        CHECK(ctx.io_context()->stopped());
+        context_thread.join();
+        ctx.stop();
+        CHECK(ctx.io_context()->stopped());
+    }
+
+    SECTION("print") {
+        CHECK_NOTHROW(test::null_stream() << ctx);
+    }
+}
+
+TEST_CASE("ContextPool", "[silkworm][concurrency][Context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    SECTION("ContextPool OK") {
+        ContextPool context_pool{2};
+        CHECK(context_pool.num_contexts() == 0);
+    }
+
+    SECTION("ContextPool KO") {
+        CHECK_THROWS_AS(ContextPool{0}, std::logic_error);
+    }
+
+    SECTION("add_context") {
+        ContextPool context_pool{2};
+        REQUIRE(context_pool.num_contexts() == 0);
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        CHECK(context_pool.num_contexts() == 2);
+    }
+
+    SECTION("next_context") {
+        ContextPool context_pool{2};
+        REQUIRE(context_pool.num_contexts() == 0);
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        CHECK(context_pool.num_contexts() == 2);
+        auto& context1 = context_pool.next_context();
+        CHECK(context1.io_context() != nullptr);
+        auto& context2 = context_pool.next_context();
+        CHECK(context2.io_context() != nullptr);
+    }
+
+    SECTION("next_io_context") {
+        ContextPool context_pool{2};
+        REQUIRE(context_pool.num_contexts() == 0);
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        CHECK(context_pool.num_contexts() == 2);
+        auto& context1 = context_pool.next_context();
+        auto& context2 = context_pool.next_context();
+        CHECK(&context_pool.next_io_context() == context1.io_context());
+        CHECK(&context_pool.next_io_context() == context2.io_context());
+    }
+
+    SECTION("start/stop w/o contexts") {
+        ContextPool context_pool{2};
+        REQUIRE(context_pool.num_contexts() == 0);
+        CHECK_NOTHROW(context_pool.start());
+        CHECK_NOTHROW(context_pool.stop());
+    }
+
+    SECTION("start/stop w/ contexts") {
+        ContextPool context_pool{2};
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        CHECK_NOTHROW(context_pool.start());
+        CHECK_NOTHROW(context_pool.stop());
+    }
+
+    SECTION("join") {
+        ContextPool context_pool{2};
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        context_pool.start();
+        std::thread joining_thread{[&]() { context_pool.join(); }};
+        context_pool.stop();
+        CHECK_NOTHROW(joining_thread.join());
+    }
+
+    SECTION("join after stop") {
+        ContextPool context_pool{2};
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        context_pool.start();
+        context_pool.stop();
+        CHECK_NOTHROW(context_pool.join());
+    }
+}
+#endif  // SILKWORM_SANITIZE
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/idle_strategy.cpp
+++ b/silkworm/infra/concurrency/idle_strategy.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,13 +14,11 @@
    limitations under the License.
 */
 
-#include "wait_strategy.hpp"
-
-#include <utility>
+#include "idle_strategy.hpp"
 
 #include <absl/strings/str_cat.h>
 
-namespace silkworm::rpc {
+namespace silkworm::concurrency {
 
 bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* error) {
     if (text == "backoff") {
@@ -64,4 +62,4 @@ std::string AbslUnparseFlag(WaitMode wait_mode) {
     }
 }
 
-}  // namespace silkworm::rpc
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/idle_strategy.hpp
+++ b/silkworm/infra/concurrency/idle_strategy.hpp
@@ -42,13 +42,13 @@
 
 #include <absl/strings/string_view.h>
 
-namespace silkworm::rpc {
+namespace silkworm::concurrency {
 
 using namespace std::chrono_literals;  // NOLINT(build/namespaces)
 
-class SleepingWaitStrategy {
+class SleepingIdleStrategy {
   public:
-    explicit SleepingWaitStrategy(std::chrono::milliseconds duration = 1ms) : duration_(duration) {}
+    explicit SleepingIdleStrategy(std::chrono::milliseconds duration = 1ms) : duration_(duration) {}
 
     inline void idle(std::size_t work_count) {
         if (work_count > 0) {
@@ -62,9 +62,9 @@ class SleepingWaitStrategy {
     std::chrono::milliseconds duration_;
 };
 
-class YieldingWaitStrategy {
+class YieldingIdleStrategy {
   public:
-    inline void idle(std::size_t work_count) {
+    static inline void idle(std::size_t work_count) {
         if (work_count > 0) {
             return;
         }
@@ -73,14 +73,14 @@ class YieldingWaitStrategy {
     }
 };
 
-class BusySpinWaitStrategy {
+class BusySpinIdleStrategy {
   public:
     inline void idle(std::size_t /*work_count*/) {
     }
 };
 
 enum class WaitMode {
-    backoff, /* Wait strategy implemented in asio-grpc's agrpc::run */
+    backoff,
     blocking,
     sleeping,
     yielding,
@@ -90,4 +90,4 @@ enum class WaitMode {
 bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* error);
 std::string AbslUnparseFlag(WaitMode wait_mode);
 
-}  // namespace silkworm::rpc
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/idle_strategy_test.cpp
+++ b/silkworm/infra/concurrency/idle_strategy_test.cpp
@@ -14,11 +14,9 @@
    limitations under the License.
 */
 
-#include "wait_strategy.hpp"
+#include "idle_strategy.hpp"
 
 #include <atomic>
-#include <cstddef>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -26,13 +24,11 @@
 #include <catch2/catch.hpp>
 #include <grpcpp/grpcpp.h>
 
-using namespace std::chrono_literals;  // NOLINT(build/namespaces)
-
-namespace silkworm::rpc {
+namespace silkworm::concurrency {
 
 using Catch::Matchers::Message;
 
-TEST_CASE("parse wait mode", "[silkrpc][common][log]") {
+TEST_CASE("parse wait mode", "[silkworm][infra][concurrency][idle_strategy]") {
     std::vector<absl::string_view> input_texts{
         "backoff", "blocking", "sleeping", "yielding", "busy_spin"};
     std::vector<WaitMode> expected_wait_modes{
@@ -52,7 +48,7 @@ TEST_CASE("parse wait mode", "[silkrpc][common][log]") {
     }
 }
 
-TEST_CASE("parse invalid wait mode", "[silkrpc][common][log]") {
+TEST_CASE("parse invalid wait mode", "[silkworm][infra][concurrency][idle_strategy]") {
     WaitMode wait_mode;
     std::string error;
     const auto success{AbslParseFlag("abc", &wait_mode, &error)};
@@ -60,7 +56,7 @@ TEST_CASE("parse invalid wait mode", "[silkrpc][common][log]") {
     CHECK(!error.empty());
 }
 
-TEST_CASE("unparse wait mode", "[silkrpc][common][log]") {
+TEST_CASE("unparse wait mode", "[silkworm][infra][concurrency][idle_strategy]") {
     std::vector<WaitMode> input_wait_modes{
         WaitMode::backoff,
         WaitMode::blocking,
@@ -82,28 +78,28 @@ inline void sleep_then_check_wait(W& w, const std::chrono::duration<R, P>& t, st
     CHECK_NOTHROW(w.idle(executed_count));
 }
 
-TEST_CASE("SleepingWaitStrategy", "[silkrpc][context_pool]") {
-    SleepingWaitStrategy wait_strategy{1ms};
+TEST_CASE("SleepingWaitStrategy", "[silkworm][infra][concurrency][idle_strategy]") {
+    SleepingIdleStrategy wait_strategy{1ms};
     sleep_then_check_wait(wait_strategy, 10ms, 1);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 10ms, 1);
 }
 
-TEST_CASE("YieldingWaitStrategy", "[silkrpc][context_pool]") {
-    YieldingWaitStrategy wait_strategy;
+TEST_CASE("YieldingWaitStrategy", "[silkworm][context_pool]") {
+    YieldingIdleStrategy wait_strategy;
     sleep_then_check_wait(wait_strategy, 10ms, 1);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 10ms, 1);
 }
 
-TEST_CASE("BusySpinWaitStrategy", "[silkrpc][context_pool]") {
-    BusySpinWaitStrategy wait_strategy;
+TEST_CASE("BusySpinWaitStrategy", "[silkworm][infra][concurrency][idle_strategy]") {
+    BusySpinIdleStrategy wait_strategy;
     sleep_then_check_wait(wait_strategy, 10ms, 1);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 20ms, 0);
     sleep_then_check_wait(wait_strategy, 10ms, 1);
 }
 
-}  // namespace silkworm::rpc
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/grpc/server/server_context_pool.cpp
+++ b/silkworm/infra/grpc/server/server_context_pool.cpp
@@ -26,6 +26,8 @@
 
 namespace silkworm::rpc {
 
+using namespace concurrency;
+
 std::ostream& operator<<(std::ostream& out, const ServerContext& c) {
     out << "io_context: " << c.io_context() << " wait_mode: " << magic_enum::enum_name(c.wait_mode());
     return out;
@@ -35,43 +37,60 @@ inline static std::string build_thread_name(const char name_tag[11], size_t id) 
     return {name_tag + std::to_string(id)};
 }
 
-ServerContext::ServerContext(std::size_t context_id, std::unique_ptr<grpc::ServerCompletionQueue>&& queue, WaitMode wait_mode)
-    : context_id_(context_id),
-      io_context_{std::make_shared<boost::asio::io_context>()},
-      work_{boost::asio::require(io_context_->get_executor(), boost::asio::execution::outstanding_work_t::tracked)},
+ServerContext::ServerContext(std::size_t context_id, ServerCompletionQueuePtr&& queue, concurrency::WaitMode wait_mode)
+    : context_{context_id, wait_mode},
       server_grpc_context_{std::make_unique<agrpc::GrpcContext>(std::move(queue))},
       client_grpc_context_{std::make_unique<agrpc::GrpcContext>(std::make_unique<grpc::CompletionQueue>())},
       server_grpc_context_work_{boost::asio::make_work_guard(server_grpc_context_->get_executor())},
-      client_grpc_context_work_{boost::asio::make_work_guard(client_grpc_context_->get_executor())},
-      wait_mode_(wait_mode) {}
+      client_grpc_context_work_{boost::asio::make_work_guard(client_grpc_context_->get_executor())} {}
+
+void ServerContext::execute_loop() {
+    switch (context_.wait_mode()) {
+        case WaitMode::backoff:
+            execute_loop_backoff();
+            break;
+        case WaitMode::blocking:
+            execute_loop_multi_threaded();
+            break;
+        case WaitMode::yielding:
+            execute_loop_single_threaded(YieldingIdleStrategy{});
+            break;
+        case WaitMode::sleeping:
+            execute_loop_single_threaded(SleepingIdleStrategy{});
+            break;
+        case WaitMode::busy_spin:
+            execute_loop_single_threaded(BusySpinIdleStrategy{});
+            break;
+    }
+}
 
 //! Execute asio-grpc loop until stopped.
-void ServerContext::execute_loop_agrpc() {
-    SILK_DEBUG << "Asio-grpc execution loop start [" << std::this_thread::get_id() << "]";
-    boost::asio::post(*io_context_, [&] {
-        agrpc::run(*server_grpc_context_, *io_context_, [&] { return io_context_->stopped(); });
+void ServerContext::execute_loop_backoff() {
+    SILK_DEBUG << "Back-off execution loop start [" << std::this_thread::get_id() << "]";
+    boost::asio::post(*io_context(), [&] {
+        agrpc::run(*server_grpc_context_, *io_context(), [&] { return io_context()->stopped(); });
     });
     std::thread client_grpc_context_thread{[&]() {
-        log::set_thread_name(build_thread_name("grpc_ctx_c", context_id_).c_str());
+        log::set_thread_name(build_thread_name("grpc_ctx_c", id()).c_str());
         SILK_DEBUG << "Client GrpcContext execution loop start [" << std::this_thread::get_id() << "]";
         client_grpc_context_->run_completion_queue();
         SILK_DEBUG << "Client GrpcContext execution loop end [" << std::this_thread::get_id() << "]";
     }};
-    io_context_->run();
+    io_context()->run();
 
     client_grpc_context_work_.reset();
     client_grpc_context_->stop();
     client_grpc_context_thread.join();
-    SILK_DEBUG << "Asio-grpc execution loop end [" << std::this_thread::get_id() << "]";
+    SILK_DEBUG << "Back-off execution loop end [" << std::this_thread::get_id() << "]";
 }
 
 template <typename WaitStrategy>
 void ServerContext::execute_loop_single_threaded(WaitStrategy&& wait_strategy) {
     SILK_DEBUG << "Single-thread execution loop start [" << std::this_thread::get_id() << "]";
-    while (!io_context_->stopped()) {
+    while (!io_context()->stopped()) {
         std::size_t work_count = server_grpc_context_->poll();
         work_count += client_grpc_context_->poll_completion_queue();
-        work_count += io_context_->poll();
+        work_count += io_context()->poll();
         wait_strategy.idle(work_count);
     }
     SILK_DEBUG << "Single-thread execution loop end [" << std::this_thread::get_id() << "]";
@@ -80,18 +99,18 @@ void ServerContext::execute_loop_single_threaded(WaitStrategy&& wait_strategy) {
 void ServerContext::execute_loop_multi_threaded() {
     SILK_DEBUG << "Multi-thread execution loop start [" << std::this_thread::get_id() << "]";
     std::thread server_grpc_context_thread{[&]() {
-        log::set_thread_name(build_thread_name("grpc_ctx_s", context_id_).c_str());
+        log::set_thread_name(build_thread_name("grpc_ctx_s", id()).c_str());
         SILK_DEBUG << "Server GrpcContext execution loop start [" << std::this_thread::get_id() << "]";
         server_grpc_context_->run();
         SILK_DEBUG << "Server GrpcContext execution loop end [" << std::this_thread::get_id() << "]";
     }};
     std::thread client_grpc_context_thread{[&]() {
-        log::set_thread_name(build_thread_name("grpc_ctx_c", context_id_).c_str());
+        log::set_thread_name(build_thread_name("grpc_ctx_c", id()).c_str());
         SILK_DEBUG << "Client GrpcContext execution loop start [" << std::this_thread::get_id() << "]";
         client_grpc_context_->run_completion_queue();
         SILK_DEBUG << "Client GrpcContext execution loop end [" << std::this_thread::get_id() << "]";
     }};
-    io_context_->run();
+    io_context()->run();
 
     server_grpc_context_work_.reset();
     client_grpc_context_work_.reset();
@@ -102,40 +121,15 @@ void ServerContext::execute_loop_multi_threaded() {
     SILK_DEBUG << "Multi-thread execution loop end [" << std::this_thread::get_id() << "]";
 }
 
-void ServerContext::execute_loop() {
-    switch (wait_mode_) {
-        case WaitMode::backoff:
-            execute_loop_agrpc();
-            break;
-        case WaitMode::blocking:
-            execute_loop_multi_threaded();
-            break;
-        case WaitMode::yielding:
-            execute_loop_single_threaded(YieldingWaitStrategy{});
-            break;
-        case WaitMode::sleeping:
-            execute_loop_single_threaded(SleepingWaitStrategy{});
-            break;
-        case WaitMode::busy_spin:
-            execute_loop_single_threaded(BusySpinWaitStrategy{});
-            break;
-    }
-}
-
-void ServerContext::stop() { io_context_->stop(); }
-
-ServerContextPool::ServerContextPool(std::size_t pool_size) : next_index_{0} {
+ServerContextPool::ServerContextPool(std::size_t pool_size) : execution_pool_{pool_size} {
     if (pool_size == 0) {
         throw std::logic_error("ServerContextPool::ServerContextPool pool_size is 0");
     }
     SILK_INFO << "Creating server context pool with size: " << pool_size;
-
-    contexts_.reserve(pool_size);
 }
 
-ServerContextPool::ServerContextPool(
-    concurrency::ContextPoolSettings settings,
-    const std::function<std::unique_ptr<grpc::ServerCompletionQueue>()>& queue_factory)
+ServerContextPool::ServerContextPool(concurrency::ContextPoolSettings settings,
+                                     const ServerCompletionQueueFactory& queue_factory)
     : ServerContextPool(settings.num_contexts) {
     for (size_t i = 0; i < settings.num_contexts; i++) {
         add_context(queue_factory(), settings.wait_mode);
@@ -148,72 +142,15 @@ ServerContextPool::~ServerContextPool() {
     SILK_TRACE << "ServerContextPool::~ServerContextPool END " << this;
 }
 
-void ServerContextPool::add_context(std::unique_ptr<grpc::ServerCompletionQueue> server_queue, WaitMode wait_mode) {
-    const auto num_contexts = contexts_.size();
-    ServerContext server_context{num_contexts, std::move(server_queue), wait_mode};
-
-    contexts_.push_back(std::move(server_context));
-    SILK_DEBUG << "ServerContextPool::add_context context[" << num_contexts << "] " << contexts_[num_contexts];
+void ServerContextPool::add_context(ServerCompletionQueuePtr queue, concurrency::WaitMode wait_mode) {
+    const auto num_contexts = execution_pool_.num_contexts();
+    const auto& server_context = execution_pool_.add_context(
+        {num_contexts, std::move(queue), wait_mode});
+    SILK_DEBUG << "ServerContextPool::add_context context[" << num_contexts << "] " << server_context;
 }
 
-void ServerContextPool::start() {
-    SILK_TRACE << "ServerContextPool::start START";
-
-    // Create a pool of threads to run all the contexts (each context having 1 thread)
-    for (std::size_t i{0}; i < contexts_.size(); ++i) {
-        auto& context = contexts_[i];
-        context_threads_.create_thread([&, i = i]() {
-            log::set_thread_name(std::string("asio_ctx_s" + std::to_string(i)).c_str());
-            SILK_TRACE << "Thread start context[" << i << "] thread_id: " << std::this_thread::get_id();
-            context.execute_loop();
-            SILK_TRACE << "Thread end context[" << i << "] thread_id: " << std::this_thread::get_id();
-        });
-        SILK_DEBUG << "ServerContextPool::start context[" << i << "] started: " << context.io_context();
-    }
-
-    SILK_TRACE << "ServerContextPool::start END";
-}
-
-void ServerContextPool::join() {
-    SILK_TRACE << "ServerContextPool::join START";
-
-    // Wait for all threads in the pool to exit.
-    SILK_DEBUG << "ServerContextPool::join joining...";
-    context_threads_.join();
-
-    SILK_TRACE << "ServerContextPool::join END";
-}
-
-void ServerContextPool::stop() {
-    SILK_TRACE << "ServerContextPool::stop START";
-
-    if (!stopped_.exchange(true)) {
-        // Explicitly stop all context runnable components
-        for (std::size_t i{0}; i < contexts_.size(); ++i) {
-            contexts_[i].stop();
-            SILK_DEBUG << "ServerContextPool::stop context[" << i << "] stopped: " << contexts_[i].io_context();
-        }
-    }
-
-    SILK_TRACE << "ServerContextPool::stop END";
-}
-
-void ServerContextPool::run() {
-    start();
-    join();
-}
-
-const ServerContext& ServerContextPool::next_context() {
-    // Use a round-robin scheme to choose the next context to use
-    // Increment the next index first to make sure that different calling threads get different contexts.
-    size_t index = next_index_.fetch_add(1) % contexts_.size();
-    const auto& context = contexts_[index];
-    return context;
-}
-
-boost::asio::io_context& ServerContextPool::next_io_context() {
-    const auto& context = next_context();
-    return *context.io_context();
+const ServerContext& ServerContextPool::add_context(ServerContext&& context) {
+    return execution_pool_.add_context(std::move(context));
 }
 
 }  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/server/server_context_pool_test.cpp
+++ b/silkworm/infra/grpc/server/server_context_pool_test.cpp
@@ -28,6 +28,8 @@
 
 namespace silkworm::rpc {
 
+using namespace concurrency;
+
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerContext", "[silkworm][rpc][server_context]") {


### PR DESCRIPTION
This PR is a first step to separate responsibilites in our server-side execution context pool:

- a new class `concurrency::ContextPool` implements a pool of execution contexts based on `asio::io_context`
- the existing class `rpc::ServerContextPool` has been changed to wrap around `concurrency::ContextPool` the gRPC support for handling server-side gRPC communication

Please note that there is still another execution context pool in `rpcdaemon` called `silkworm::rpc::ContextPool` that:
- again implements a pool of execution contexts based on `asio::io_context`
- handles client-side `::grpc::CompletionQueue` instances for gRPC communication
- maintains both private and shared state in each execution context and in context pool

This class [to be renamed `silkworm::rpc::ClientContextPool`] is *not* changed in this PR, it will be refactored in next PR.