### PR TITLE
core: fix multi-thread access in lru_cache

### DIFF
--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -291,9 +291,9 @@ evmc_result EVM::execute_with_baseline_interpreter(evmc_revision rev, const evmc
     std::shared_ptr<evmone::baseline::CodeAnalysis> analysis;
     const bool use_cache{code_hash && baseline_analysis_cache};
     if (use_cache) {
-        const auto* ptr{baseline_analysis_cache->get(*code_hash)};
-        if (ptr) {
-            analysis = *ptr;
+        const auto optional_analysis{baseline_analysis_cache->get_as_copy(*code_hash)};
+        if (optional_analysis) {
+            analysis = *optional_analysis;
         }
     }
     if (!analysis) {


### PR DESCRIPTION
In case of multi-thread access the `lru_cache::get` method must not be used because returns address of internal map: I have inserted an assertion to avoid this misuse and made some changes to protect `lru_cache::get_as_copy`, which is now thread-safe