### PR TITLE
sentry: fix PeerInfo node ID compatilibity

### DIFF
--- a/silkworm/node/backend/remote/backend_kv_server_test.cpp
+++ b/silkworm/node/backend/remote/backend_kv_server_test.cpp
@@ -230,7 +230,6 @@ class MockSentryClient
 
         silkworm::sentry::api::api_common::NodeInfo info = {
             silkworm::sentry::common::EnodeUrl{node_url_str},
-            silkworm::sentry::common::EccPublicKey::deserialize_hex(kTestSentryNodeId),
             kTestSentryNodeClientId,
             boost::asio::ip::tcp::endpoint{boost::asio::ip::make_address(ip_str), port},
             port,

--- a/silkworm/sentry/api/api_common/node_info.hpp
+++ b/silkworm/sentry/api/api_common/node_info.hpp
@@ -20,14 +20,12 @@
 
 #include <boost/asio/ip/tcp.hpp>
 
-#include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/enode_url.hpp>
 
 namespace silkworm::sentry::api::api_common {
 
 struct NodeInfo {
     sentry::common::EnodeUrl node_url;
-    sentry::common::EccPublicKey node_public_key;
     std::string client_id;
     boost::asio::ip::tcp::endpoint rlpx_server_listen_endpoint;
     uint16_t rlpx_server_port;

--- a/silkworm/sentry/api/api_common/peer_info.hpp
+++ b/silkworm/sentry/api/api_common/peer_info.hpp
@@ -21,14 +21,12 @@
 
 #include <boost/asio/ip/tcp.hpp>
 
-#include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/enode_url.hpp>
 
 namespace silkworm::sentry::api::api_common {
 
 struct PeerInfo {
     sentry::common::EnodeUrl url;
-    sentry::common::EccPublicKey peer_public_key;
     boost::asio::ip::tcp::endpoint local_endpoint;
     boost::asio::ip::tcp::endpoint remote_endpoint;
     bool is_inbound;

--- a/silkworm/sentry/grpc/interfaces/node_info.cpp
+++ b/silkworm/sentry/grpc/interfaces/node_info.cpp
@@ -46,7 +46,6 @@ boost::asio::ip::tcp::endpoint parse_endpoint(const std::string& address) {
 api::api_common::NodeInfo node_info_from_proto_node_info(const types::NodeInfoReply& info) {
     return api::api_common::NodeInfo{
         sentry::common::EnodeUrl{info.enode()},
-        peer_public_key_from_id_string(info.id()),
         info.name(),
         parse_endpoint(info.listener_addr()),
         static_cast<uint16_t>(info.ports().listener()),
@@ -55,7 +54,7 @@ api::api_common::NodeInfo node_info_from_proto_node_info(const types::NodeInfoRe
 
 types::NodeInfoReply proto_node_info_from_node_info(const api::api_common::NodeInfo& info) {
     types::NodeInfoReply reply;
-    reply.set_id(peer_id_string_from_public_key(info.node_public_key));
+    reply.set_id(peer_id_string_from_public_key(info.node_url.public_key()));
     reply.set_name(info.client_id);
     reply.set_enode(info.node_url.to_string());
 

--- a/silkworm/sentry/grpc/interfaces/peer_id.cpp
+++ b/silkworm/sentry/grpc/interfaces/peer_id.cpp
@@ -30,10 +30,6 @@ proto_types::H512 peer_id_from_public_key(const sentry::common::EccPublicKey& ke
     return *H512_from_bytes(key.serialized());
 }
 
-sentry::common::EccPublicKey peer_public_key_from_id_string(const std::string& peer_id_str) {
-    return sentry::common::EccPublicKey::deserialize_hex(peer_id_str);
-}
-
 std::string peer_id_string_from_public_key(const sentry::common::EccPublicKey& key) {
     return key.hex();
 }

--- a/silkworm/sentry/grpc/interfaces/peer_id.hpp
+++ b/silkworm/sentry/grpc/interfaces/peer_id.hpp
@@ -26,7 +26,6 @@ namespace silkworm::sentry::grpc::interfaces {
 sentry::common::EccPublicKey peer_public_key_from_id(const ::types::H512& peer_id);
 ::types::H512 peer_id_from_public_key(const sentry::common::EccPublicKey& key);
 
-sentry::common::EccPublicKey peer_public_key_from_id_string(const std::string& peer_id_str);
 std::string peer_id_string_from_public_key(const sentry::common::EccPublicKey& key);
 
 }  // namespace silkworm::sentry::grpc::interfaces

--- a/silkworm/sentry/grpc/interfaces/peer_info.cpp
+++ b/silkworm/sentry/grpc/interfaces/peer_info.cpp
@@ -39,7 +39,6 @@ api::api_common::PeerInfo peer_info_from_proto_peer_info(const types::PeerInfo& 
 
     return api::api_common::PeerInfo{
         sentry::common::EnodeUrl{info.enode()},
-        peer_public_key_from_id_string(info.id()),
         parse_endpoint(info.conn_local_addr()),
         parse_endpoint(info.conn_remote_addr()),
         info.conn_is_inbound(),
@@ -51,7 +50,7 @@ api::api_common::PeerInfo peer_info_from_proto_peer_info(const types::PeerInfo& 
 
 types::PeerInfo proto_peer_info_from_peer_info(const api::api_common::PeerInfo& peer) {
     types::PeerInfo info;
-    info.set_id(peer_id_string_from_public_key(peer.peer_public_key));
+    info.set_id(peer_id_string_from_public_key(peer.url.public_key()));
     info.set_name(peer.client_id);
     info.set_enode(peer.url.to_string());
 

--- a/silkworm/sentry/peer_manager_api.cpp
+++ b/silkworm/sentry/peer_manager_api.cpp
@@ -76,7 +76,6 @@ static std::optional<api::api_common::PeerInfo> make_peer_info(rlpx::Peer& peer)
 
     return api::api_common::PeerInfo{
         url_opt.value(),
-        peer_public_key_opt.value(),
         peer.local_endpoint(),
         peer.remote_endpoint(),
         peer.is_inbound(),

--- a/silkworm/sentry/sentry.cpp
+++ b/silkworm/sentry/sentry.cpp
@@ -245,7 +245,6 @@ common::EnodeUrl SentryImpl::make_node_url() const {
 api::api_common::NodeInfo SentryImpl::make_node_info() const {
     return {
         make_node_url(),
-        node_key_.value().public_key(),
         client_id(),
         rlpx_server_.listen_endpoint(),
         settings_.port,


### PR DESCRIPTION
Problem:
PeerInfo/NodeInfo that erigon sentry returns contains a `string id` field
that is a hex representation of a 32 byte Keccak256Hash of a real H512 64 byte peer ID.
When silkworm sentry client tries to decode it as a peer ID, it fails.

Solution:
Do not use this GRPC value on the client.

Note: if needed, it can be obtained on the client side from the `url` field by using:

    string id = to_hex(keccak256(peer_info.url.public_key().serialized()));

but hopefully we shouldn't use for anything as it just gets confusing for no reason.

Note 2: in the past erigon and sentry.proto was using H256 hash for the peer_id-s too, but it was converted to full H512. But PeerInfo.id/NodeInfo.id was not converted for some reason. Omission?
