### PR TITLE
infra: add awaitable task definition

### DIFF
--- a/silkworm/infra/concurrency/task.hpp
+++ b/silkworm/infra/concurrency/task.hpp
@@ -1,0 +1,31 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/infra/concurrency/coroutine.hpp>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+/// Use just \silkworm as namespace here to make these definitions available everywhere
+/// So that we can write Task<void> foo(); instead of concurrency::Task<void> foo();
+namespace silkworm {
+
+template <typename T>
+using Task = boost::asio::awaitable<T>;
+
+}  // namespace silkworm


### PR DESCRIPTION
This PR is intentionally tiny: it just introduces an asynchronous task type definition named `silkworm::Task`, usable in place of `boost::asio::awaitable`, which currently is used pretty everywhere.

Benefits:
- improve code readability and terseness (short-term)
- put in one place some required header inclusions
- open up the possibility for our own coroutine `awaitable` implementation (long-term, not sure about this: I still hope the C++ standard will fill this hole)

I would like to receive feedback about this (e.g. naming and location) before applying the changes to the code: it will be a huge PR, that I will probably do on Sunday 😃 