### PR TITLE
infra: add gRPC client context pool and services

### DIFF
--- a/silkworm/infra/concurrency/base_service.hpp
+++ b/silkworm/infra/concurrency/base_service.hpp
@@ -1,0 +1,26 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <boost/asio/execution_context.hpp>
+
+namespace silkworm::concurrency {
+
+template <typename T>
+using BaseService = boost::asio::detail::execution_context_service_base<T>;
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/context_pool.hpp
+++ b/silkworm/infra/concurrency/context_pool.hpp
@@ -86,7 +86,7 @@ class ContextPool {
             add_context(T{contexts_.size(), settings.wait_mode});
         }
     }
-    ~ContextPool() {
+    virtual ~ContextPool() {
         SILK_TRACE << "ContextPool::~ContextPool START " << this;
         stop();
         join();
@@ -105,7 +105,7 @@ class ContextPool {
     }
 
     //! Start one execution thread for each context.
-    void start() {
+    virtual void start() {
         SILK_TRACE << "ContextPool::start START";
 
         // Create a pool of threads to run all the contexts (each context having 1 thread)
@@ -136,7 +136,7 @@ class ContextPool {
     }
 
     //! Stop all execution threads. This does *NOT* wait for termination: use \ref join() for that.
-    void stop() {
+    virtual void stop() {
         SILK_TRACE << "ContextPool::stop START";
 
         if (!stopped_.exchange(true)) {

--- a/silkworm/infra/concurrency/private_service.hpp
+++ b/silkworm/infra/concurrency/private_service.hpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <boost/asio/execution_context.hpp>
+
+#include <silkworm/infra/concurrency/base_service.hpp>
+
+namespace silkworm::concurrency {
+
+template <typename T>
+class PrivateService : public BaseService<PrivateService<T>> {
+  public:
+    explicit PrivateService(boost::asio::execution_context& owner) : BaseService<PrivateService>(owner) {}
+
+    void shutdown() override { unique_.reset(); }
+
+    //! Explicitly *take ownership* of \code std::unique_ptr to enforce isolation
+    void set_private(std::unique_ptr<T>&& unique) {
+        unique_ = std::move(unique);
+    }
+    std::unique_ptr<T>& unique() { return unique_; }
+
+  private:
+    std::unique_ptr<T> unique_;
+};
+
+template <typename T>
+void add_private_service(boost::asio::execution_context& context, std::unique_ptr<T>&& unique) {
+    if (not has_service<PrivateService<T>>(context)) {
+        make_service<PrivateService<T>>(context);
+    }
+    use_service<PrivateService<T>>(context).set_private(std::move(unique));
+}
+
+template <typename T>
+std::unique_ptr<T>& use_private_service(boost::asio::execution_context& context) {
+    return use_service<PrivateService<T>>(context).unique();
+}
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/private_service_test.cpp
+++ b/silkworm/infra/concurrency/private_service_test.cpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "private_service.hpp"
+
+#include <boost/asio/io_context.hpp>
+
+#include <catch2/catch.hpp>
+
+namespace silkworm::concurrency {
+
+TEST_CASE("PrivateService", "[silkworm][infra][concurrency][services]") {
+    struct Integer{
+        explicit Integer(int value) : value_(value) {}
+        [[nodiscard]] int value() const { return value_; }
+      private:
+        int value_{0};
+    };
+    boost::asio::io_context ioc;
+
+    SECTION("register service") {
+        CHECK(!use_private_service<Integer>(ioc));
+        CHECK_NOTHROW(add_private_service<Integer>(ioc, std::make_unique<Integer>(1)));
+        CHECK(use_private_service<Integer>(ioc)->value() == 1);
+    }
+    SECTION("register service twice") {
+        CHECK(!use_private_service<Integer>(ioc));
+        CHECK_NOTHROW(add_private_service<Integer>(ioc, std::make_unique<Integer>(1)));
+        CHECK(use_private_service<Integer>(ioc)->value() == 1);
+        CHECK_NOTHROW(add_private_service<Integer>(ioc, std::make_unique<Integer>(2)));
+        CHECK(use_private_service<Integer>(ioc)->value() == 2);
+    }
+}
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/private_service_test.cpp
+++ b/silkworm/infra/concurrency/private_service_test.cpp
@@ -17,15 +17,15 @@
 #include "private_service.hpp"
 
 #include <boost/asio/io_context.hpp>
-
 #include <catch2/catch.hpp>
 
 namespace silkworm::concurrency {
 
 TEST_CASE("PrivateService", "[silkworm][infra][concurrency][services]") {
-    struct Integer{
+    struct Integer {
         explicit Integer(int value) : value_(value) {}
         [[nodiscard]] int value() const { return value_; }
+
       private:
         int value_{0};
     };

--- a/silkworm/infra/concurrency/shared_service.hpp
+++ b/silkworm/infra/concurrency/shared_service.hpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <boost/asio/execution_context.hpp>
+
+#include <silkworm/infra/concurrency/base_service.hpp>
+
+namespace silkworm::concurrency {
+
+template <typename T>
+class SharedService : public BaseService<SharedService<T>> {
+  public:
+    explicit SharedService(boost::asio::execution_context& owner) : BaseService<SharedService>(owner) {}
+
+    void shutdown() override { shared_.reset(); }
+
+    //! Explicitly make a *copy* of \code std::shared_ptr to be thread-safe
+    void set_shared(std::shared_ptr<T> shared) {
+        shared_ = std::move(shared);
+    }
+    std::shared_ptr<T>& shared() { return shared_; }
+
+  private:
+    std::shared_ptr<T> shared_;
+};
+
+template <typename T>
+void add_shared_service(boost::asio::execution_context& context, std::shared_ptr<T> shared) {
+    if (not has_service<SharedService<T>>(context)) {
+        make_service<SharedService<T>>(context);
+    }
+    use_service<SharedService<T>>(context).set_shared(std::move(shared));
+}
+
+template <typename T>
+std::shared_ptr<T>& use_shared_service(boost::asio::execution_context& context) {
+    return use_service<SharedService<T>>(context).shared();
+}
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/shared_service_test.cpp
+++ b/silkworm/infra/concurrency/shared_service_test.cpp
@@ -17,15 +17,15 @@
 #include "shared_service.hpp"
 
 #include <boost/asio/io_context.hpp>
-
 #include <catch2/catch.hpp>
 
 namespace silkworm::concurrency {
 
 TEST_CASE("SharedService", "[silkworm][infra][concurrency][services]") {
-    struct Integer{
+    struct Integer {
         explicit Integer(int value) : value_(value) {}
         [[nodiscard]] int value() const { return value_; }
+
       private:
         int value_{0};
     };

--- a/silkworm/infra/concurrency/shared_service_test.cpp
+++ b/silkworm/infra/concurrency/shared_service_test.cpp
@@ -1,0 +1,64 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "shared_service.hpp"
+
+#include <boost/asio/io_context.hpp>
+
+#include <catch2/catch.hpp>
+
+namespace silkworm::concurrency {
+
+TEST_CASE("SharedService", "[silkworm][infra][concurrency][services]") {
+    struct Integer{
+        explicit Integer(int value) : value_(value) {}
+        [[nodiscard]] int value() const { return value_; }
+      private:
+        int value_{0};
+    };
+    boost::asio::io_context ioc1;
+    boost::asio::io_context ioc2;
+
+    SECTION("no service") {
+        CHECK(!use_shared_service<Integer>(ioc1));
+        CHECK(!use_shared_service<Integer>(ioc2));
+    }
+    SECTION("register service") {
+        CHECK(!use_shared_service<Integer>(ioc1));
+        CHECK(!use_shared_service<Integer>(ioc2));
+        auto shared_integer = std::make_shared<Integer>(1);
+        CHECK_NOTHROW(add_shared_service<Integer>(ioc1, shared_integer));
+        CHECK_NOTHROW(add_shared_service<Integer>(ioc2, shared_integer));
+        CHECK(use_shared_service<Integer>(ioc1)->value() == 1);
+        CHECK(use_shared_service<Integer>(ioc2)->value() == 1);
+    }
+    SECTION("register service twice") {
+        CHECK(!use_shared_service<Integer>(ioc1));
+        CHECK(!use_shared_service<Integer>(ioc2));
+        auto shared_integer_1 = std::make_shared<Integer>(1);
+        auto shared_integer_2 = std::make_shared<Integer>(2);
+        CHECK_NOTHROW(add_shared_service<Integer>(ioc1, shared_integer_1));
+        CHECK_NOTHROW(add_shared_service<Integer>(ioc2, shared_integer_1));
+        CHECK(use_shared_service<Integer>(ioc1)->value() == 1);
+        CHECK(use_shared_service<Integer>(ioc2)->value() == 1);
+        CHECK_NOTHROW(add_shared_service<Integer>(ioc1, shared_integer_2));
+        CHECK_NOTHROW(add_shared_service<Integer>(ioc2, shared_integer_2));
+        CHECK(use_shared_service<Integer>(ioc1)->value() == 2);
+        CHECK(use_shared_service<Integer>(ioc2)->value() == 2);
+    }
+}
+
+}  // namespace silkworm::concurrency

--- a/silkworm/infra/grpc/client/client_context_pool.cpp
+++ b/silkworm/infra/grpc/client/client_context_pool.cpp
@@ -1,0 +1,122 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "client_context_pool.hpp"
+
+#include <thread>
+
+#include <magic_enum.hpp>
+
+#include <silkworm/infra/concurrency/idle_strategy.hpp>
+
+namespace silkworm::rpc {
+
+using namespace concurrency;
+
+std::ostream& operator<<(std::ostream& out, const ClientContext& c) {
+    out << "io_context: " << c.io_context() << " wait_mode: " << magic_enum::enum_name(c.wait_mode());
+    return out;
+}
+
+ClientContext::ClientContext(std::size_t context_id, WaitMode wait_mode)
+    : Context(context_id, wait_mode),
+      grpc_context_{std::make_unique<agrpc::GrpcContext>()},
+      grpc_context_work_{boost::asio::make_work_guard(grpc_context_->get_executor())} {}
+
+void ClientContext::execute_loop() {
+    switch (wait_mode_) {
+        case WaitMode::backoff:
+            execute_loop_backoff();
+            break;
+        case WaitMode::blocking:
+            execute_loop_multi_threaded();
+            break;
+        case WaitMode::yielding:
+            execute_loop_single_threaded(YieldingIdleStrategy{});
+            break;
+        case WaitMode::sleeping:
+            execute_loop_single_threaded(SleepingIdleStrategy{});
+            break;
+        case WaitMode::busy_spin:
+            execute_loop_single_threaded(BusySpinIdleStrategy{});
+            break;
+    }
+}
+
+void ClientContext::execute_loop_backoff() {
+    SILK_DEBUG << "Back-off execution loop start [" << std::this_thread::get_id() << "]";
+    agrpc::run(*grpc_context_, *io_context_, [&] { return io_context_->stopped(); });
+    SILK_DEBUG << "Back-off execution loop end [" << std::this_thread::get_id() << "]";
+}
+
+template <typename IdleStrategy>
+void ClientContext::execute_loop_single_threaded(IdleStrategy&& idle_strategy) {
+    SILK_DEBUG << "Single-thread execution loop start [" << std::this_thread::get_id() << "]";
+    while (!io_context_->stopped()) {
+        std::size_t work_count = grpc_context_->poll_completion_queue();
+        work_count += io_context_->poll();
+        idle_strategy.idle(work_count);
+    }
+    SILK_DEBUG << "Single-thread execution loop end [" << std::this_thread::get_id() << "]";
+}
+
+void ClientContext::execute_loop_multi_threaded() {
+    SILK_DEBUG << "Multi-thread execution loop start [" << std::this_thread::get_id() << "]";
+    std::thread grpc_context_thread{[grpc_context = grpc_context_]() {
+        grpc_context->run_completion_queue();
+    }};
+    io_context_->run();
+
+    grpc_context_work_.reset();
+    grpc_context_->stop();
+    grpc_context_thread.join();
+    SILK_DEBUG << "Multi-thread execution loop end [" << std::this_thread::get_id() << "]";
+}
+
+ClientContextPool::ClientContextPool(std::size_t pool_size, concurrency::WaitMode wait_mode)
+    : ContextPool(pool_size) {
+    // Create as many execution contexts as required by the pool size
+    for (std::size_t i{0}; i < pool_size; ++i) {
+        add_context(wait_mode);
+    }
+}
+
+ClientContextPool::ClientContextPool(concurrency::ContextPoolSettings settings)
+    : ClientContextPool(settings.num_contexts, settings.wait_mode) {}
+
+void ClientContextPool::start() {
+    // Cannot restart because ::grpc::CompletionQueue inside agrpc::GrpcContext cannot be reused
+    if (stopped_) {
+        throw std::logic_error("cannot restart context pool, create another one");
+    }
+
+    ContextPool<ClientContext>::start();
+}
+
+void ClientContextPool::stop() {
+    // Flag the pool as stopped to prevent restart
+    stopped_ = true;
+
+    ContextPool<ClientContext>::stop();
+}
+
+void ClientContextPool::add_context(concurrency::WaitMode wait_mode) {
+    const auto context_count = num_contexts();
+    const auto& client_context = ContextPool::add_context(ClientContext{context_count, wait_mode});
+    SILK_DEBUG << "ClientContextPool::add_context context[" << context_count << "] " << client_context;
+}
+
+}  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/client/client_context_pool.hpp
+++ b/silkworm/infra/grpc/client/client_context_pool.hpp
@@ -1,0 +1,85 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <memory>
+
+#include <agrpc/asio_grpc.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include <silkworm/infra/concurrency/context_pool.hpp>
+#include <silkworm/infra/concurrency/context_pool_settings.hpp>
+
+namespace silkworm::rpc {
+
+//! Asynchronous client scheduler running an execution loop w/ integrated gRPC client.
+class ClientContext : public concurrency::Context {
+  public:
+    explicit ClientContext(std::size_t context_id, concurrency::WaitMode wait_mode = concurrency::WaitMode::blocking);
+
+    [[nodiscard]] agrpc::GrpcContext* grpc_context() const noexcept { return grpc_context_.get(); }
+
+    //! Execute the scheduler loop until stopped.
+    void execute_loop() override;
+
+  private:
+    //! Execute back-off loop until stopped.
+    void execute_loop_backoff();
+
+    //! Execute single-threaded loop until stopped.
+    template <typename IdleStrategy>
+    void execute_loop_single_threaded(IdleStrategy&& idle_strategy);
+
+    //! Execute multi-threaded loop until stopped.
+    void execute_loop_multi_threaded();
+
+    //! The asio-grpc asynchronous event scheduler.
+    std::shared_ptr<agrpc::GrpcContext> grpc_context_;
+
+    //! The work-tracking executor that keep the asio-grpc scheduler running.
+    boost::asio::executor_work_guard<agrpc::GrpcContext::executor_type> grpc_context_work_;
+};
+
+std::ostream& operator<<(std::ostream& out, const ClientContext& c);
+
+//! Pool of \ref ClientContext instances running as separate reactive schedulers.
+//! \warning currently cannot start/stop more than once because ::grpc::CompletionQueue cannot be used after shutdown
+class ClientContextPool : public concurrency::ContextPool<ClientContext> {
+  public:
+    explicit ClientContextPool(std::size_t pool_size, concurrency::WaitMode wait_mode = concurrency::WaitMode::blocking);
+    explicit ClientContextPool(concurrency::ContextPoolSettings settings);
+
+    ClientContextPool(const ClientContextPool&) = delete;
+    ClientContextPool& operator=(const ClientContextPool&) = delete;
+
+    void start() override;
+    void stop() override;
+
+    //! Add a new \ref ClientContext to the pool.
+    void add_context(concurrency::WaitMode wait_mode);
+
+  private:
+    //! Flag indicating if pool has been stopped.
+    std::atomic_bool stopped_{false};
+};
+
+}  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/client/client_context_pool_test.cpp
+++ b/silkworm/infra/grpc/client/client_context_pool_test.cpp
@@ -1,0 +1,218 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "client_context_pool.hpp"
+
+#include <atomic>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <boost/asio/post.hpp>
+#include <catch2/catch.hpp>
+
+#include <silkworm/infra/test/log.hpp>
+
+namespace silkworm::rpc {
+
+using Catch::Matchers::Message;
+
+// Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
+#ifndef SILKWORM_SANITIZE
+
+TEST_CASE("ClientContext", "[silkworm][infra][grpc][client][client_context]") {
+    concurrency::WaitMode all_wait_modes[] = {
+        concurrency::WaitMode::backoff,
+        concurrency::WaitMode::blocking,
+        concurrency::WaitMode::sleeping,
+        concurrency::WaitMode::yielding,
+        concurrency::WaitMode::busy_spin};
+    for (auto wait_mode : all_wait_modes) {
+        ClientContext context{0, wait_mode};
+
+        SECTION(std::string("Context::Context wait_mode=") + std::to_string(static_cast<int>(wait_mode))) {
+            CHECK_NOTHROW(context.io_context() != nullptr);
+            CHECK_NOTHROW(context.grpc_context() != nullptr);
+        }
+
+        SECTION(std::string("Context::execute_loop wait_mode=") + std::to_string(static_cast<int>(wait_mode))) {
+            std::atomic_bool processed{false};
+            auto* io_context = context.io_context();
+            boost::asio::post(*io_context, [&]() {
+                processed = true;
+                context.stop();
+            });
+            auto context_thread = std::thread([&]() { context.execute_loop(); });
+            CHECK_NOTHROW(context_thread.join());
+            CHECK(processed);
+        }
+
+        SECTION(std::string("Context::stop wait_mode=") + std::to_string(static_cast<int>(wait_mode))) {
+            std::atomic_bool processed{false};
+            auto* io_context = context.io_context();
+            boost::asio::post(*io_context, [&]() {
+                processed = true;
+            });
+            auto context_thread = std::thread([&]() { context.execute_loop(); });
+            CHECK_NOTHROW(context.stop());
+            CHECK_NOTHROW(context_thread.join());
+        }
+
+        SECTION("print") {
+            CHECK_NOTHROW(test::null_stream() << context);
+        }
+    }
+}
+
+TEST_CASE("ClientContextPool: create context pool", "[silkworm][infra][grpc][client][client_context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    SECTION("reject size 0") {
+        CHECK_THROWS_MATCHES((ClientContextPool{0}), std::logic_error,
+                             Message("ContextPool::ContextPool pool_size is 0"));
+    }
+
+    SECTION("accept size 1") {
+        ClientContextPool cp{1};
+        CHECK(&cp.next_context() == &cp.next_context());
+        CHECK(&cp.next_io_context() == &cp.next_io_context());
+    }
+
+    SECTION("accept size greater than 1") {
+        ClientContextPool cp{3};
+
+        const auto& context1 = cp.next_context();
+        const auto& context2 = cp.next_context();
+        const auto& context3 = cp.next_context();
+
+        const auto& context4 = cp.next_context();
+        const auto& context5 = cp.next_context();
+        const auto& context6 = cp.next_context();
+
+        CHECK(&context1 == &context4);
+        CHECK(&context2 == &context5);
+        CHECK(&context3 == &context6);
+
+        const auto& io_context1 = cp.next_io_context();
+        const auto& io_context2 = cp.next_io_context();
+        const auto& io_context3 = cp.next_io_context();
+
+        const auto& io_context4 = cp.next_io_context();
+        const auto& io_context5 = cp.next_io_context();
+        const auto& io_context6 = cp.next_io_context();
+
+        CHECK(&io_context1 == &io_context4);
+        CHECK(&io_context2 == &io_context5);
+        CHECK(&io_context3 == &io_context6);
+    }
+}
+
+TEST_CASE("ClientContextPool: start context pool", "[silkworm][infra][grpc][client][client_context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    SECTION("running 1 thread") {
+        ClientContextPool cp{1};
+        cp.start();
+        cp.stop();
+        cp.join();
+    }
+
+    SECTION("running 3 thread") {
+        ClientContextPool cp{3};
+        cp.start();
+        cp.stop();
+        cp.join();
+    }
+}
+
+TEST_CASE("ClientContextPool: run context pool", "[silkworm][infra][grpc][client][client_context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    SECTION("running 1 thread") {
+        ClientContextPool cp{1};
+        auto context_pool_thread = std::thread([&]() { cp.run(); });
+        boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
+        CHECK_NOTHROW(context_pool_thread.join());
+    }
+
+    SECTION("running 3 thread") {
+        ClientContextPool cp{3};
+        auto context_pool_thread = std::thread([&]() { cp.run(); });
+        boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
+        CHECK_NOTHROW(context_pool_thread.join());
+    }
+
+    SECTION("multiple runners require multiple pools") {
+        ClientContextPool cp1{3};
+        ClientContextPool cp2{3};
+        auto context_pool_thread1 = std::thread([&]() { cp1.run(); });
+        auto context_pool_thread2 = std::thread([&]() { cp2.run(); });
+        boost::asio::post(cp1.next_io_context(), [&]() { cp1.stop(); });
+        boost::asio::post(cp2.next_io_context(), [&]() { cp2.stop(); });
+        CHECK_NOTHROW(context_pool_thread1.join());
+        CHECK_NOTHROW(context_pool_thread2.join());
+    }
+}
+
+TEST_CASE("ClientContextPool: stop context pool", "[silkworm][infra][grpc][client][client_context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    SECTION("not yet running") {
+        ClientContextPool cp{3};
+        CHECK_NOTHROW(cp.stop());
+    }
+
+    SECTION("already stopped") {
+        ClientContextPool cp{3};
+        cp.start();
+        cp.stop();
+        CHECK_NOTHROW(cp.stop());
+        cp.join();
+    }
+
+    SECTION("already stopped after run in dedicated thread") {
+        ClientContextPool cp{3};
+        auto context_pool_thread = std::thread([&]() { cp.run(); });
+        boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
+        boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
+        context_pool_thread.join();
+        boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
+    }
+}
+
+TEST_CASE("ClientContextPool: cannot restart context pool", "[silkworm][infra][grpc][client][client_context]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    SECTION("running 1 thread") {
+        ClientContextPool cp{1};
+        cp.start();
+        cp.stop();
+        cp.join();
+        CHECK_THROWS_AS(cp.start(), std::logic_error);
+    }
+
+    /*SECTION("running 3 thread") {
+        ClientContextPool cp{3};
+        auto context_pool_thread = std::thread([&]() { cp.run(); });
+        boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
+        CHECK_NOTHROW(context_pool_thread.join());
+        CHECK_THROWS_AS(cp.start(), std::logic_error);
+    }*/
+}
+
+#endif  // SILKWORM_SANITIZE
+
+}  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/client/client_context_pool_test.cpp
+++ b/silkworm/infra/grpc/client/client_context_pool_test.cpp
@@ -204,13 +204,13 @@ TEST_CASE("ClientContextPool: cannot restart context pool", "[silkworm][infra][g
         CHECK_THROWS_AS(cp.start(), std::logic_error);
     }
 
-    /*SECTION("running 3 thread") {
+    SECTION("running 3 thread") {
         ClientContextPool cp{3};
         auto context_pool_thread = std::thread([&]() { cp.run(); });
         boost::asio::post(cp.next_io_context(), [&]() { cp.stop(); });
         CHECK_NOTHROW(context_pool_thread.join());
         CHECK_THROWS_AS(cp.start(), std::logic_error);
-    }*/
+    }
 }
 
 #endif  // SILKWORM_SANITIZE


### PR DESCRIPTION
This PR introduces:

- refactoring and extraction of gRPC context pool running `rpcdaemon` (i.e. `silkrpc`) into a cleaner `ClientContextPool` based on `concurrency::ContextPool` and unaware of `rpcdaemon` (i.e. `silkrpc`) internal state
- add private and shared service abstractions based on service registry available in `boost::asio::io_context`, which will be used in following PR to attach the `rpcdaemon` (i.e. `silkrpc`) internal state to `ClientContextPool`

This is just the first PR in a row aimed at refactoring some modules out of `rpcdaemon` (i.e. `silkrpc`) to move Engine JSON API service into `sync`.