### PR TITLE
rpcdaemon: use ClientContextPool and state services

### DIFF
--- a/cmd/rpcdaemon/ethbackend_coroutines.cpp
+++ b/cmd/rpcdaemon/ethbackend_coroutines.cpp
@@ -18,15 +18,13 @@
 #include <iomanip>
 #include <iostream>
 
-#include <silkworm/infra/concurrency/coroutine.hpp>
-
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <grpcpp/grpcpp.h>
 
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/interfaces/types/types.pb.h>
 #include <silkworm/silkrpc/common/util.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/ethbackend/remote_backend.hpp>
 
 using namespace silkworm;
@@ -57,12 +55,7 @@ boost::asio::awaitable<void> ethbackend_etherbase(ethbackend::BackEnd& backend) 
 
 int ethbackend_coroutines(const std::string& target) {
     try {
-        // TODO(canepat): handle also secure channel for remote
-        ChannelFactory create_channel = [&]() {
-            return grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
-        };
-        // TODO(canepat): handle also local (shared-memory) database
-        ContextPool context_pool{1, create_channel};
+        ClientContextPool context_pool{1};
         auto& context = context_pool.next_context();
         auto io_context = context.io_context();
         auto grpc_context = context.grpc_context();

--- a/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
+++ b/cmd/rpcdaemon/kv_seek_async_coroutines.cpp
@@ -17,15 +17,11 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
-#include <utility>
-
-#include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/co_spawn.hpp>
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/core/common/util.hpp>
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/ethdb/kv/remote_database.hpp>

--- a/cmd/rpcdaemon/silkrpc_daemon.cpp
+++ b/cmd/rpcdaemon/silkrpc_daemon.cpp
@@ -45,7 +45,7 @@ ABSL_FLAG(uint32_t, num_contexts, std::thread::hardware_concurrency() / 3, "numb
 ABSL_FLAG(uint32_t, num_workers, 16, "number of worker threads as 32-bit integer");
 ABSL_FLAG(uint32_t, timeout, kDefaultTimeout.count(), "gRPC call timeout as 32-bit integer");
 ABSL_FLAG(LogLevel, log_verbosity, LogLevel::Critical, "logging verbosity level");
-ABSL_FLAG(strategy::WaitMode, wait_mode, strategy::WaitMode::blocking, "scheduler wait mode");
+ABSL_FLAG(concurrency::WaitMode, wait_mode, concurrency::WaitMode::blocking, "scheduler wait mode");
 ABSL_FLAG(std::string, jwt_secret_file, kDefaultJwtFilename, "Token file to ensure safe connection between CL and EL");
 ABSL_FLAG(std::string, datadir, kDefaultDataDir, "DB Path");
 

--- a/examples/get_latest_block.cpp
+++ b/examples/get_latest_block.cpp
@@ -94,8 +94,8 @@ int main(int argc, char* argv[]) {
         auto& context = context_pool.next_context();
         auto io_context = context.io_context();
 
-        auto grpc_channel{::grpc::CreateChannel(target, ::grpc::InsecureChannelCredentials())};
-        auto database = std::make_unique<ethdb::kv::RemoteDatabase>(*context.grpc_context(), grpc_channel);
+        auto channel{::grpc::CreateChannel(target, ::grpc::InsecureChannelCredentials())};
+        auto database = std::make_unique<ethdb::kv::RemoteDatabase>(*context.grpc_context(), channel);
 
         auto context_pool_thread = std::thread([&]() { context_pool.run(); });
 

--- a/silkworm/infra/concurrency/base_service.hpp
+++ b/silkworm/infra/concurrency/base_service.hpp
@@ -18,9 +18,9 @@
 
 #include <boost/asio/execution_context.hpp>
 
-namespace silkworm::concurrency {
+namespace silkworm {
 
 template <typename T>
 using BaseService = boost::asio::detail::execution_context_service_base<T>;
 
-}  // namespace silkworm::concurrency
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/private_service.hpp
+++ b/silkworm/infra/concurrency/private_service.hpp
@@ -22,7 +22,7 @@
 
 #include <silkworm/infra/concurrency/base_service.hpp>
 
-namespace silkworm::concurrency {
+namespace silkworm {
 
 template <typename T>
 class PrivateService : public BaseService<PrivateService<T>> {
@@ -32,7 +32,7 @@ class PrivateService : public BaseService<PrivateService<T>> {
     void shutdown() override { unique_.reset(); }
 
     //! Explicitly *take ownership* of \code std::unique_ptr to enforce isolation
-    void set_private(std::unique_ptr<T>&& unique) {
+    void set_unique(std::unique_ptr<T>&& unique) {
         unique_ = std::move(unique);
     }
     std::unique_ptr<T>& unique() { return unique_; }
@@ -46,7 +46,7 @@ void add_private_service(boost::asio::execution_context& context, std::unique_pt
     if (not has_service<PrivateService<T>>(context)) {
         make_service<PrivateService<T>>(context);
     }
-    use_service<PrivateService<T>>(context).set_private(std::move(unique));
+    use_service<PrivateService<T>>(context).set_unique(std::move(unique));
 }
 
 template <typename T>
@@ -54,4 +54,4 @@ std::unique_ptr<T>& use_private_service(boost::asio::execution_context& context)
     return use_service<PrivateService<T>>(context).unique();
 }
 
-}  // namespace silkworm::concurrency
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/private_service_test.cpp
+++ b/silkworm/infra/concurrency/private_service_test.cpp
@@ -19,7 +19,7 @@
 #include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
-namespace silkworm::concurrency {
+namespace silkworm {
 
 TEST_CASE("PrivateService", "[silkworm][infra][concurrency][services]") {
     struct Integer {
@@ -43,6 +43,17 @@ TEST_CASE("PrivateService", "[silkworm][infra][concurrency][services]") {
         CHECK_NOTHROW(add_private_service<Integer>(ioc, std::make_unique<Integer>(2)));
         CHECK(use_private_service<Integer>(ioc)->value() == 2);
     }
+    SECTION("register and lookup with same type") {
+        class A {};
+        class B : public A {};
+        CHECK(!use_private_service<A>(ioc));
+        CHECK(!use_private_service<B>(ioc));
+        CHECK_NOTHROW(add_private_service(ioc, std::make_unique<B>()));
+        CHECK(!use_private_service<A>(ioc));
+        CHECK(use_private_service<B>(ioc));
+        CHECK_NOTHROW(add_private_service<A>(ioc, std::make_unique<B>()));
+        CHECK(use_private_service<A>(ioc));
+    }
 }
 
-}  // namespace silkworm::concurrency
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/shared_service.hpp
+++ b/silkworm/infra/concurrency/shared_service.hpp
@@ -22,7 +22,7 @@
 
 #include <silkworm/infra/concurrency/base_service.hpp>
 
-namespace silkworm::concurrency {
+namespace silkworm {
 
 template <typename T>
 class SharedService : public BaseService<SharedService<T>> {
@@ -54,4 +54,4 @@ std::shared_ptr<T>& use_shared_service(boost::asio::execution_context& context) 
     return use_service<SharedService<T>>(context).shared();
 }
 
-}  // namespace silkworm::concurrency
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/shared_service_test.cpp
+++ b/silkworm/infra/concurrency/shared_service_test.cpp
@@ -19,7 +19,7 @@
 #include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
-namespace silkworm::concurrency {
+namespace silkworm {
 
 TEST_CASE("SharedService", "[silkworm][infra][concurrency][services]") {
     struct Integer {
@@ -61,4 +61,4 @@ TEST_CASE("SharedService", "[silkworm][infra][concurrency][services]") {
     }
 }
 
-}  // namespace silkworm::concurrency
+}  // namespace silkworm

--- a/silkworm/infra/grpc/client/client_context_pool.hpp
+++ b/silkworm/infra/grpc/client/client_context_pool.hpp
@@ -25,11 +25,14 @@
 #include <agrpc/asio_grpc.hpp>
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
+#include <grpcpp/grpcpp.h>
 
 #include <silkworm/infra/concurrency/context_pool.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 
 namespace silkworm::rpc {
+
+using ChannelFactory = std::function<std::shared_ptr<::grpc::Channel>()>;
 
 //! Asynchronous client scheduler running an execution loop w/ integrated gRPC client.
 class ClientContext : public concurrency::Context {

--- a/silkworm/infra/grpc/server/server_context_pool_test.cpp
+++ b/silkworm/infra/grpc/server/server_context_pool_test.cpp
@@ -32,7 +32,7 @@ using namespace concurrency;
 
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
-TEST_CASE("ServerContext", "[silkworm][rpc][server_context]") {
+TEST_CASE("ServerContext", "[silkworm][infra][grpc][server][server_context]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
     std::unique_ptr<grpc::ServerCompletionQueue> scq = builder.AddCompletionQueue();
@@ -78,7 +78,7 @@ TEST_CASE("ServerContext", "[silkworm][rpc][server_context]") {
     }
 }
 
-TEST_CASE("ServerContextPool", "[silkworm][rpc][server_context]") {
+TEST_CASE("ServerContextPool", "[silkworm][infra][grpc][server][server_context]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
 

--- a/silkworm/silkrpc/commands/admin_api.hpp
+++ b/silkworm/silkrpc/commands/admin_api.hpp
@@ -22,8 +22,10 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 
+#include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
@@ -40,6 +42,8 @@ using boost::asio::awaitable;
 class AdminRpcApi {
   public:
     explicit AdminRpcApi(std::unique_ptr<ethbackend::BackEnd>& backend) : backend_(backend) {}
+    explicit AdminRpcApi(boost::asio::io_context& io_context)
+        : AdminRpcApi(use_private_service<ethbackend::BackEnd>(io_context)) {}
     virtual ~AdminRpcApi() = default;
 
     AdminRpcApi(const AdminRpcApi&) = delete;
@@ -50,8 +54,8 @@ class AdminRpcApi {
     awaitable<void> handle_admin_peers(const nlohmann::json& request, nlohmann::json& reply);
 
   private:
-    friend class silkworm::http::RequestHandler;
-
     std::unique_ptr<ethbackend::BackEnd>& backend_;
+
+    friend class silkworm::http::RequestHandler;
 };
 }  // namespace silkworm::rpc::commands

--- a/silkworm/silkrpc/commands/debug_api.hpp
+++ b/silkworm/silkrpc/commands/debug_api.hpp
@@ -31,8 +31,8 @@
 #include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
-#include <silkworm/silkrpc/ethdb/transaction_database.hpp>
 #include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
+#include <silkworm/silkrpc/ethdb/transaction_database.hpp>
 #include <silkworm/silkrpc/json/stream.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 

--- a/silkworm/silkrpc/commands/debug_api_test.cpp
+++ b/silkworm/silkrpc/commands/debug_api_test.cpp
@@ -24,7 +24,6 @@
 #include <boost/asio/use_future.hpp>
 #endif  // !defined(__clang__)
 #include <catch2/catch.hpp>
-#include <grpcpp  //grpcpp.h>
 #include <nlohmann/json.hpp>
 
 #include <silkworm/infra/concurrency/shared_service.hpp>

--- a/silkworm/silkrpc/commands/debug_api_test.cpp
+++ b/silkworm/silkrpc/commands/debug_api_test.cpp
@@ -24,7 +24,7 @@
 #include <boost/asio/use_future.hpp>
 #endif  // !defined(__clang__)
 #include <catch2/catch.hpp>
-#include <grpcpp//grpcpp.h>
+#include <grpcpp  //grpcpp.h>
 #include <nlohmann/json.hpp>
 
 #include <silkworm/infra/concurrency/shared_service.hpp>

--- a/silkworm/silkrpc/commands/engine_api.cpp
+++ b/silkworm/silkrpc/commands/engine_api.cpp
@@ -20,6 +20,7 @@
 
 #include <evmc/evmc.hpp>
 
+#include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/chain.hpp>
 #include <silkworm/silkrpc/ethdb/transaction_database.hpp>
 #include <silkworm/silkrpc/types/execution_payload.hpp>

--- a/silkworm/silkrpc/commands/engine_api.hpp
+++ b/silkworm/silkrpc/commands/engine_api.hpp
@@ -25,8 +25,8 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/infra/concurrency/private_service.hpp>
-#include <silkworm/silkrpc/ethdb/database.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>
+#include <silkworm/silkrpc/ethdb/database.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 
 namespace silkworm::http {

--- a/silkworm/silkrpc/commands/erigon_api.cpp
+++ b/silkworm/silkrpc/commands/erigon_api.cpp
@@ -16,7 +16,6 @@
 
 #include "erigon_api.hpp"
 
-#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -25,7 +24,6 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/silkrpc/common/binary_search.hpp>
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
@@ -36,12 +34,6 @@
 #include <silkworm/silkrpc/json/types.hpp>
 
 namespace silkworm::rpc::commands {
-
-ErigonRpcApi::ErigonRpcApi(Context& context)
-    : context_(context),
-      backend_(context.backend()),
-      block_cache_(context.block_cache()),
-      database_(context.database()) {}
 
 // https://eth.wiki/json-rpc/API#erigon_getBlockByTimestamp
 awaitable<void> ErigonRpcApi::handle_erigon_get_block_by_timestamp(const nlohmann::json& request, nlohmann::json& reply) {

--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -36,7 +36,6 @@
 #include <silkworm/node/db/stages.hpp>
 #include <silkworm/node/db/tables.hpp>
 #include <silkworm/node/db/util.hpp>
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
@@ -862,7 +861,7 @@ awaitable<void> EthereumRpcApi::handle_eth_get_transaction_receipt(const nlohman
 awaitable<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request, nlohmann::json& reply) {
     auto params = request["params"];
     if (params.size() != 1) {
-        auto error_msg = "invalid eth_estimategas params: " + params.dump();
+        auto error_msg = "invalid eth_estimateGas params: " + params.dump();
         SILKRPC_ERROR << error_msg << "\n";
         reply = make_json_error(request["id"], 100, error_msg);
         co_return;
@@ -885,7 +884,7 @@ awaitable<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& re
         const auto latest_block_with_hash = co_await core::read_block_by_number(*block_cache_, tx_database, latest_block_number);
         const auto latest_block = latest_block_with_hash->block;
         StateReader state_reader(cached_database);
-        state::RemoteState remote_state{*context_.io_context(), cached_database, latest_block.header.number};
+        state::RemoteState remote_state{io_context_, cached_database, latest_block.header.number};
 
         Tracers tracers;
         EVMExecutor evm_executor{*chain_config_ptr, workers_, remote_state};
@@ -1117,7 +1116,7 @@ awaitable<void> EthereumRpcApi::handle_eth_call(const nlohmann::json& request, s
         const auto chain_config_ptr = lookup_chain_config(chain_id);
         const auto [block_number, is_latest_block] = co_await core::get_block_number(block_id, tx_database, /*latest_required=*/true);
 
-        state::RemoteState remote_state{*context_.io_context(),
+        state::RemoteState remote_state{io_context_,
                                         is_latest_block ? static_cast<core::rawdb::DatabaseReader&>(cached_database) : static_cast<core::rawdb::DatabaseReader&>(tx_database),
                                         block_number};
         EVMExecutor executor{*chain_config_ptr, workers_, remote_state};
@@ -1143,61 +1142,6 @@ awaitable<void> EthereumRpcApi::handle_eth_call(const nlohmann::json& request, s
     } catch (...) {
         SILKRPC_ERROR << "unexpected exception processing request: " << request.dump() << "\n";
         make_glaze_json_error(reply, request["id"], 100, "unexpected exception");
-    }
-
-    co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
-}
-
-// https://eth.wiki/json-rpc/API#eth_call
-boost::asio::awaitable<void> EthereumRpcApi::handle_eth_call_original(const nlohmann::json& request, nlohmann::json& reply) {
-    auto params = request["params"];
-    if (params.size() != 2) {
-        auto error_msg = "invalid eth_call params: " + params.dump();
-        SILKRPC_ERROR << error_msg << "\n";
-        reply = make_json_error(request["id"], 100, error_msg);
-        co_return;
-    }
-    const auto call = params[0].get<Call>();
-    const auto block_id = params[1].get<std::string>();
-    SILKRPC_DEBUG << "call: " << call << " block_id: " << block_id << "\n";
-
-    auto tx = co_await database_->begin();
-
-    try {
-        ethdb::TransactionDatabase tx_database{*tx};
-        ethdb::kv::CachedDatabase cached_database{BlockNumberOrHash{block_id}, *tx, *state_cache_};
-
-        const auto chain_id = co_await core::rawdb::read_chain_id(tx_database);
-        const auto chain_config_ptr = lookup_chain_config(chain_id);
-        const auto [block_number, is_latest_block] = co_await core::get_block_number(block_id, tx_database, /*latest_required=*/true);
-
-        state::RemoteState remote_state{*context_.io_context(),
-                                        is_latest_block ? static_cast<core::rawdb::DatabaseReader&>(cached_database) : static_cast<core::rawdb::DatabaseReader&>(tx_database),
-                                        block_number};
-        EVMExecutor executor{*chain_config_ptr, workers_, remote_state};
-        const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, tx_database, block_number);
-        silkworm::Transaction txn{call.to_transaction()};
-        const auto execution_result = co_await executor.call(block_with_hash->block, txn);
-
-        if (execution_result.pre_check_error) {
-            reply = make_json_error(request["id"], -32000, execution_result.pre_check_error.value());
-        } else if (execution_result.error_code == evmc_status_code::EVMC_SUCCESS) {
-            reply = make_json_content(request["id"], "0x" + silkworm::to_hex(execution_result.data));
-        } else {
-            const auto error_message = EVMExecutor::get_error_message(execution_result.error_code, execution_result.data);
-            if (execution_result.data.empty()) {
-                reply = make_json_error(request["id"], -32000, error_message);
-            } else {
-                reply = make_json_error(request["id"], RevertError{{3, error_message}, execution_result.data});
-            }
-        }
-    } catch (const std::exception& e) {
-        SILKRPC_ERROR << "exception: " << e.what() << " processing request: " << request.dump() << "\n";
-        reply = make_json_error(request["id"], 100, e.what());
-    } catch (...) {
-        SILKRPC_ERROR << "unexpected exception processing request: " << request.dump() << "\n";
-        reply = make_json_error(request["id"], 100, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
@@ -1261,7 +1205,7 @@ awaitable<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::js
         const core::rawdb::DatabaseReader& db_reader =
             is_latest_block ? static_cast<core::rawdb::DatabaseReader&>(cached_database) : static_cast<core::rawdb::DatabaseReader&>(tx_database);
         StateReader state_reader(db_reader);
-        state::RemoteState remote_state{*context_.io_context(), db_reader, block_with_hash->block.header.number};
+        state::RemoteState remote_state{io_context_, db_reader, block_with_hash->block.header.number};
 
         evmc::address to{};
         if (call.to) {
@@ -1363,7 +1307,7 @@ awaitable<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& req
         const core::rawdb::DatabaseReader& db_reader =
             is_latest_block ? static_cast<core::rawdb::DatabaseReader&>(cached_database) : static_cast<core::rawdb::DatabaseReader&>(tx_database);
         auto block_number = block_with_hash->block.header.number;
-        state::RemoteState remote_state{*context_.io_context(), db_reader, block_number};
+        state::RemoteState remote_state{io_context_, db_reader, block_number};
 
         const auto start_time = clock_time::now();
 
@@ -1453,8 +1397,8 @@ awaitable<void> EthereumRpcApi::handle_eth_new_filter(const nlohmann::json& requ
         filter.start = start;
         filter.end = end;
 
-        const auto filter_id = filter_storage_.add_filter(filter);
-        SILKRPC_INFO << "Added a new filter, storage size: " << filter_storage_.size() << "\n";
+        const auto filter_id = filter_storage_->add_filter(filter);
+        SILKRPC_INFO << "Added a new filter, storage size: " << filter_storage_->size() << "\n";
 
         if (filter_id) {
             reply = make_json_content(request["id"], filter_id.value());
@@ -1529,7 +1473,7 @@ awaitable<void> EthereumRpcApi::handle_eth_get_filter_logs(const nlohmann::json&
     auto filter_id = params[0].get<std::string>();
     SILKRPC_INFO << "filter_id: " << filter_id << "\n";
 
-    const auto filter_ref = filter_storage_.get_filter(filter_id);
+    const auto filter_ref = filter_storage_->get_filter(filter_id);
     if (!filter_ref) {
         reply = make_json_error(request["id"], -32000, "filter not found");
         co_return;
@@ -1582,7 +1526,7 @@ awaitable<void> EthereumRpcApi::handle_eth_get_filter_changes(const nlohmann::js
     auto filter_id = params[0].get<std::string>();
     SILKRPC_INFO << "filter_id: " << filter_id << "\n";
 
-    const auto filter_opt = filter_storage_.get_filter(filter_id);
+    const auto filter_opt = filter_storage_->get_filter(filter_id);
 
     if (!filter_opt) {
         reply = make_json_error(request["id"], -32000, "filter not found");
@@ -1634,9 +1578,9 @@ awaitable<void> EthereumRpcApi::handle_eth_uninstall_filter(const nlohmann::json
     auto filter_id = params[0].get<std::string>();
     SILKRPC_DEBUG << "filter_id: " << filter_id << "\n";
 
-    const auto success = filter_storage_.remove_filter(filter_id);
+    const auto success = filter_storage_->remove_filter(filter_id);
 
-    SILKRPC_INFO << "Removing filter " << (success ? "succedeed" : "failed") << ", storage size: " << filter_storage_.size() << "\n";
+    SILKRPC_INFO << "Removing filter " << (success ? "succeeded" : "failed") << ", storage size: " << filter_storage_->size() << "\n";
 
     reply = make_json_content(request["id"], success);
 
@@ -2153,10 +2097,10 @@ awaitable<void> EthereumRpcApi::get_logs(ethdb::TransactionDatabase& tx_database
     }
 
     Logs chunk_logs;
-    Logs filtered_chunck_logs;
+    Logs filtered_chunk_logs;
     Logs filtered_block_logs{};
     chunk_logs.reserve(512);
-    filtered_chunck_logs.reserve(64);
+    filtered_chunk_logs.reserve(64);
     filtered_block_logs.reserve(256);
 
     for (const auto& block_to_match : block_numbers) {
@@ -2175,16 +2119,16 @@ awaitable<void> EthereumRpcApi::get_logs(ethdb::TransactionDatabase& tx_database
                 log.index = log_index++;
             }
             SILKRPC_DEBUG << "chunk_logs.size(): " << chunk_logs.size() << "\n";
-            filtered_chunck_logs.clear();
-            filter_logs(std::move(chunk_logs), addresses, topics, filtered_chunck_logs);
-            SILKRPC_DEBUG << "filtered_chunk_logs.size(): " << filtered_chunck_logs.size() << "\n";
-            if (filtered_chunck_logs.size() > 0) {
+            filtered_chunk_logs.clear();
+            filter_logs(std::move(chunk_logs), addresses, topics, filtered_chunk_logs);
+            SILKRPC_DEBUG << "filtered_chunk_logs.size(): " << filtered_chunk_logs.size() << "\n";
+            if (filtered_chunk_logs.size() > 0) {
                 const auto tx_id = boost::endian::load_big_u32(&k[sizeof(uint64_t)]);
                 SILKRPC_DEBUG << "tx_id: " << tx_id << "\n";
-                for (auto& log : filtered_chunck_logs) {
+                for (auto& log : filtered_chunk_logs) {
                     log.tx_index = tx_id;
                 }
-                filtered_block_logs.insert(filtered_block_logs.end(), filtered_chunck_logs.begin(), filtered_chunck_logs.end());
+                filtered_block_logs.insert(filtered_block_logs.end(), filtered_chunk_logs.begin(), filtered_chunk_logs.end());
             }
             return true;
         });

--- a/silkworm/silkrpc/commands/eth_api.hpp
+++ b/silkworm/silkrpc/commands/eth_api.hpp
@@ -32,17 +32,17 @@
 #include <roaring.hh>
 #pragma GCC diagnostic pop
 
+#include <silkworm/core/types/receipt.hpp>
 #include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/infra/concurrency/shared_service.hpp>
-#include <silkworm/core/types/receipt.hpp>
 #include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/core/filter_storage.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
+#include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
 #include <silkworm/silkrpc/ethdb/transaction.hpp>
 #include <silkworm/silkrpc/ethdb/transaction_database.hpp>
-#include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 #include <silkworm/silkrpc/txpool/miner.hpp>
 #include <silkworm/silkrpc/txpool/transaction_pool.hpp>

--- a/silkworm/silkrpc/commands/net_api.hpp
+++ b/silkworm/silkrpc/commands/net_api.hpp
@@ -22,8 +22,10 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 
+#include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
@@ -40,6 +42,8 @@ using boost::asio::awaitable;
 class NetRpcApi {
   public:
     explicit NetRpcApi(std::unique_ptr<ethbackend::BackEnd>& backend) : backend_(backend) {}
+    explicit NetRpcApi(boost::asio::io_context& io_context)
+        : NetRpcApi(use_private_service<ethbackend::BackEnd>(io_context)) {}
     virtual ~NetRpcApi() = default;
 
     NetRpcApi(const NetRpcApi&) = delete;

--- a/silkworm/silkrpc/commands/net_api_test.cpp
+++ b/silkworm/silkrpc/commands/net_api_test.cpp
@@ -28,12 +28,13 @@ using Catch::Matchers::Message;
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("NetRpcApi::NetRpcApi", "[silkrpc][erigon_api]") {
-    boost::asio::io_context io_context;
-    auto channel{grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials())};
+    boost::asio::io_context ioc;
+    auto grpc_channel{grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials())};
     agrpc::GrpcContext grpc_context;
-    std::unique_ptr<ethbackend::BackEnd> backend{
-        std::make_unique<ethbackend::RemoteBackEnd>(io_context, channel, grpc_context)};
-    CHECK_NOTHROW(NetRpcApi{backend});
+    add_private_service<ethbackend::BackEnd>(
+        ioc,
+        std::make_unique<ethbackend::RemoteBackEnd>(ioc, grpc_channel, grpc_context));
+    CHECK_NOTHROW(NetRpcApi{ioc});
 }
 #endif  // SILKWORM_SANITIZE
 

--- a/silkworm/silkrpc/commands/ots_api.cpp
+++ b/silkworm/silkrpc/commands/ots_api.cpp
@@ -60,7 +60,7 @@ boost::asio::awaitable<void> OtsRpcApi::handle_ots_has_code(const nlohmann::json
     try {
         ethdb::TransactionDatabase tx_database{*tx};
         ethdb::kv::CachedDatabase cached_database{BlockNumberOrHash{block_id}, *tx, *state_cache_};
-        // Check if target block is latest one: use local state cache (if any) for target transaction
+        // Check if target block is the latest one: use local state cache (if any) for target transaction
         const bool is_latest_block = co_await core::is_latest_block_number(BlockNumberOrHash{block_id}, tx_database);
         StateReader state_reader{is_latest_block ? static_cast<core::rawdb::DatabaseReader&>(cached_database) : static_cast<core::rawdb::DatabaseReader&>(tx_database)};
 
@@ -477,7 +477,7 @@ boost::asio::awaitable<void> OtsRpcApi::handle_ots_getContractCreator(const nloh
         ethdb::TransactionDatabase tx_database{*tx};
         auto block_with_hash = co_await core::read_block_by_number(*block_cache_, tx_database, block_found);
 
-        trace::TraceCallExecutor executor{*context_.io_context(), *context_.block_cache(), tx_database, workers_};
+        trace::TraceCallExecutor executor{io_context_, *block_cache_, tx_database, workers_};
         const auto result = co_await executor.trace_deploy_transaction(block_with_hash->block, contract_address);
 
         reply = make_json_content(request["id"], result);

--- a/silkworm/silkrpc/commands/ots_api.hpp
+++ b/silkworm/silkrpc/commands/ots_api.hpp
@@ -25,9 +25,11 @@
 #include <boost/asio/thread_pool.hpp>
 #include <nlohmann/json.hpp>
 
+#include <silkworm/infra/concurrency/private_service.hpp>
+#include <silkworm/infra/concurrency/shared_service.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
 #include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
@@ -42,7 +44,12 @@ namespace silkworm::rpc::commands {
 
 class OtsRpcApi {
   public:
-    explicit OtsRpcApi(Context& context, boost::asio::thread_pool& workers) : context_(context), workers_{workers}, database_(context.database()), state_cache_(context.state_cache()), block_cache_(context.block_cache()) {}
+    OtsRpcApi(boost::asio::io_context& io_context, boost::asio::thread_pool& workers)
+        : io_context_(io_context),
+          workers_{workers},
+          database_(use_private_service<ethdb::Database>(io_context_)),
+          state_cache_(use_shared_service<ethdb::kv::StateCache>(io_context_)),
+          block_cache_(use_shared_service<BlockCache>(io_context_)) {}
     virtual ~OtsRpcApi() = default;
 
     OtsRpcApi(const OtsRpcApi&) = delete;
@@ -57,7 +64,7 @@ class OtsRpcApi {
     boost::asio::awaitable<void> handle_ots_getTransactionBySenderAndNonce(const nlohmann::json& request, nlohmann::json& reply);
     boost::asio::awaitable<void> handle_ots_getContractCreator(const nlohmann::json& request, nlohmann::json& reply);
 
-    Context& context_;
+    boost::asio::io_context& io_context_;
     boost::asio::thread_pool& workers_;
     std::unique_ptr<ethdb::Database>& database_;
     std::shared_ptr<ethdb::kv::StateCache>& state_cache_;
@@ -66,7 +73,8 @@ class OtsRpcApi {
 
   private:
     static IssuanceDetails get_issuance(const ChainConfig& chain_config, const silkworm::BlockWithHash& block);
-    static intx::uint256 get_block_fees(const ChainConfig& chain_config, const silkworm::BlockWithHash& block, std::vector<Receipt>& receipts, silkworm::BlockNum block_number);
+    static intx::uint256 get_block_fees(const ChainConfig& chain_config, const silkworm::BlockWithHash& block,
+                                        std::vector<Receipt>& receipts, silkworm::BlockNum block_number);
 };
 
 }  // namespace silkworm::rpc::commands

--- a/silkworm/silkrpc/commands/ots_api.hpp
+++ b/silkworm/silkrpc/commands/ots_api.hpp
@@ -25,9 +25,9 @@
 #include <boost/asio/thread_pool.hpp>
 #include <nlohmann/json.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/infra/concurrency/shared_service.hpp>
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>

--- a/silkworm/silkrpc/commands/parity_api.cpp
+++ b/silkworm/silkrpc/commands/parity_api.cpp
@@ -22,7 +22,6 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/node/db/tables.hpp>
-#include <silkworm/silkrpc/common/constants.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
@@ -52,7 +51,7 @@ awaitable<void> ParityRpcApi::handle_parity_get_block_receipts(const nlohmann::j
         ethdb::TransactionDatabase tx_database{*tx};
 
         const auto block_number = co_await core::get_block_number(block_id, tx_database);
-        const auto block_with_hash = co_await core::read_block_by_number(*context_.block_cache(), tx_database, block_number);
+        const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, tx_database, block_number);
         auto receipts{co_await core::get_receipts(tx_database, *block_with_hash)};
         SILKRPC_INFO << "#receipts: " << receipts.size() << "\n";
 

--- a/silkworm/silkrpc/commands/parity_api_test.cpp
+++ b/silkworm/silkrpc/commands/parity_api_test.cpp
@@ -25,10 +25,8 @@ using Catch::Matchers::Message;
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("ParityRpcApi::ParityRpcApi", "[silkrpc][erigon_api]") {
-    ContextPool context_pool{1, []() {
-                                 return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
-                             }};
-    CHECK_NOTHROW(ParityRpcApi{context_pool.next_context()});
+    boost::asio::io_context ioc;
+    CHECK_NOTHROW(ParityRpcApi{ioc});
 }
 #endif  // SILKWORM_SANITIZE
 

--- a/silkworm/silkrpc/commands/rpc_api.hpp
+++ b/silkworm/silkrpc/commands/rpc_api.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/thread_pool.hpp>
 
 #include <silkworm/silkrpc/commands/admin_api.hpp>
@@ -40,20 +41,30 @@ namespace silkworm::rpc::commands {
 
 class RpcApiTable;
 
-class RpcApi : protected EthereumRpcApi, NetRpcApi, AdminRpcApi, Web3RpcApi, DebugRpcApi, ParityRpcApi, ErigonRpcApi, TraceRpcApi, EngineRpcApi, TxPoolRpcApi, OtsRpcApi {
+class RpcApi : protected EthereumRpcApi,
+               NetRpcApi,
+               AdminRpcApi,
+               Web3RpcApi,
+               DebugRpcApi,
+               ParityRpcApi,
+               ErigonRpcApi,
+               TraceRpcApi,
+               EngineRpcApi,
+               TxPoolRpcApi,
+               OtsRpcApi {
   public:
-    explicit RpcApi(Context& context, boost::asio::thread_pool& workers)
-        : EthereumRpcApi{context, workers},
-          NetRpcApi{context.backend()},
-          AdminRpcApi{context.backend()},
-          Web3RpcApi{context},
-          DebugRpcApi{context, workers},
-          ParityRpcApi{context},
-          ErigonRpcApi{context},
-          TraceRpcApi{context, workers},
-          EngineRpcApi(context.database(), context.backend()),
-          TxPoolRpcApi(context),
-          OtsRpcApi{context, workers} {}
+    explicit RpcApi(boost::asio::io_context& io_context, boost::asio::thread_pool& workers)
+        : EthereumRpcApi{io_context, workers},
+          NetRpcApi{io_context},
+          AdminRpcApi{io_context},
+          Web3RpcApi{io_context},
+          DebugRpcApi{io_context, workers},
+          ParityRpcApi{io_context},
+          ErigonRpcApi{io_context},
+          TraceRpcApi{io_context, workers},
+          EngineRpcApi(io_context),
+          TxPoolRpcApi(io_context),
+          OtsRpcApi{io_context, workers} {}
 
     ~RpcApi() override = default;
 

--- a/silkworm/silkrpc/commands/trace_api.hpp
+++ b/silkworm/silkrpc/commands/trace_api.hpp
@@ -25,10 +25,13 @@
 #include <boost/asio/thread_pool.hpp>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
+#include <silkworm/infra/concurrency/private_service.hpp>
+#include <silkworm/infra/concurrency/shared_service.hpp>
+#include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
 #include <silkworm/silkrpc/ethdb/transaction_database.hpp>
+#include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
 #include <silkworm/silkrpc/json/stream.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 
@@ -40,8 +43,12 @@ namespace silkworm::rpc::commands {
 
 class TraceRpcApi {
   public:
-    explicit TraceRpcApi(Context& context, boost::asio::thread_pool& workers)
-        : context_(context), database_(context.database()), tx_pool_{context.tx_pool()}, workers_{workers} {}
+    TraceRpcApi(boost::asio::io_context& io_context, boost::asio::thread_pool& workers)
+        : io_context_(io_context),
+          block_cache_{use_shared_service<BlockCache>(io_context_)},
+          state_cache_{use_shared_service<ethdb::kv::StateCache>(io_context_)},
+          database_{use_private_service<ethdb::Database>(io_context_)},
+          workers_{workers} {}
     virtual ~TraceRpcApi() = default;
 
     TraceRpcApi(const TraceRpcApi&) = delete;
@@ -60,9 +67,10 @@ class TraceRpcApi {
     boost::asio::awaitable<void> handle_trace_filter(const nlohmann::json& request, json::Stream& stream);
 
   private:
-    Context& context_;
+    boost::asio::io_context& io_context_;
+    std::shared_ptr<BlockCache>& block_cache_;
+    std::shared_ptr<ethdb::kv::StateCache>& state_cache_;
     std::unique_ptr<ethdb::Database>& database_;
-    std::unique_ptr<txpool::TransactionPool>& tx_pool_;
     boost::asio::thread_pool& workers_;
 
     friend class silkworm::http::RequestHandler;

--- a/silkworm/silkrpc/commands/trace_api.hpp
+++ b/silkworm/silkrpc/commands/trace_api.hpp
@@ -30,8 +30,8 @@
 #include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
-#include <silkworm/silkrpc/ethdb/transaction_database.hpp>
 #include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
+#include <silkworm/silkrpc/ethdb/transaction_database.hpp>
 #include <silkworm/silkrpc/json/stream.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 

--- a/silkworm/silkrpc/commands/trace_api_test.cpp
+++ b/silkworm/silkrpc/commands/trace_api_test.cpp
@@ -28,13 +28,11 @@ using Catch::Matchers::Message;
 TEST_CASE("TraceRpcApi") {
     SILKRPC_LOG_VERBOSITY(LogLevel::None);
 
-    auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
-    FilterStorage filter_storage{0x400};
-    Context context{channel, std::make_shared<BlockCache>(), std::make_shared<ethdb::kv::CoherentStateCache>(), filter_storage};
+    boost::asio::io_context ioc;
     boost::asio::thread_pool workers{1};
 
     SECTION("CTOR") {
-        CHECK_NOTHROW(TraceRpcApi{context, workers});
+        CHECK_NOTHROW(TraceRpcApi{ioc, workers});
     }
 }
 #endif  // SILKWORM_SANITIZE

--- a/silkworm/silkrpc/commands/txpool_api.cpp
+++ b/silkworm/silkrpc/commands/txpool_api.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <utility>
 
+#include <silkworm/silkrpc/json/types.hpp>
+
 namespace silkworm::rpc::commands {
 
 // https://eth.wiki/json-rpc/API#txpool_status

--- a/silkworm/silkrpc/commands/web3_api.hpp
+++ b/silkworm/silkrpc/commands/web3_api.hpp
@@ -21,9 +21,10 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
+#include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/ethbackend/backend.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
@@ -37,8 +38,10 @@ namespace silkworm::rpc::commands {
 
 class Web3RpcApi {
   public:
-    explicit Web3RpcApi(Context& context) : database_(context.database()), backend_(context.backend()) {}
-    virtual ~Web3RpcApi() {}
+    explicit Web3RpcApi(boost::asio::io_context& io_context)
+        : database_{use_private_service<ethdb::Database>(io_context)},
+          backend_{use_private_service<ethbackend::BackEnd>(io_context)} {}
+    virtual ~Web3RpcApi() = default;
 
     Web3RpcApi(const Web3RpcApi&) = delete;
     Web3RpcApi& operator=(const Web3RpcApi&) = delete;

--- a/silkworm/silkrpc/core/cached_chain_test.cpp
+++ b/silkworm/silkrpc/core/cached_chain_test.cpp
@@ -31,7 +31,6 @@
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/node/db/tables.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/test/mock_database_reader.hpp>

--- a/silkworm/silkrpc/core/evm_access_list_tracer.hpp
+++ b/silkworm/silkrpc/core/evm_access_list_tracer.hpp
@@ -24,7 +24,6 @@
 #include <silkworm/core/execution/evm.hpp>
 #pragma GCC diagnostic pop
 #include <silkworm/core/state/intra_block_state.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/types/block.hpp>
 #include <silkworm/silkrpc/types/call.hpp>

--- a/silkworm/silkrpc/core/evm_debug.hpp
+++ b/silkworm/silkrpc/core/evm_debug.hpp
@@ -31,7 +31,6 @@
 #include <silkworm/core/execution/evm.hpp>
 #pragma GCC diagnostic pop
 #include <silkworm/core/state/intra_block_state.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/json/stream.hpp>
 #include <silkworm/silkrpc/types/block.hpp>

--- a/silkworm/silkrpc/core/evm_executor.hpp
+++ b/silkworm/silkrpc/core/evm_executor.hpp
@@ -36,7 +36,6 @@
 #include <silkworm/core/protocol/rule_set.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/transaction.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/core/remote_state.hpp>
 

--- a/silkworm/silkrpc/core/evm_executor_test.cpp
+++ b/silkworm/silkrpc/core/evm_executor_test.cpp
@@ -25,6 +25,8 @@
 #include <catch2/catch.hpp>
 #include <evmc/evmc.hpp>
 
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
+#include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/types/transaction.hpp>
 
@@ -61,8 +63,7 @@ TEST_CASE("EVMExecutor") {
         const uint64_t chain_id = 5;
         const auto chain_config_ptr = lookup_chain_config(chain_id);
 
-        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool my_pool{1, my_channel};
+        ClientContextPool my_pool{1};
         boost::asio::thread_pool workers{1};
         my_pool.start();
 
@@ -88,8 +89,7 @@ TEST_CASE("EVMExecutor") {
         const uint64_t chain_id = 5;
         const auto chain_config_ptr = lookup_chain_config(chain_id);
 
-        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool my_pool{1, my_channel};
+        ClientContextPool my_pool{1};
         boost::asio::thread_pool workers{1};
         my_pool.start();
 
@@ -117,8 +117,7 @@ TEST_CASE("EVMExecutor") {
         const uint64_t chain_id = 5;
         const auto chain_config_ptr = lookup_chain_config(chain_id);
 
-        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool my_pool{1, my_channel};
+        ClientContextPool my_pool{1};
         boost::asio::thread_pool workers{1};
         my_pool.start();
 
@@ -147,8 +146,7 @@ TEST_CASE("EVMExecutor") {
         const uint64_t chain_id = 5;
         const auto chain_config_ptr = lookup_chain_config(chain_id);
 
-        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool my_pool{1, my_channel};
+        ClientContextPool my_pool{1};
         boost::asio::thread_pool workers{1};
         my_pool.start();
 
@@ -177,8 +175,7 @@ TEST_CASE("EVMExecutor") {
         const uint64_t chain_id = 5;
         const auto chain_config_ptr = lookup_chain_config(chain_id);
 
-        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool my_pool{1, my_channel};
+        ClientContextPool my_pool{1};
         boost::asio::thread_pool workers{1};
         my_pool.start();
 
@@ -216,8 +213,7 @@ TEST_CASE("EVMExecutor") {
         const uint64_t chain_id = 5;
         const auto chain_config_ptr = lookup_chain_config(chain_id);
 
-        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool my_pool{1, my_channel};
+        ClientContextPool my_pool{1};
         boost::asio::thread_pool workers{1};
         my_pool.start();
 

--- a/silkworm/silkrpc/core/evm_trace.hpp
+++ b/silkworm/silkrpc/core/evm_trace.hpp
@@ -37,7 +37,6 @@
 #pragma GCC diagnostic pop
 #include <silkworm/core/state/intra_block_state.hpp>
 #include <silkworm/silkrpc/common/block_cache.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/core/evm_executor.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/json/stream.hpp>

--- a/silkworm/silkrpc/core/filter_storage_test.cpp
+++ b/silkworm/silkrpc/core/filter_storage_test.cpp
@@ -28,7 +28,7 @@ namespace silkworm::rpc {
 using Catch::Matchers::Message;
 
 TEST_CASE("FilterStorage base") {
-    FilterStorage filter_storage{3, 1};
+    FilterStorage filter_storage{3, 0.01};
     SECTION("adding 1 entry") {
         StoredFilter filter;
         const auto filter_id = filter_storage.add_filter(filter);
@@ -89,7 +89,7 @@ TEST_CASE("FilterStorage base") {
     SECTION("filter expires") {
         StoredFilter filter;
         const auto filter_id = filter_storage.add_filter(filter);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         const auto filter_opt = filter_storage.get_filter(filter_id.value());
 
         CHECK(filter_opt.has_value() == false);
@@ -100,7 +100,7 @@ TEST_CASE("FilterStorage base") {
         filter_storage.add_filter(filter);
         filter_storage.add_filter(filter);
         filter_storage.add_filter(filter);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         const auto filter_id = filter_storage.add_filter(filter);
 
         CHECK(filter_id.has_value() == true);

--- a/silkworm/silkrpc/ethbackend/remote_backend_test.cpp
+++ b/silkworm/silkrpc/ethbackend/remote_backend_test.cpp
@@ -23,8 +23,8 @@
 #include <catch2/catch.hpp>
 #include <evmc/evmc.hpp>
 #include <gmock/gmock.h>
-#include <grpcpp/grpcpp.h>
 
+#include <silkworm/core/common/util.hpp>
 #include <silkworm/interfaces/remote/ethbackend_mock.grpc.pb.h>
 #include <silkworm/silkrpc/test/api_test_base.hpp>
 #include <silkworm/silkrpc/test/grpc_actions.hpp>
@@ -237,7 +237,7 @@ TEST_CASE_METHOD(EthBackendTest, "BackEnd::engine_get_payload_v1", "[silkrpc][et
         p->set_block_number(0x1);
         p->set_gas_limit(0x1c9c380);
         p->set_timestamp(0x5);
-        const auto tx_bytes{*silkworm::from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
+        const auto tx_bytes{*from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
         p->add_transactions(tx_bytes.data(), tx_bytes.size());
         const auto hi_hi_hi_logsbloom{make_h256(0x1000000000000000, 0x0, 0x0, 0x0)};
         const auto hi_hi_logsbloom{new ::types::H512()};
@@ -263,7 +263,7 @@ TEST_CASE_METHOD(EthBackendTest, "BackEnd::engine_get_payload_v1", "[silkrpc][et
         CHECK(payload.prev_randao == 0x0000000000000000000000000000000000000000000000000000000000000001_bytes32);
         CHECK(payload.base_fee == 0x7);
         CHECK(payload.transactions.size() == 1);
-        CHECK(silkworm::to_hex(payload.transactions[0]) == "f92ebdeab45d368f6354e8c5a8ac586c");
+        CHECK(to_hex(payload.transactions[0]) == "f92ebdeab45d368f6354e8c5a8ac586c");
         silkworm::Bloom expected_bloom{0};
         expected_bloom[0] = 0x10;
         CHECK(payload.logs_bloom == expected_bloom);
@@ -288,7 +288,7 @@ TEST_CASE_METHOD(EthBackendTest, "BackEnd::engine_new_payload_v1", "[silkrpc][et
     silkworm::Bloom bloom;
     bloom.fill(0);
     bloom[0] = 0x12;
-    const auto transaction{*silkworm::from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
+    const auto transaction{*from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
     const ExecutionPayload execution_payload{
         .timestamp = 0x5,
         .gas_limit = 0x1c9c380,

--- a/silkworm/silkrpc/ethdb/kv/state_changes_stream.cpp
+++ b/silkworm/silkrpc/ethdb/kv/state_changes_stream.cpp
@@ -22,6 +22,7 @@
 #include <boost/asio/use_future.hpp>
 #include <boost/system/error_code.hpp>
 
+#include <silkworm/infra/concurrency/shared_service.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/grpc/util.hpp>
 
@@ -36,11 +37,11 @@ void StateChangesStream::set_registration_interval(boost::posix_time::millisecon
     StateChangesStream::registration_interval_ = registration_interval;
 }
 
-StateChangesStream::StateChangesStream(Context& context, remote::KV::StubInterface* stub)
+StateChangesStream::StateChangesStream(ClientContext& context, remote::KV::StubInterface* stub)
     : scheduler_(*context.io_context()),
       grpc_context_(*context.grpc_context()),
       stub_(stub),
-      cache_(context.state_cache().get()),
+      cache_(use_shared_service<ethdb::kv::StateCache>(scheduler_).get()),
       retry_timer_{scheduler_} {}
 
 std::future<void> StateChangesStream::open() {

--- a/silkworm/silkrpc/ethdb/kv/state_changes_stream.hpp
+++ b/silkworm/silkrpc/ethdb/kv/state_changes_stream.hpp
@@ -32,8 +32,8 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_context.hpp>
 
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/ethdb/kv/rpc.hpp>
 #include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
 
@@ -62,7 +62,7 @@ class StateChangesStream {
     //! Set the retry interval between successive registration attempts
     static void set_registration_interval(boost::posix_time::milliseconds registration_interval);
 
-    explicit StateChangesStream(Context& context, remote::KV::StubInterface* stub);
+    explicit StateChangesStream(ClientContext& context, remote::KV::StubInterface* stub);
 
     //! Open up the stream, starting the register-and-receive loop
     std::future<void> open();

--- a/silkworm/silkrpc/http/connection.cpp
+++ b/silkworm/silkrpc/http/connection.cpp
@@ -36,8 +36,13 @@
 
 namespace silkworm::rpc::http {
 
-Connection::Connection(Context& context, boost::asio::thread_pool& workers, commands::RpcApiTable& handler_table, std::optional<std::string> jwt_secret)
-    : socket_{*context.io_context()}, request_handler_{context, workers, socket_, handler_table, std::move(jwt_secret)}, buffer_{} {
+Connection::Connection(boost::asio::io_context& io_context,
+                       boost::asio::thread_pool& workers,
+                       commands::RpcApiTable& handler_table,
+                       std::optional<std::string> jwt_secret)
+    : socket_{io_context},
+      request_handler_{io_context, workers, socket_, handler_table, std::move(jwt_secret)},
+      buffer_{} {
     request_.content.reserve(kRequestContentInitialCapacity);
     request_.headers.reserve(kRequestHeadersInitialCapacity);
     request_.method.reserve(kRequestMethodInitialCapacity);

--- a/silkworm/silkrpc/http/connection.hpp
+++ b/silkworm/silkrpc/http/connection.hpp
@@ -28,12 +28,12 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/thread_pool.hpp>
 
 #include <silkworm/silkrpc/commands/rpc_api_table.hpp>
 #include <silkworm/silkrpc/common/constants.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/http/reply.hpp>
 #include <silkworm/silkrpc/http/request.hpp>
 #include <silkworm/silkrpc/http/request_handler.hpp>
@@ -48,7 +48,10 @@ class Connection {
     Connection& operator=(const Connection&) = delete;
 
     //! Construct a connection running within the given execution context.
-    Connection(Context& context, boost::asio::thread_pool& workers, commands::RpcApiTable& handler_table, std::optional<std::string> jwt_secret);
+    Connection(boost::asio::io_context& io_context,
+               boost::asio::thread_pool& workers,
+               commands::RpcApiTable& handler_table,
+               std::optional<std::string> jwt_secret);
 
     ~Connection();
 

--- a/silkworm/silkrpc/http/connection_test.cpp
+++ b/silkworm/silkrpc/http/connection_test.cpp
@@ -20,6 +20,7 @@
 #include <catch2/catch.hpp>
 #include <grpcpp/grpcpp.h>
 
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/silkrpc/commands/rpc_api_table.hpp>
 
 namespace silkworm::rpc::http {
@@ -35,8 +36,7 @@ TEST_CASE("connection creation", "[silkrpc][http][connection]") {
     SILKRPC_LOG_VERBOSITY(LogLevel::None);
 
     SECTION("field initialization") {
-        ChannelFactory create_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
-        ContextPool context_pool{1, create_channel};
+        ClientContextPool context_pool{1};
         context_pool.start();
         boost::asio::thread_pool workers;
         // Uncommenting the following lines you got stuck into llvm-cov problem:

--- a/silkworm/silkrpc/http/request_handler.cpp
+++ b/silkworm/silkrpc/http/request_handler.cpp
@@ -23,7 +23,6 @@
 #include "request_handler.hpp"
 
 #include <iostream>
-#include <utility>
 #include <vector>
 
 #include <boost/asio/write.hpp>
@@ -71,7 +70,7 @@ boost::asio::awaitable<void> RequestHandler::handle_user_request(const http::Req
             std::string batch_reply_content = "[";
             bool first_element = true;
             for (auto& item : request_json.items()) {
-                const auto item_json = item.value();
+                const auto& item_json = item.value();
                 if (!item_json.contains("id")) {
                     reply.content = "\n";
                     reply.status = http::StatusType::ok;
@@ -111,7 +110,7 @@ boost::asio::awaitable<void> RequestHandler::handle_request_and_create_reply(con
     }
 
     const auto method = request_json["method"].get<std::string>();
-    if (method.size() == 0) {
+    if (method.empty()) {
         reply.content = make_json_error(request_id, -32600, "invalid request").dump();
         reply.status = http::StatusType::bad_request;
         co_return;

--- a/silkworm/silkrpc/http/request_handler.hpp
+++ b/silkworm/silkrpc/http/request_handler.hpp
@@ -24,12 +24,12 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/thread_pool.hpp>
 
 #include <silkworm/silkrpc/commands/rpc_api.hpp>
 #include <silkworm/silkrpc/commands/rpc_api_table.hpp>
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/http/reply.hpp>
 #include <silkworm/silkrpc/http/request.hpp>
 
@@ -37,11 +37,12 @@ namespace silkworm::rpc::http {
 
 class RequestHandler {
   public:
-    RequestHandler(Context& context, boost::asio::thread_pool& workers,
-                   boost::asio::ip::tcp::socket& socket, const commands::RpcApiTable& rpc_api_table,
+    RequestHandler(boost::asio::io_context& io_context,
+                   boost::asio::thread_pool& workers,
+                   boost::asio::ip::tcp::socket& socket,
+                   const commands::RpcApiTable& rpc_api_table,
                    std::optional<std::string> jwt_secret)
-        : rpc_api_{context, workers},
-          io_context_{*context.io_context()},
+        : rpc_api_{io_context, workers},
           socket_{socket},
           rpc_api_table_(rpc_api_table),
           jwt_secret_(std::move(jwt_secret)) {}
@@ -65,7 +66,6 @@ class RequestHandler {
     boost::asio::awaitable<void> write_headers();
 
     commands::RpcApi rpc_api_;
-    boost::asio::io_context& io_context_;
     boost::asio::ip::tcp::socket& socket_;
     const commands::RpcApiTable& rpc_api_table_;
     const std::optional<std::string> jwt_secret_;

--- a/silkworm/silkrpc/http/server.hpp
+++ b/silkworm/silkrpc/http/server.hpp
@@ -29,9 +29,11 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/thread_pool.hpp>
 
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/silkrpc/commands/rpc_api_table.hpp>
 #include <silkworm/silkrpc/concurrency/context_pool.hpp>
 #include <silkworm/silkrpc/http/request_handler.hpp>
@@ -45,7 +47,11 @@ class Server {
     Server& operator=(const Server&) = delete;
 
     // Construct the server to listen on the specified local TCP end-point
-    explicit Server(const std::string& end_point, const std::string& api_spec, Context& context, boost::asio::thread_pool& workers, std::optional<std::string> jwt_secret);
+    explicit Server(const std::string& end_point,
+                    const std::string& api_spec,
+                    boost::asio::io_context& io_context,
+                    boost::asio::thread_pool& workers,
+                    std::optional<std::string> jwt_secret);
 
     void start();
 
@@ -56,16 +62,19 @@ class Server {
 
     boost::asio::awaitable<void> run();
 
-    // The repository of API request handlers
+    //! The repository of API request handlers
     commands::RpcApiTable handler_table_;
 
-    // The context used to perform asynchronous operations
-    Context& context_;
+    //! The context used to perform asynchronous operations
+    boost::asio::io_context& io_context_;
 
-    // The acceptor used to listen for incoming TCP connections
+    //! The acceptor used to listen for incoming TCP connections
     boost::asio::ip::tcp::acceptor acceptor_;
 
+    //! The pool of threads used to execute concurrent calls
     boost::asio::thread_pool& workers_;
+
+    //! The JSON Web Token (JWT) secret for secure channel communication
     std::optional<std::string> jwt_secret_;
 };
 

--- a/silkworm/silkrpc/test/api_test_base.hpp
+++ b/silkworm/silkrpc/test/api_test_base.hpp
@@ -32,7 +32,7 @@ class JsonApiTestBase : public ContextTestBase {
   public:
     template <auto method, typename... Args>
     auto run(Args&&... args) {
-        JsonApi api{context_};
+        JsonApi api{io_context_};
         return spawn_and_wait((api.*method)(std::forward<Args>(args)...));
     }
 };
@@ -44,7 +44,7 @@ class JsonApiWithWorkersTestBase : public ContextTestBase {
 
     template <auto method, typename... Args>
     auto run(Args&&... args) {
-        JsonApi api{context_, workers_};
+        JsonApi api{io_context_, workers_};
         return spawn_and_wait((api.*method)(std::forward<Args>(args)...));
     }
 

--- a/silkworm/silkrpc/test/context_test_base.cpp
+++ b/silkworm/silkrpc/test/context_test_base.cpp
@@ -22,8 +22,8 @@
 #include <silkworm/silkrpc/common/log.hpp>
 #include <silkworm/silkrpc/core/filter_storage.hpp>
 #include <silkworm/silkrpc/ethbackend/remote_backend.hpp>
-#include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
 #include <silkworm/silkrpc/ethdb/kv/remote_database.hpp>
+#include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
 
 namespace silkworm::rpc::test {
 

--- a/silkworm/silkrpc/test/context_test_base.cpp
+++ b/silkworm/silkrpc/test/context_test_base.cpp
@@ -16,25 +16,29 @@
 
 #include "context_test_base.hpp"
 
+#include <silkworm/infra/concurrency/private_service.hpp>
+#include <silkworm/infra/concurrency/shared_service.hpp>
 #include <silkworm/silkrpc/common/block_cache.hpp>
 #include <silkworm/silkrpc/common/log.hpp>
+#include <silkworm/silkrpc/core/filter_storage.hpp>
+#include <silkworm/silkrpc/ethbackend/remote_backend.hpp>
 #include <silkworm/silkrpc/ethdb/kv/state_cache.hpp>
+#include <silkworm/silkrpc/ethdb/kv/remote_database.hpp>
 
 namespace silkworm::rpc::test {
 
-FilterStorage filter_storage{0x400};
-
 ContextTestBase::ContextTestBase()
     : log_guard_{LogLevel::None},
-      context_{
-          grpc::CreateChannel("localhost:12345", grpc::InsecureChannelCredentials()),
-          std::make_shared<BlockCache>(),
-          std::make_shared<ethdb::kv::CoherentStateCache>(),
-          filter_storage,
-      },
+      context_{0},
       io_context_{*context_.io_context()},
       grpc_context_{*context_.grpc_context()},
       context_thread_{[&]() { context_.execute_loop(); }} {
+    add_shared_service(io_context_, std::make_shared<BlockCache>());
+    add_shared_service(io_context_, std::make_shared<FilterStorage>(1024));
+    add_shared_service<ethdb::kv::StateCache>(io_context_, std::make_shared<ethdb::kv::CoherentStateCache>());
+    auto grpc_channel{::grpc::CreateChannel("localhost:12345", ::grpc::InsecureChannelCredentials())};
+    add_private_service<ethdb::Database>(io_context_, std::make_unique<ethdb::kv::RemoteDatabase>(grpc_context_, grpc_channel));
+    add_private_service<ethbackend::BackEnd>(io_context_, std::make_unique<ethbackend::RemoteBackEnd>(io_context_, grpc_channel, grpc_context_));
 }
 
 ContextTestBase::~ContextTestBase() {

--- a/silkworm/silkrpc/test/context_test_base.hpp
+++ b/silkworm/silkrpc/test/context_test_base.hpp
@@ -26,7 +26,8 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_future.hpp>
 
-#include <silkworm/silkrpc/concurrency/context_pool.hpp>
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
+#include <silkworm/silkrpc/common/log.hpp>
 
 namespace silkworm::rpc::test {
 
@@ -63,7 +64,7 @@ class ContextTestBase {
     ~ContextTestBase();
 
     SetLogVerbosityGuard log_guard_;
-    Context context_;
+    ClientContext context_;
     boost::asio::io_context& io_context_;
     agrpc::GrpcContext& grpc_context_;
     std::thread context_thread_;

--- a/silkworm/silkrpc/test/mock_database.hpp
+++ b/silkworm/silkrpc/test/mock_database.hpp
@@ -14,20 +14,20 @@
    limitations under the License.
 */
 
-#include "web3_api.hpp"
+#pragma once
 
-#include <catch2/catch.hpp>
-#include <grpcpp/grpcpp.h>
+#include <memory>
 
-namespace silkworm::rpc::commands {
+#include <boost/asio/awaitable.hpp>
+#include <gmock/gmock.h>
 
-using Catch::Matchers::Message;
+#include <silkworm/silkrpc/ethdb/database.hpp>
 
-#ifndef SILKWORM_SANITIZE
-TEST_CASE("Web3RpcApi::Web3RpcApi", "[silkrpc][erigon_api]") {
-    boost::asio::io_context ioc;
-    CHECK_NOTHROW(Web3RpcApi{ioc});
-}
-#endif  // SILKWORM_SANITIZE
+namespace silkworm::rpc::test {
 
-}  // namespace silkworm::rpc::commands
+class MockDatabase : public ethdb::Database {
+  public:
+    MOCK_METHOD((boost::asio::awaitable<std::unique_ptr<ethdb::Transaction>>), begin, ());
+};
+
+}  // namespace silkworm::rpc::test


### PR DESCRIPTION
This PR continues the work to migrate `rpcdaemon` (i.e. `silkrpc`) from `silkworm::rpc::ContextPool` (still there but to be removed soon) to `silkworm::rpc::ClientContextPool`. Namely:

- rpcdaemon: use ClientContextPool instead of old context pool
- rpcdaemon: add state services
- infra: refactoring
- cmd: refactoring

Please note that some unit tests are still using `silkworm::rpc::ContextPool`.