### PR TITLE
third_party: upgrade ethereum EL tests to v12.2

### DIFF
--- a/cmd/test/ethereum.cpp
+++ b/cmd/test/ethereum.cpp
@@ -58,10 +58,7 @@ static const std::vector<fs::path> kSlowTests{
     kBlockchainDir / "GeneralStateTests" / "VMTests" / "vmPerformance",
 };
 
-static const std::vector<fs::path> kFailingTests{
-    // EOF is not implemented yet
-    kBlockchainDir / "GeneralStateTests" / "EIPTests" / "stEOF",
-};
+static const std::vector<fs::path> kFailingTests{};
 
 static constexpr size_t kColumnWidth{80};
 


### PR DESCRIPTION
[v12](https://github.com/ethereum/tests/releases/tag/v12) -> [v12.2](https://github.com/ethereum/tests/releases/tag/v12.2)