### PR TITLE
build: link `mimalloc` as shared library

### DIFF
--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -14,13 +14,15 @@
    limitations under the License.
 ]]
 
-if(MSVC)
-  add_link_options(/STACK:${SILKWORM_STACK_SIZE})
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  add_link_options(-Wl,-stack_size -Wl,${SILKWORM_STACK_SIZE})
-else()
-  add_link_options(-Wl,-z,stack-size=${SILKWORM_STACK_SIZE})
-endif()
+macro(increase_stack_size target)
+  if(MSVC)
+    target_link_options(${target} PRIVATE /STACK:${SILKWORM_STACK_SIZE})
+  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_options(${target} PRIVATE -Wl,-stack_size -Wl,${SILKWORM_STACK_SIZE})
+  else()
+    target_link_options(${target} PRIVATE -Wl,-z,stack-size=${SILKWORM_STACK_SIZE})
+  endif()
+endmacro()
 
 # Tests
 add_subdirectory(test)
@@ -61,6 +63,7 @@ if(NOT SILKWORM_CORE_ONLY)
 
   add_executable(silkworm "${SILKWORM_CMD_SRC}")
   target_link_libraries(silkworm PRIVATE silkworm_node silkworm_sync cmd_common $<$<BOOL:${MSVC}>:Kernel32.lib>)
+  increase_stack_size(silkworm)
 
   add_executable(check_changes check_changes.cpp)
   target_link_libraries(check_changes PRIVATE silkworm_node CLI11::CLI11 absl::time)
@@ -91,9 +94,11 @@ if(NOT SILKWORM_CORE_ONLY)
 
   add_executable(snapshots snapshots.cpp)
   target_link_libraries(snapshots PRIVATE silkworm_node cmd_common torrent-rasterbar)
+  increase_stack_size(snapshots)
 
   add_executable(sentry sentry.cpp common/sentry_options.cpp common/sentry_options.hpp)
   target_link_libraries(sentry PRIVATE silkworm_sentry cmd_common)
+  increase_stack_size(sentry)
 
   # cmake-format: off
   set(BACKEND_KV_SERVER_SRC

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -14,15 +14,13 @@
    limitations under the License.
 ]]
 
-macro(increase_stack_size target)
-  if(MSVC)
-    target_link_options(${target} PRIVATE /STACK:${SILKWORM_STACK_SIZE})
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(${target} PRIVATE -Wl,-stack_size -Wl,${SILKWORM_STACK_SIZE})
-  else()
-    target_link_options(${target} PRIVATE -Wl,-z,stack-size=${SILKWORM_STACK_SIZE})
-  endif()
-endmacro()
+if(MSVC)
+  add_link_options(/STACK:${SILKWORM_STACK_SIZE})
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  add_link_options(-Wl,-stack_size -Wl,${SILKWORM_STACK_SIZE})
+else()
+  add_link_options(-Wl,-z,stack-size=${SILKWORM_STACK_SIZE})
+endif()
 
 # Tests
 add_subdirectory(test)
@@ -63,7 +61,6 @@ if(NOT SILKWORM_CORE_ONLY)
 
   add_executable(silkworm "${SILKWORM_CMD_SRC}")
   target_link_libraries(silkworm PRIVATE silkworm_node silkworm_sync cmd_common $<$<BOOL:${MSVC}>:Kernel32.lib>)
-  increase_stack_size(silkworm)
 
   add_executable(check_changes check_changes.cpp)
   target_link_libraries(check_changes PRIVATE silkworm_node CLI11::CLI11 absl::time)
@@ -94,11 +91,9 @@ if(NOT SILKWORM_CORE_ONLY)
 
   add_executable(snapshots snapshots.cpp)
   target_link_libraries(snapshots PRIVATE silkworm_node cmd_common torrent-rasterbar)
-  increase_stack_size(snapshots)
 
   add_executable(sentry sentry.cpp common/sentry_options.cpp common/sentry_options.hpp)
   target_link_libraries(sentry PRIVATE silkworm_sentry cmd_common)
