### PR TITLE
fix: avoid startup crash in backend_kv_server

### DIFF
--- a/cmd/backend_kv_server.cpp
+++ b/cmd/backend_kv_server.cpp
@@ -32,8 +32,8 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
-#include <silkworm/infra/grpc/common/util.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
+#include <silkworm/infra/grpc/common/util.hpp>
 #include <silkworm/node/backend/ethereum_backend.hpp>
 #include <silkworm/node/backend/remote/backend_kv_server.hpp>
 #include <silkworm/node/db/access_layer.hpp>


### PR DESCRIPTION
Bug fixes:
- avoid multiple calls to `rpc::BackEndKvServer::build_and_start`
- refactor state changes simulator as async task

Bonus:
- use RAII for cleanup
- replace `rpc::ServerContextPool` w/ `rpc::ClientContextPool` (no more dummy `::grpc::ServerCompletionQueue`)

Fixes #1054