### PR TITLE
cmd: move logging options out of common sentry options

### DIFF
--- a/cmd/common/sentry_options.cpp
+++ b/cmd/common/sentry_options.cpp
@@ -29,8 +29,6 @@
 namespace silkworm::cmd::common {
 
 void add_sentry_options(CLI::App& cli, silkworm::sentry::Settings& settings) {
-    add_logging_options(cli, settings.log_settings);
-
     add_option_ip_endpoint(cli, "--sentry.api.addr", settings.api_address, "GRPC API endpoint");
 
     cli.add_option("--port", settings.port)

--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -44,6 +44,7 @@ Settings sentry_parse_cli_settings(int argc, char* argv[]) {
     Settings settings;
     settings.build_info = silkworm_get_buildinfo();
 
+    add_logging_options(cli, settings.log_settings);
     add_option_data_dir(cli, settings.data_dir_path);
     add_context_pool_options(cli, settings.context_pool_settings);
     add_sentry_options(cli, settings);


### PR DESCRIPTION
Fixes #1022 