-  increase_stack_size(sentry)
 
   # cmake-format: off
   set(BACKEND_KV_SERVER_SRC

--- a/cmd/rpcdaemon/CMakeLists.txt
+++ b/cmd/rpcdaemon/CMakeLists.txt
@@ -19,21 +19,6 @@ find_package(CLI11 REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(Protobuf REQUIRED)
 
-if(SILKWORM_USE_MIMALLOC)
-  if(CONAN_PACKAGE_MANAGER)
-    find_package(mimalloc REQUIRED)
-  else()
-    set(MI_BUILD_SHARED ON)
-    set(MI_BUILD_STATIC OFF)
-    set(MI_BUILD_OBJECT OFF)
-    set(MI_BUILD_TESTS OFF)
-    add_subdirectory(
-      "${SILKWORM_MAIN_DIR}/third_party/mimalloc" "${CMAKE_BINARY_DIR}/third_party/mimalloc" EXCLUDE_FROM_ALL
-    )
-    target_compile_options(mimalloc PRIVATE -Wno-error)
-  endif()
-endif()
-
 if(MSVC)
   add_compile_options(/bigobj)
 endif()
@@ -63,10 +48,12 @@ set(SILKRPC_DAEMON_LIBRARIES
 )
 # cmake-format: on
 if(SILKWORM_USE_MIMALLOC)
+  if(CONAN_PACKAGE_MANAGER)
+    find_package(mimalloc REQUIRED)
+  endif()
   list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc)
 endif()
 
 add_executable(silkrpcdaemon silkrpc_daemon.cpp)
 target_include_directories(silkrpcdaemon PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(silkrpcdaemon PRIVATE ${SILKRPC_DAEMON_LIBRARIES})
-increase_stack_size(silkrpcdaemon)

--- a/cmd/rpcdaemon/CMakeLists.txt
+++ b/cmd/rpcdaemon/CMakeLists.txt
@@ -23,14 +23,14 @@ if(SILKWORM_USE_MIMALLOC)
   if(CONAN_PACKAGE_MANAGER)
     find_package(mimalloc REQUIRED)
   else()
-    set(MI_BUILD_SHARED OFF)
-    set(MI_BUILD_STATIC ON)
+    set(MI_BUILD_SHARED ON)
+    set(MI_BUILD_STATIC OFF)
     set(MI_BUILD_OBJECT OFF)
     set(MI_BUILD_TESTS OFF)
     add_subdirectory(
       "${SILKWORM_MAIN_DIR}/third_party/mimalloc" "${CMAKE_BINARY_DIR}/third_party/mimalloc" EXCLUDE_FROM_ALL
     )
-    target_compile_options(mimalloc-static PRIVATE -Wno-error)
+    target_compile_options(mimalloc PRIVATE -Wno-error)
   endif()
 endif()
 
@@ -63,9 +63,10 @@ set(SILKRPC_DAEMON_LIBRARIES
 )
 # cmake-format: on
 if(SILKWORM_USE_MIMALLOC)
-  list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc-static)
+  list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc)
 endif()
 
 add_executable(silkrpcdaemon silkrpc_daemon.cpp)
 target_include_directories(silkrpcdaemon PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(silkrpcdaemon PRIVATE ${SILKRPC_DAEMON_LIBRARIES})
+increase_stack_size(silkrpcdaemon)

--- a/cmd/rpcdaemon/CMakeLists.txt
+++ b/cmd/rpcdaemon/CMakeLists.txt
@@ -54,7 +54,11 @@ set(SILKRPC_DAEMON_LIBRARIES
 )
 # cmake-format: on
 if(SILKWORM_USE_MIMALLOC)
-  list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc)
+  if(CONAN_PACKAGE_MANAGER)
+    list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc::mimalloc)
+  else()
+    list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc)
+  endif()
 endif()
 
 add_executable(silkrpcdaemon silkrpc_daemon.cpp)

--- a/cmd/rpcdaemon/CMakeLists.txt
+++ b/cmd/rpcdaemon/CMakeLists.txt
@@ -19,6 +19,12 @@ find_package(CLI11 REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(Protobuf REQUIRED)
 
+if(SILKWORM_USE_MIMALLOC)
+  if(CONAN_PACKAGE_MANAGER)
+    find_package(mimalloc REQUIRED)
+  endif()
+endif()
+
 if(MSVC)
   add_compile_options(/bigobj)
 endif()
@@ -48,9 +54,6 @@ set(SILKRPC_DAEMON_LIBRARIES
 )
 # cmake-format: on
 if(SILKWORM_USE_MIMALLOC)
-  if(CONAN_PACKAGE_MANAGER)
-    find_package(mimalloc REQUIRED)
-  endif()
   list(APPEND SILKRPC_DAEMON_LIBRARIES mimalloc)
 endif()
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -182,7 +182,19 @@ if(NOT SILKWORM_CORE_ONLY)
     option(ROARING_LINK_STATIC "Link executables (tests, benchmarks) statically" ON)
   endif()
   add_subdirectory(CRoaring EXCLUDE_FROM_ALL)
-  
+
+  # mimalloc
+  if(SILKWORM_USE_MIMALLOC)
+    if(NOT CONAN_PACKAGE_MANAGER)
+      set(MI_BUILD_SHARED ON)
+      set(MI_BUILD_STATIC OFF)
+      set(MI_BUILD_OBJECT OFF)
+      set(MI_BUILD_TESTS OFF)
+      add_subdirectory(mimalloc EXCLUDE_FROM_ALL)
+      target_compile_options(mimalloc PRIVATE -Wno-error)
+    endif()
+  endif()
+
   # MDBX
   set(MDBX_ENABLE_TESTS OFF)
   add_subdirectory(libmdbx)


### PR DESCRIPTION
The change is required to fix an issue with `mimalloc` static library on Apple Silicon that causes `silkrpcdaemon` to crash with code `EXC_BAD_ACCESS` in blocking gRPC calls during interface protocol negotiations when gRPC server is down.

Apparently, switching back to shared library fixes the issue.