### PR TITLE
infra: sync_wait

### DIFF
--- a/silkworm/infra/concurrency/sync_wait.hpp
+++ b/silkworm/infra/concurrency/sync_wait.hpp
@@ -1,0 +1,76 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/infra/concurrency/coroutine.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/asio/awaitable.hpp>
+
+namespace silkworm {
+
+namespace asio = boost::asio;
+/**
+ * Do a synchronous wait of a coroutine on the specified io_context
+ *
+ * sync_wait:
+ * - schedules a coroutine for execution in the specified io_context
+ * - blocks the calling thread until the coroutine completes
+ * - returns the result of the coroutine
+ *
+ * Rationale: doing an asynchronous wait of a coroutine is easy:
+ *    auto result = co_await task();
+ * Doing a synchronous wait of a coroutine is more verbose:
+ *    auto result = asio::co_spawn(io_context, task(), asio::use_future).get();
+ * also this exposes implementation details.
+ * Using sync_wait the call becomes:
+ *   auto result = sync_wait(io_context, task());
+ * Or, if the current object has an io_context:
+ *   auto result = sync_wait(in(this), task());
+ *
+ */
+template <typename T>
+T sync_wait(asio::io_context& io_context, const asio::awaitable<T>& task) {
+    auto future_result = asio::co_spawn(io_context, task, asio::use_future);
+    return future_result.get();
+}
+
+template <typename T>
+T sync_wait(asio::io_context& io_context, asio::awaitable<T>&& task) {
+    auto future_result = asio::co_spawn(io_context, std::move(task), asio::use_future);
+    return future_result.get();
+}
+
+/**
+ * Simplify the call to sync_wait
+ *
+ * When the desired io_context is not immediately available in the scope of the caller,
+ * but is owned by some object, this function can be used to retrieve it and simplify
+ * the call to sync_wait
+ *
+ * For example, provided that some class Engine has an io_context:
+ *    sync_wait(in(engine), engine.do_work());
+ * or provided that the current object has an io_context:
+ *    sync_wait(in(this), engine.do_work());
+ */
+
+template <typename C>
+asio::io_context& in(C& context) {
+    return context.get_executor();
+}
+
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/sync_wait_test.cpp
+++ b/silkworm/infra/concurrency/sync_wait_test.cpp
@@ -35,17 +35,17 @@ asio::awaitable<void> dummy_task() {
 }
 
 class DummyEngine {
-    asio::io_context& io;
+    asio::io_context& io_;
 
   public:
-    DummyEngine(asio::io_context& io) : io{io} {}
+    DummyEngine(asio::io_context& io) : io_{io} {}
 
     asio::awaitable<int> do_work() {
         co_return 42;
     }
 
     asio::io_context& get_executor() {
-        return io;
+        return io_;
     }
 };
 

--- a/silkworm/infra/concurrency/sync_wait_test.cpp
+++ b/silkworm/infra/concurrency/sync_wait_test.cpp
@@ -1,0 +1,79 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "sync_wait.hpp"
+
+#include <chrono>
+
+#include <boost/asio.hpp>
+#include <catch2/catch.hpp>
+
+namespace silkworm {
+
+namespace asio = boost::asio;
+
+asio::awaitable<void> dummy_task() {
+    auto executor = co_await asio::this_coro::executor;
+
+    asio::steady_timer timer{executor};
+    timer.expires_after(std::chrono::milliseconds(100));
+
+    co_await timer.async_wait(asio::use_awaitable);
+}
+
+class DummyEngine {
+    asio::io_context& io;
+
+  public:
+    DummyEngine(asio::io_context& io) : io{io} {}
+
+    asio::awaitable<int> do_work() {
+        co_return 42;
+    }
+
+    asio::io_context& get_executor() {
+        return io;
+    }
+};
+
+TEST_CASE("sync wait") {
+    asio::io_context io;
+    asio::io_context::work work{io};
+
+    SECTION("wait for function") {
+        std::thread io_execution([&io]() { io.run(); });
+
+        sync_wait(io, dummy_task());
+
+        io.stop();
+        io_execution.join();
+    }
+
+    SECTION("wait for method") {
+        std::thread io_execution([&io]() { io.run(); });
+
+        DummyEngine engine{io};
+
+        auto value = sync_wait(in(engine), engine.do_work());
+
+        CHECK(value == 42);
+
+        io.stop();
+        io_execution.join();
+    }
+}
+
+}  // namespace silkworm


### PR DESCRIPTION
**Doing an asynchronous wait of a coroutine is easy**:

`auto result = co_await task();`

**Doing a synchronous wait of a coroutine is more verbose**:

`auto result = asio::co_spawn(io_context, task(), asio::use_future).get();`

also, this exposes implementation details.


**Using the simple sync_wait() function of this PR, the call becomes**:

`auto result = sync_wait(io_context, task());`

so at the call site, the intent of the code becomes clearer.

A simple getter enables us to simplify the code further when the io_context is not available in the scope and we need to get it from get_executor() method:

`auto result = sync_wait(in(this), task());`