### PR TITLE
rpcdaemon, sync: Engine API versioning

### DIFF
--- a/silkworm/silkrpc/commands/engine_api.cpp
+++ b/silkworm/silkrpc/commands/engine_api.cpp
@@ -70,7 +70,7 @@ awaitable<void> EngineRpcApi::handle_engine_get_payload_v1(const nlohmann::json&
     try {
 #endif
         const auto payload_id = params[0].get<std::string>();
-        auto payload = co_await backend_->engine_get_payload_v1(std::stoul(payload_id, 0, 16));
+        const auto payload = co_await backend_->engine_get_payload(std::stoul(payload_id, 0, 16));
         reply = make_json_content(request["id"], payload);
 #ifndef BUILD_COVERAGE
     } catch (const boost::system::system_error& se) {
@@ -103,8 +103,8 @@ awaitable<void> EngineRpcApi::handle_engine_new_payload_v1(const nlohmann::json&
 #ifndef BUILD_COVERAGE
     try {
 #endif
-        const auto payload = params[0].get<ExecutionPayloadV1>();
-        auto new_payload = co_await backend_->engine_new_payload_v1(payload);
+        const auto payload = params[0].get<ExecutionPayload>();
+        auto new_payload = co_await backend_->engine_new_payload(payload);
         reply = make_json_content(request["id"], new_payload);
 #ifndef BUILD_COVERAGE
     } catch (const boost::system::system_error& se) {
@@ -135,7 +135,7 @@ awaitable<void> EngineRpcApi::handle_engine_forkchoice_updated_v1(const nlohmann
 #ifndef BUILD_COVERAGE
     try {
 #endif
-        const auto forkchoice_state = params[0].get<ForkChoiceStateV1>();
+        const auto forkchoice_state = params[0].get<ForkChoiceState>();
 
         if (forkchoice_state.safe_block_hash == kZeroHash) {
             const auto error_msg = "safe block hash is empty";
@@ -152,17 +152,17 @@ awaitable<void> EngineRpcApi::handle_engine_forkchoice_updated_v1(const nlohmann
         }
 
         if (params.size() == 2 && !params[1].is_null()) {
-            const auto payload_attributes = params[1].get<PayloadAttributesV1>();
-            const ForkChoiceUpdatedRequestV1 forkchoice_update_request{
+            const auto payload_attributes = params[1].get<PayloadAttributes>();
+            const ForkChoiceUpdatedRequest forkchoice_update_request{
                 .fork_choice_state = forkchoice_state,
                 .payload_attributes = std::make_optional(payload_attributes)};
-            const auto fork_updated = co_await backend_->engine_forkchoice_updated_v1(forkchoice_update_request);
+            const auto fork_updated = co_await backend_->engine_forkchoice_updated(forkchoice_update_request);
             reply = make_json_content(request["id"], fork_updated);
         } else {
-            const ForkChoiceUpdatedRequestV1 forkchoice_update_request{
+            const ForkChoiceUpdatedRequest forkchoice_update_request{
                 .fork_choice_state = forkchoice_state,
                 .payload_attributes = std::nullopt};
-            const auto fork_updated = co_await backend_->engine_forkchoice_updated_v1(forkchoice_update_request);
+            const auto fork_updated = co_await backend_->engine_forkchoice_updated(forkchoice_update_request);
             reply = make_json_content(request["id"], fork_updated);
         }
 #ifndef BUILD_COVERAGE
@@ -190,7 +190,7 @@ awaitable<void> EngineRpcApi::handle_engine_exchange_transition_configuration_v1
         reply = make_json_error(request.at("id"), kInvalidParams, error_msg);
         co_return;
     }
-    const auto cl_configuration = params[0].get<TransitionConfigurationV1>();
+    const auto cl_configuration = params[0].get<TransitionConfiguration>();
     auto tx = co_await database_->begin();
 
 #ifndef BUILD_COVERAGE
@@ -219,7 +219,7 @@ awaitable<void> EngineRpcApi::handle_engine_exchange_transition_configuration_v1
             co_return;
         }
         // We MUST respond with configurable setting values set according to EIP-3675 [Specification 1.]
-        const TransitionConfigurationV1 transition_configuration{
+        const TransitionConfiguration transition_configuration{
             .terminal_total_difficulty = config.terminal_total_difficulty.value(),
             .terminal_block_hash = kZeroHash,  // terminal_block_hash removed from chain_config, return zero
             .terminal_block_number = 0         // terminal_block_number removed from chain_config, return zero

--- a/silkworm/silkrpc/commands/engine_api_test.cpp
+++ b/silkworm/silkrpc/commands/engine_api_test.cpp
@@ -47,9 +47,9 @@ class BackEndMock : public ethbackend::BackEnd {  // NOLINT
     MOCK_METHOD((awaitable<uint64_t>), net_version, ());
     MOCK_METHOD((awaitable<std::string>), client_version, ());
     MOCK_METHOD((awaitable<uint64_t>), net_peer_count, ());
-    MOCK_METHOD((awaitable<ExecutionPayloadV1>), engine_get_payload_v1, (uint64_t));
-    MOCK_METHOD((awaitable<PayloadStatusV1>), engine_new_payload_v1, (const ExecutionPayloadV1&));
-    MOCK_METHOD((awaitable<ForkChoiceUpdatedReplyV1>), engine_forkchoice_updated_v1, (const ForkChoiceUpdatedRequestV1&));
+    MOCK_METHOD((awaitable<ExecutionPayload>), engine_get_payload, (uint64_t));
+    MOCK_METHOD((awaitable<PayloadStatus>), engine_new_payload, (const ExecutionPayload&));
+    MOCK_METHOD((awaitable<ForkChoiceUpdatedReply>), engine_forkchoice_updated, (const ForkChoiceUpdatedRequest&));
     MOCK_METHOD((awaitable<NodeInfos>), engine_node_info, ());
     MOCK_METHOD((awaitable<PeerInfos>), peers, ());
 };
@@ -215,8 +215,8 @@ TEST_CASE("handle_engine_get_payload_v1 succeeds if request is expected payload"
     silkworm::test::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     auto* backend = new BackEndMock;
-    EXPECT_CALL(*backend, engine_get_payload_v1(1)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ExecutionPayloadV1> {
-        co_return ExecutionPayloadV1{1};
+    EXPECT_CALL(*backend, engine_get_payload(1)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ExecutionPayload> {
+        co_return ExecutionPayload{.number = 1};
     }));
 
     std::unique_ptr<ethbackend::BackEnd> backend_ptr(backend);
@@ -315,8 +315,8 @@ TEST_CASE("handle_engine_new_payload_v1 succeeds if request is expected payload 
     silkworm::test::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     auto* backend = new BackEndMock;
-    EXPECT_CALL(*backend, engine_new_payload_v1(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<PayloadStatusV1> {
-        co_return PayloadStatusV1{
+    EXPECT_CALL(*backend, engine_new_payload(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<PayloadStatus> {
+        co_return PayloadStatus{
             .status = "INVALID",
             .latest_valid_hash = 0x0000000000000000000000000000000000000000000000000000000000000040_bytes32,
             .validation_error = "some error"};
@@ -422,9 +422,9 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 succeeds only with forkchoiceStat
     silkworm::test::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     auto* backend = new BackEndMock;
-    EXPECT_CALL(*backend, engine_forkchoice_updated_v1(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ForkChoiceUpdatedReplyV1> {
-        co_return ForkChoiceUpdatedReplyV1{
-            .payload_status = PayloadStatusV1{
+    EXPECT_CALL(*backend, engine_forkchoice_updated(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ForkChoiceUpdatedReply> {
+        co_return ForkChoiceUpdatedReply{
+            .payload_status = PayloadStatus{
                 .status = "INVALID",
                 .latest_valid_hash = 0x0000000000000000000000000000000000000000000000000000000000000040_bytes32,
                 .validation_error = "some error"},
@@ -435,7 +435,7 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 succeeds only with forkchoiceStat
     nlohmann::json request = R"({
         "jsonrpc":"2.0",
         "id":1,
-        "method":"engine_forkchoiceUpdatedv1",
+        "method":"engine_forkchoiceUpdatedV1",
         "params":[
             {
                 "headBlockHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
@@ -480,9 +480,9 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 succeeds with both params", "[sil
     silkworm::test::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     auto* backend = new BackEndMock;
-    EXPECT_CALL(*backend, engine_forkchoice_updated_v1(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ForkChoiceUpdatedReplyV1> {
-        co_return ForkChoiceUpdatedReplyV1{
-            .payload_status = PayloadStatusV1{
+    EXPECT_CALL(*backend, engine_forkchoice_updated(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ForkChoiceUpdatedReply> {
+        co_return ForkChoiceUpdatedReply{
+            .payload_status = PayloadStatus{
                 .status = "INVALID",
                 .latest_valid_hash = 0x0000000000000000000000000000000000000000000000000000000000000040_bytes32,
                 .validation_error = "some error"},
@@ -493,7 +493,7 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 succeeds with both params", "[sil
     nlohmann::json request = R"({
         "jsonrpc":"2.0",
         "id":1,
-        "method":"engine_forkchoiceUpdatedv1",
+        "method":"engine_forkchoiceUpdatedV1",
         "params":[
             {
                 "headBlockHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
@@ -543,9 +543,9 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 succeeds with both params and sec
     silkworm::test::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     auto* backend = new BackEndMock;
-    EXPECT_CALL(*backend, engine_forkchoice_updated_v1(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ForkChoiceUpdatedReplyV1> {
-        co_return ForkChoiceUpdatedReplyV1{
-            .payload_status = PayloadStatusV1{
+    EXPECT_CALL(*backend, engine_forkchoice_updated(testing::_)).WillOnce(InvokeWithoutArgs([]() -> awaitable<ForkChoiceUpdatedReply> {
+        co_return ForkChoiceUpdatedReply{
+            .payload_status = PayloadStatus{
                 .status = "INVALID",
                 .latest_valid_hash = 0x0000000000000000000000000000000000000000000000000000000000000040_bytes32,
                 .validation_error = "some error"},
@@ -556,7 +556,7 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 succeeds with both params and sec
     nlohmann::json request = R"({
         "jsonrpc":"2.0",
         "id":1,
-        "method":"engine_forkchoiceUpdatedv1",
+        "method":"engine_forkchoiceUpdatedV1",
         "params":[
             {
                 "headBlockHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
@@ -647,7 +647,7 @@ TEST_CASE("handle_engine_forkchoice_updated_v1 fails with empty finalized block 
     nlohmann::json request = R"({
         "jsonrpc":"2.0",
         "id":1,
-        "method":"engine_forkchoiceUpdatedv1",
+        "method":"engine_forkchoiceUpdatedV1",
         "params":[
             {
                 "headBlockHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",

--- a/silkworm/silkrpc/ethbackend/backend.hpp
+++ b/silkworm/silkrpc/ethbackend/backend.hpp
@@ -37,9 +37,9 @@ class BackEnd {
     virtual boost::asio::awaitable<uint64_t> net_version() = 0;
     virtual boost::asio::awaitable<std::string> client_version() = 0;
     virtual boost::asio::awaitable<uint64_t> net_peer_count() = 0;
-    virtual boost::asio::awaitable<ExecutionPayloadV1> engine_get_payload_v1(uint64_t payload_id) = 0;
-    virtual boost::asio::awaitable<PayloadStatusV1> engine_new_payload_v1(const ExecutionPayloadV1& payload) = 0;
-    virtual boost::asio::awaitable<ForkChoiceUpdatedReplyV1> engine_forkchoice_updated_v1(const ForkChoiceUpdatedRequestV1& fcu_request) = 0;
+    virtual boost::asio::awaitable<ExecutionPayload> engine_get_payload(uint64_t payload_id) = 0;
+    virtual boost::asio::awaitable<PayloadStatus> engine_new_payload(const ExecutionPayload& payload) = 0;
+    virtual boost::asio::awaitable<ForkChoiceUpdatedReply> engine_forkchoice_updated(const ForkChoiceUpdatedRequest& fcu_request) = 0;
     virtual boost::asio::awaitable<NodeInfos> engine_node_info() = 0;
     virtual boost::asio::awaitable<PeerInfos> peers() = 0;
 };

--- a/silkworm/silkrpc/ethbackend/remote_backend.hpp
+++ b/silkworm/silkrpc/ethbackend/remote_backend.hpp
@@ -25,6 +25,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <evmc/evmc.hpp>
+#include <gsl/pointers>
 #include <nlohmann/json.hpp>
 
 #include <silkworm/interfaces/remote/ethbackend.grpc.pb.h>
@@ -50,19 +51,19 @@ class RemoteBackEnd final : public BackEnd {
     awaitable<uint64_t> net_version() override;
     awaitable<std::string> client_version() override;
     awaitable<uint64_t> net_peer_count() override;
-    awaitable<ExecutionPayloadV1> engine_get_payload_v1(uint64_t payload_id) override;
-    awaitable<PayloadStatusV1> engine_new_payload_v1(const ExecutionPayloadV1& payload) override;
-    awaitable<ForkChoiceUpdatedReplyV1> engine_forkchoice_updated_v1(const ForkChoiceUpdatedRequestV1& fcu_request) override;
+    awaitable<ExecutionPayload> engine_get_payload(uint64_t payload_id) override;
+    awaitable<PayloadStatus> engine_new_payload(const ExecutionPayload& payload) override;
+    awaitable<ForkChoiceUpdatedReply> engine_forkchoice_updated(const ForkChoiceUpdatedRequest& fcu_request) override;
     awaitable<NodeInfos> engine_node_info() override;
     awaitable<PeerInfos> peers() override;
 
   private:
-    static ExecutionPayloadV1 decode_execution_payload(const ::types::ExecutionPayload& execution_payload_grpc);
-    static ::types::ExecutionPayload encode_execution_payload(const ExecutionPayloadV1& execution_payload);
-    static ::remote::EngineForkChoiceState* encode_forkchoice_state(const ForkChoiceStateV1& forkchoice_state);
-    static ::remote::EnginePayloadAttributes* encode_payload_attributes(const PayloadAttributesV1& payload_attributes);
-    static ::remote::EngineForkChoiceUpdatedRequest encode_forkchoice_updated_request(const ForkChoiceUpdatedRequestV1& fcu_request);
-    static PayloadStatusV1 decode_payload_status(const ::remote::EnginePayloadStatus& payload_status_grpc);
+    static ExecutionPayload decode_execution_payload(const ::types::ExecutionPayload& execution_payload_grpc);
+    static ::types::ExecutionPayload encode_execution_payload(const ExecutionPayload& execution_payload);
+    static gsl::owner<::remote::EngineForkChoiceState*> encode_forkchoice_state(const ForkChoiceState& forkchoice_state);
+    static gsl::owner<::remote::EnginePayloadAttributes*> encode_payload_attributes(const PayloadAttributes& payload_attributes);
+    static ::remote::EngineForkChoiceUpdatedRequest encode_forkchoice_updated_request(const ForkChoiceUpdatedRequest& fcu_request);
+    static PayloadStatus decode_payload_status(const ::remote::EnginePayloadStatus& payload_status_grpc);
     static std::string decode_status_message(const ::remote::EngineStatus& status);
 
     boost::asio::io_context::executor_type executor_;

--- a/silkworm/silkrpc/json/execution_payload.cpp
+++ b/silkworm/silkrpc/json/execution_payload.cpp
@@ -15,7 +15,6 @@
 */
 
 #include <cstring>
-#include <utility>
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
@@ -25,7 +24,7 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const ExecutionPayloadV1& execution_payload) {
+void to_json(nlohmann::json& json, const ExecutionPayload& execution_payload) {
     nlohmann::json transaction_list;
     for (const auto& transaction : execution_payload.transactions) {
         transaction_list.push_back("0x" + silkworm::to_hex(transaction));
@@ -46,7 +45,7 @@ void to_json(nlohmann::json& json, const ExecutionPayloadV1& execution_payload) 
     json["transactions"] = transaction_list;
 }
 
-void from_json(const nlohmann::json& json, ExecutionPayloadV1& execution_payload) {
+void from_json(const nlohmann::json& json, ExecutionPayload& execution_payload) {
     // Parse logs bloom
     silkworm::Bloom logs_bloom;
     std::memcpy(&logs_bloom[0],
@@ -59,7 +58,7 @@ void from_json(const nlohmann::json& json, ExecutionPayloadV1& execution_payload
             *silkworm::from_hex(hex_transaction.get<std::string>()));
     }
 
-    execution_payload = ExecutionPayloadV1{
+    execution_payload = ExecutionPayload{
         .number = static_cast<uint64_t>(std::stol(json.at("blockNumber").get<std::string>(), nullptr, 16)),
         .timestamp = static_cast<uint64_t>(std::stol(json.at("timestamp").get<std::string>(), nullptr, 16)),
         .gas_limit = static_cast<uint64_t>(std::stol(json.at("gasLimit").get<std::string>(), nullptr, 16)),

--- a/silkworm/silkrpc/json/execution_payload.hpp
+++ b/silkworm/silkrpc/json/execution_payload.hpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const ExecutionPayloadV1& execution_payload);
-void from_json(const nlohmann::json& json, ExecutionPayloadV1& execution_payload);
+void to_json(nlohmann::json& json, const ExecutionPayload& execution_payload);
+void from_json(const nlohmann::json& json, ExecutionPayload& execution_payload);
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/json/execution_payload_test.cpp
+++ b/silkworm/silkrpc/json/execution_payload_test.cpp
@@ -28,7 +28,8 @@ using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 
 TEST_CASE("serialize ExecutionPayloadV1", "[silkworm][rpc][to_json]") {
     // uint64_t are kept as hex for readability
-    ExecutionPayloadV1 execution_payload{
+    ExecutionPayload execution_payload_v1{
+        .version = 1,
         .number = 0x1,
         .timestamp = 0x5,
         .gas_limit = 0x1c9c380,
@@ -41,7 +42,7 @@ TEST_CASE("serialize ExecutionPayloadV1", "[silkworm][rpc][to_json]") {
         .base_fee = 0x7,
         .transactions = {*silkworm::from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")},
     };
-    nlohmann::json j = execution_payload;
+    nlohmann::json j = execution_payload_v1;
     CHECK(j == R"({
         "parentHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
         "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
@@ -62,7 +63,7 @@ TEST_CASE("serialize ExecutionPayloadV1", "[silkworm][rpc][to_json]") {
 
 TEST_CASE("deserialize ExecutionPayloadV1", "[silkworm][rpc][to_json]") {
     // uint64_t are kept as hex for readability
-    ExecutionPayloadV1 actual_payload = R"({
+    ExecutionPayload actual_payload = R"({
         "parentHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
         "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
         "stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
@@ -79,7 +80,8 @@ TEST_CASE("deserialize ExecutionPayloadV1", "[silkworm][rpc][to_json]") {
         "transactions":["0xf92ebdeab45d368f6354e8c5a8ac586c"]
     })"_json;
     // expected deserialization result
-    ExecutionPayloadV1 expected_payload{
+    ExecutionPayload expected_payload_v1{
+        .version = 1,
         .number = 0x1,
         .timestamp = 0x5,
         .gas_limit = 0x1c9c380,
@@ -94,17 +96,18 @@ TEST_CASE("deserialize ExecutionPayloadV1", "[silkworm][rpc][to_json]") {
         .transactions = {{0xf9, 0x2e, 0xbd, 0xea, 0xb4, 0x5d, 0x36, 0x8f, 0x63, 0x54, 0xe8, 0xc5, 0xa8, 0xac, 0x58, 0x6c}},
     };
 
-    CHECK(actual_payload.parent_hash == expected_payload.parent_hash);
-    CHECK(actual_payload.suggested_fee_recipient == expected_payload.suggested_fee_recipient);
-    CHECK(actual_payload.state_root == expected_payload.state_root);
-    CHECK(actual_payload.receipts_root == expected_payload.receipts_root);
-    CHECK(actual_payload.prev_randao == expected_payload.prev_randao);
-    CHECK(actual_payload.number == expected_payload.number);
-    CHECK(actual_payload.gas_limit == expected_payload.gas_limit);
-    CHECK(actual_payload.timestamp == expected_payload.timestamp);
-    CHECK(actual_payload.base_fee == expected_payload.base_fee);
-    CHECK(actual_payload.block_hash == expected_payload.block_hash);
-    CHECK(actual_payload.transactions == expected_payload.transactions);
+    CHECK(actual_payload.parent_hash == expected_payload_v1.parent_hash);
+    CHECK(actual_payload.suggested_fee_recipient == expected_payload_v1.suggested_fee_recipient);
+    CHECK(actual_payload.state_root == expected_payload_v1.state_root);
+    CHECK(actual_payload.receipts_root == expected_payload_v1.receipts_root);
+    CHECK(actual_payload.prev_randao == expected_payload_v1.prev_randao);
+    CHECK(actual_payload.number == expected_payload_v1.number);
+    CHECK(actual_payload.gas_limit == expected_payload_v1.gas_limit);
+    CHECK(actual_payload.timestamp == expected_payload_v1.timestamp);
+    CHECK(actual_payload.base_fee == expected_payload_v1.base_fee);
+    CHECK(actual_payload.block_hash == expected_payload_v1.block_hash);
+    CHECK(actual_payload.transactions == expected_payload_v1.transactions);
+    CHECK(actual_payload.withdrawals == std::nullopt);
 }
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/json/fork_choice.cpp
+++ b/silkworm/silkrpc/json/fork_choice.cpp
@@ -25,20 +25,20 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const ForkChoiceStateV1& forkchoice_state) {
+void to_json(nlohmann::json& json, const ForkChoiceState& forkchoice_state) {
     json["headBlockHash"] = forkchoice_state.head_block_hash;
     json["safeBlockHash"] = forkchoice_state.safe_block_hash;
     json["finalizedBlockHash"] = forkchoice_state.finalized_block_hash;
 }
 
-void from_json(const nlohmann::json& json, ForkChoiceStateV1& forkchoice_state) {
-    forkchoice_state = ForkChoiceStateV1{
+void from_json(const nlohmann::json& json, ForkChoiceState& forkchoice_state) {
+    forkchoice_state = ForkChoiceState{
         .head_block_hash = json.at("headBlockHash").get<evmc::bytes32>(),
         .safe_block_hash = json.at("safeBlockHash").get<evmc::bytes32>(),
         .finalized_block_hash = json.at("finalizedBlockHash").get<evmc::bytes32>()};
 }
 
-void to_json(nlohmann::json& json, const ForkChoiceUpdatedReplyV1& forkchoice_updated_reply) {
+void to_json(nlohmann::json& json, const ForkChoiceUpdatedReply& forkchoice_updated_reply) {
     nlohmann::json json_payload_status = forkchoice_updated_reply.payload_status;
     json["payloadStatus"] = json_payload_status;
     if (forkchoice_updated_reply.payload_id != std::nullopt) {

--- a/silkworm/silkrpc/json/fork_choice.hpp
+++ b/silkworm/silkrpc/json/fork_choice.hpp
@@ -22,9 +22,9 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const ForkChoiceStateV1& forkchoice_state);
-void from_json(const nlohmann::json& json, ForkChoiceStateV1& forkchoice_state);
+void to_json(nlohmann::json& json, const ForkChoiceState& forkchoice_state);
+void from_json(const nlohmann::json& json, ForkChoiceState& forkchoice_state);
 
-void to_json(nlohmann::json& json, const ForkChoiceUpdatedReplyV1& forkchoice_updated_reply);
+void to_json(nlohmann::json& json, const ForkChoiceUpdatedReply& forkchoice_updated_reply);
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/json/fork_choice_test.cpp
+++ b/silkworm/silkrpc/json/fork_choice_test.cpp
@@ -25,7 +25,7 @@ using Catch::Matchers::Message;
 using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 
 TEST_CASE("serialize ForkChoiceStateV1", "[silkworm::json][to_json]") {
-    ForkChoiceStateV1 forkchoice_state{
+    ForkChoiceState forkchoice_state{
         .head_block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,
         .safe_block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,
         .finalized_block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32};
@@ -45,7 +45,7 @@ TEST_CASE("deserialize ForkChoiceStateV1", "[silkworm::json][from_json]") {
         "finalizedBlockHash":"0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858"
     })"_json;
 
-    ForkChoiceStateV1 forkchoice_state = j;
+    ForkChoiceState forkchoice_state = j;
     CHECK(forkchoice_state.head_block_hash == 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32);
     CHECK(forkchoice_state.safe_block_hash == 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32);
     CHECK(forkchoice_state.finalized_block_hash == 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32);

--- a/silkworm/silkrpc/json/payload_attributes.cpp
+++ b/silkworm/silkrpc/json/payload_attributes.cpp
@@ -25,14 +25,14 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const PayloadAttributesV1& payload_attributes) {
+void to_json(nlohmann::json& json, const PayloadAttributes& payload_attributes) {
     json["timestamp"] = to_quantity(payload_attributes.timestamp);
     json["prevRandao"] = payload_attributes.prev_randao;
     json["feeRecipient"] = payload_attributes.suggested_fee_recipient;
 }
 
-void from_json(const nlohmann::json& json, PayloadAttributesV1& payload_attributes) {
-    payload_attributes = PayloadAttributesV1{
+void from_json(const nlohmann::json& json, PayloadAttributes& payload_attributes) {
+    payload_attributes = PayloadAttributes{
         .timestamp = static_cast<uint64_t>(std::stol(json.at("timestamp").get<std::string>(), nullptr, 16)),
         .prev_randao = json.at("prevRandao").get<evmc::bytes32>(),
         .suggested_fee_recipient = json.at("feeRecipient").get<evmc::address>(),

--- a/silkworm/silkrpc/json/payload_attributes.hpp
+++ b/silkworm/silkrpc/json/payload_attributes.hpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const PayloadAttributesV1& payload_attributes);
-void from_json(const nlohmann::json& json, PayloadAttributesV1& payload_attributes);
+void to_json(nlohmann::json& json, const PayloadAttributes& payload_attributes);
+void from_json(const nlohmann::json& json, PayloadAttributes& payload_attributes);
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/json/payload_attributes_test.cpp
+++ b/silkworm/silkrpc/json/payload_attributes_test.cpp
@@ -25,7 +25,7 @@ using Catch::Matchers::Message;
 using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 
 TEST_CASE("serialize PayloadAttributesV1", "[silkworm::json][to_json]") {
-    PayloadAttributesV1 payload_attributes{
+    PayloadAttributes payload_attributes{
         .timestamp = 0x1,
         .prev_randao = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,
         .suggested_fee_recipient = 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address};
@@ -45,8 +45,7 @@ TEST_CASE("deserialize PayloadAttributesV1", "[silkworm::json][from_json]") {
         "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
     })"_json;
 
-    PayloadAttributesV1 payload_attributes = j;
-
+    PayloadAttributes payload_attributes = j;
     CHECK(payload_attributes.timestamp == 0x1);
     CHECK(payload_attributes.prev_randao == 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32);
     CHECK(payload_attributes.suggested_fee_recipient == 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address);

--- a/silkworm/silkrpc/json/transition_configuration.cpp
+++ b/silkworm/silkrpc/json/transition_configuration.cpp
@@ -25,14 +25,14 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const TransitionConfigurationV1& transition_configuration) {
+void to_json(nlohmann::json& json, const TransitionConfiguration& transition_configuration) {
     json["terminalTotalDifficulty"] = to_quantity(transition_configuration.terminal_total_difficulty);
     json["terminalBlockHash"] = transition_configuration.terminal_block_hash;
     json["terminalBlockNumber"] = to_quantity(transition_configuration.terminal_block_number);
 }
 
-void from_json(const nlohmann::json& json, TransitionConfigurationV1& transition_configuration) {
-    transition_configuration = TransitionConfigurationV1{
+void from_json(const nlohmann::json& json, TransitionConfiguration& transition_configuration) {
+    transition_configuration = TransitionConfiguration{
         .terminal_total_difficulty = json.at("terminalTotalDifficulty").get<intx::uint256>(),
         .terminal_block_hash = json.at("terminalBlockHash").get<evmc::bytes32>(),
         .terminal_block_number = static_cast<uint64_t>(std::stol(json.at("terminalBlockNumber").get<std::string>(), nullptr, 16))};

--- a/silkworm/silkrpc/json/transition_configuration.hpp
+++ b/silkworm/silkrpc/json/transition_configuration.hpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::rpc {
 
-void to_json(nlohmann::json& json, const TransitionConfigurationV1& transition_configuration);
-void from_json(const nlohmann::json& json, TransitionConfigurationV1& transition_configuration);
+void to_json(nlohmann::json& json, const TransitionConfiguration& transition_configuration);
+void from_json(const nlohmann::json& json, TransitionConfiguration& transition_configuration);
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/json/transition_configuration_test.cpp
+++ b/silkworm/silkrpc/json/transition_configuration_test.cpp
@@ -25,7 +25,7 @@ using Catch::Matchers::Message;
 using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 
 TEST_CASE("serialize TransitionConfigurationV1", "[silkworm::json][to_json]") {
-    TransitionConfigurationV1 transition_configuration{
+    TransitionConfiguration transition_configuration{
         .terminal_total_difficulty = 0xf4240,
         .terminal_block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,
         .terminal_block_number = 0x0};
@@ -37,17 +37,16 @@ TEST_CASE("serialize TransitionConfigurationV1", "[silkworm::json][to_json]") {
 }
 
 TEST_CASE("deserialize TransitionConfigurationV1", "[silkworm::json][from_json]") {
-    TransitionConfigurationV1 actual_transition_configuration = R"({
+    TransitionConfiguration actual_transition_configuration = R"({
         "terminalTotalDifficulty":"0xf4240",
         "terminalBlockHash":"0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858",
         "terminalBlockNumber":"0x0"
     })"_json;
 
-    TransitionConfigurationV1 expected_transition_configuration{
+    TransitionConfiguration expected_transition_configuration{
         .terminal_total_difficulty = 0xf4240,
         .terminal_block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,
         .terminal_block_number = 0x0};
-
     CHECK(actual_transition_configuration.terminal_total_difficulty == expected_transition_configuration.terminal_total_difficulty);
     CHECK(actual_transition_configuration.terminal_block_hash == expected_transition_configuration.terminal_block_hash);
     CHECK(actual_transition_configuration.terminal_block_number == expected_transition_configuration.terminal_block_number);

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -489,7 +489,7 @@ void to_json(nlohmann::json& json, const Transaction& transaction) {
     }
 }
 
-void to_json(nlohmann::json& json, const PayloadStatusV1& payload_status) {
+void to_json(nlohmann::json& json, const PayloadStatus& payload_status) {
     json["status"] = payload_status.status;
 
     if (payload_status.latest_valid_hash) {

--- a/silkworm/silkrpc/json/types.hpp
+++ b/silkworm/silkrpc/json/types.hpp
@@ -112,7 +112,7 @@ void to_json(nlohmann::json& json, const BlockTransactionsResponse& b);
 
 void to_json(nlohmann::json& json, const Transaction& transaction);
 
-void to_json(nlohmann::json& json, const PayloadStatusV1& payload_status);
+void to_json(nlohmann::json& json, const PayloadStatus& payload_status);
 
 void to_json(nlohmann::json& json, const Forks& forks);
 

--- a/silkworm/silkrpc/json/types_test.cpp
+++ b/silkworm/silkrpc/json/types_test.cpp
@@ -1170,11 +1170,11 @@ TEST_CASE("serialize issuance", "[silkworm::json][to_json]") {
 }
 
 TEST_CASE("serialize ForkChoiceUpdatedReplyV1", "[silkworm::json][to_json]") {
-    silkworm::rpc::PayloadStatusV1 payload_status{
+    silkworm::rpc::PayloadStatus payload_status{
         .status = "VALID",
         .latest_valid_hash = 0x0000000000000000000000000000000000000000000000000000000000000040_bytes32,
         .validation_error = "some error"};
-    silkworm::rpc::ForkChoiceUpdatedReplyV1 forkchoice_update_reply{
+    silkworm::rpc::ForkChoiceUpdatedReply forkchoice_update_reply{
         .payload_status = payload_status,
         .payload_id = 0x1};
 
@@ -1190,7 +1190,7 @@ TEST_CASE("serialize ForkChoiceUpdatedReplyV1", "[silkworm::json][to_json]") {
 }
 
 TEST_CASE("serialize PayloadStatusV1", "[silkworm::json][to_json]") {
-    silkworm::rpc::PayloadStatusV1 payload_status{
+    silkworm::rpc::PayloadStatus payload_status{
         .status = "VALID",
         .latest_valid_hash = 0x0000000000000000000000000000000000000000000000000000000000000040_bytes32,
         .validation_error = "some error"};

--- a/silkworm/silkrpc/types/execution_payload.cpp
+++ b/silkworm/silkrpc/types/execution_payload.cpp
@@ -19,7 +19,8 @@
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
-std::ostream& operator<<(std::ostream& out, const ExecutionPayloadV1& payload) {
+
+std::ostream& operator<<(std::ostream& out, const ExecutionPayload& payload) {
     auto bloom_bytes{silkworm::ByteView(&payload.logs_bloom[0], 256)};
     out << "number: " << payload.number
         << " block_hash: " << payload.block_hash
@@ -33,12 +34,14 @@ std::ostream& operator<<(std::ostream& out, const ExecutionPayloadV1& payload) {
         << " prev_randao: " << payload.prev_randao
         << " logs_bloom: " << silkworm::to_hex(bloom_bytes)
         << " extra_data: " << silkworm::to_hex(payload.extra_data)
-        << "#transactions: " << payload.transactions.size();
-
+        << " #transactions: " << payload.transactions.size();
+    if (payload.withdrawals) {
+        out << " #withdrawals: " << payload.withdrawals->size();
+    }
     return out;
 }
 
-std::ostream& operator<<(std::ostream& out, const PayloadStatusV1& payload_status) {
+std::ostream& operator<<(std::ostream& out, const PayloadStatus& payload_status) {
     out << "status: " << payload_status.status;
 
     if (payload_status.latest_valid_hash) {
@@ -50,4 +53,5 @@ std::ostream& operator<<(std::ostream& out, const PayloadStatusV1& payload_statu
 
     return out;
 }
+
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/types/execution_payload.hpp
+++ b/silkworm/silkrpc/types/execution_payload.hpp
@@ -25,14 +25,20 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/bloom.hpp>
+#include <silkworm/core/types/withdrawal.hpp>
 
 namespace silkworm::rpc {
 
 //! Capabilities as specified in https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities
 using Capabilities = std::vector<std::string>;
 
+//! ExecutionPayload represents either
 //! ExecutionPayloadV1 as specified in https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#executionpayloadv1
-struct ExecutionPayloadV1 {
+//! or
+//! ExecutionPayloadV2 as specified in https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#executionpayloadv2
+struct ExecutionPayload {
+    uint32_t version{1};
+
     uint64_t number;
     uint64_t timestamp;
     uint64_t gas_limit;
@@ -44,67 +50,68 @@ struct ExecutionPayloadV1 {
     evmc::bytes32 block_hash;
     evmc::bytes32 prev_randao;
     intx::uint256 base_fee;
-    silkworm::Bloom logs_bloom;
-    silkworm::Bytes extra_data;
-    std::vector<silkworm::Bytes> transactions;
+    Bloom logs_bloom;
+    Bytes extra_data;
+    std::vector<Bytes> transactions;
+    std::optional<std::vector<Withdrawal>> withdrawals{std::nullopt};  // present iff version=2
 };
 
 //! ForkChoiceStateV1 as specified by https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#forkchoicestatev1
-struct ForkChoiceStateV1 {
+struct ForkChoiceState {
     evmc::bytes32 head_block_hash;
     evmc::bytes32 safe_block_hash;
     evmc::bytes32 finalized_block_hash;
 };
 
 //! PayloadAttributesV1 as specified by https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payloadattributesv1
-struct PayloadAttributesV1 {
+struct PayloadAttributes {
     uint64_t timestamp;
     evmc::bytes32 prev_randao;
     evmc::address suggested_fee_recipient;
 };
 
 //! PayloadStatusV1 as specified by https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payloadstatusv1
-struct PayloadStatusV1 {
+struct PayloadStatus {
     static inline const char* kValid{"VALID"};
     static inline const char* kInvalid{"INVALID"};
     static inline const char* kSyncing{"SYNCING"};
     static inline const char* kAccepted{"ACCEPTED"};
     static inline const char* kInvalidBlockHash{"INVALID_BLOCK_HASH"};
-    static const PayloadStatusV1 Syncing;
-    static const PayloadStatusV1 Accepted;
-    static const PayloadStatusV1 InvalidBlockHash;
+    static const PayloadStatus Syncing;
+    static const PayloadStatus Accepted;
+    static const PayloadStatus InvalidBlockHash;
 
     std::string status;
     std::optional<evmc::bytes32> latest_valid_hash;
     std::optional<std::string> validation_error;
 };
 
-inline const PayloadStatusV1 PayloadStatusV1::Syncing{.status = PayloadStatusV1::kSyncing};
-inline const PayloadStatusV1 PayloadStatusV1::Accepted{.status = PayloadStatusV1::kAccepted};
-inline const PayloadStatusV1 PayloadStatusV1::InvalidBlockHash{.status = PayloadStatusV1::kInvalidBlockHash};
+inline const PayloadStatus PayloadStatus::Syncing{.status = PayloadStatus::kSyncing};
+inline const PayloadStatus PayloadStatus::Accepted{.status = PayloadStatus::kAccepted};
+inline const PayloadStatus PayloadStatus::InvalidBlockHash{.status = PayloadStatus::kInvalidBlockHash};
 
-struct ForkChoiceUpdatedRequestV1 {
-    ForkChoiceStateV1 fork_choice_state;
-    std::optional<PayloadAttributesV1> payload_attributes;
+struct ForkChoiceUpdatedRequest {
+    ForkChoiceState fork_choice_state;
+    std::optional<PayloadAttributes> payload_attributes;
 };
 
-struct ForkChoiceUpdatedReplyV1 {
-    PayloadStatusV1 payload_status;
+struct ForkChoiceUpdatedReply {
+    PayloadStatus payload_status;
     std::optional<uint64_t> payload_id;
 };
 
 //! TransitionConfigurationV1 as specified by https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#transitionconfigurationv1
-struct TransitionConfigurationV1 {
+struct TransitionConfiguration {
     intx::uint256 terminal_total_difficulty;
     evmc::bytes32 terminal_block_hash;
     uint64_t terminal_block_number{0};
 };
 
-std::ostream& operator<<(std::ostream& out, const ExecutionPayloadV1& payload);
-std::ostream& operator<<(std::ostream& out, const PayloadStatusV1& payload_status);
-std::ostream& operator<<(std::ostream& out, const ForkChoiceStateV1& fork_choice_state);
-std::ostream& operator<<(std::ostream& out, const PayloadAttributesV1& payload_attributes);
-std::ostream& operator<<(std::ostream& out, const ForkChoiceUpdatedReplyV1& fork_choice_updated_reply);
-std::ostream& operator<<(std::ostream& out, const TransitionConfigurationV1& transition_configuration);
+std::ostream& operator<<(std::ostream& out, const ExecutionPayload& payload);
+std::ostream& operator<<(std::ostream& out, const PayloadStatus& payload_status);
+std::ostream& operator<<(std::ostream& out, const ForkChoiceState& fork_choice_state);
+std::ostream& operator<<(std::ostream& out, const PayloadAttributes& payload_attributes);
+std::ostream& operator<<(std::ostream& out, const ForkChoiceUpdatedReply& fork_choice_updated_reply);
+std::ostream& operator<<(std::ostream& out, const TransitionConfiguration& transition_configuration);
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/types/execution_payload_test.cpp
+++ b/silkworm/silkrpc/types/execution_payload_test.cpp
@@ -23,15 +23,20 @@
 
 namespace silkworm::rpc {
 
-TEST_CASE("print empty execution payload", "[silkrpc][types][execution_payload]") {
-    ExecutionPayloadV1 p{};
+TEST_CASE("print empty ExecutionPayloadV1", "[silkworm][rpc][types]") {
+    ExecutionPayload p{.version = 1};
     CHECK_NOTHROW(silkworm::test::null_stream() << p);
 }
 
-TEST_CASE("print empty payload status", "[silkrpc][types][execution_payload]") {
-    PayloadStatusV1 p{
+TEST_CASE("print empty PayloadStatusV1", "[silkworm][rpc][types]") {
+    PayloadStatus p{
         .latest_valid_hash = evmc::bytes32{},
         .validation_error = ""};
+    CHECK_NOTHROW(silkworm::test::null_stream() << p);
+}
+
+TEST_CASE("print empty ExecutionPayloadV2", "[silkworm][rpc][types]") {
+    ExecutionPayload p{.version = 2};
     CHECK_NOTHROW(silkworm::test::null_stream() << p);
 }
 

--- a/silkworm/sync/engine_api_backend.cpp
+++ b/silkworm/sync/engine_api_backend.cpp
@@ -18,16 +18,16 @@
 
 namespace silkworm::chainsync {
 
-awaitable<rpc::PayloadStatusV1> EngineApiBackend::engine_new_payload_v1(const rpc::ExecutionPayloadV1& payload) {
-    co_return co_await pos_sync_.new_payload_v1(payload);
+awaitable<rpc::PayloadStatus> EngineApiBackend::engine_new_payload(const rpc::ExecutionPayload& payload) {
+    co_return co_await pos_sync_.new_payload(payload);
 }
 
-awaitable<rpc::ExecutionPayloadV1> EngineApiBackend::engine_get_payload_v1(uint64_t payload_id) {
-    co_return co_await pos_sync_.get_payload_v1(payload_id);
+awaitable<rpc::ExecutionPayload> EngineApiBackend::engine_get_payload(uint64_t payload_id) {
+    co_return co_await pos_sync_.get_payload(payload_id);
 }
 
-awaitable<rpc::ForkChoiceUpdatedReplyV1> EngineApiBackend::engine_forkchoice_updated_v1(const rpc::ForkChoiceUpdatedRequestV1& fcu_request) {
-    co_return co_await pos_sync_.fork_choice_update_v1(fcu_request.fork_choice_state, fcu_request.payload_attributes);
+awaitable<rpc::ForkChoiceUpdatedReply> EngineApiBackend::engine_forkchoice_updated(const rpc::ForkChoiceUpdatedRequest& fcu_request) {
+    co_return co_await pos_sync_.fork_choice_update(fcu_request.fork_choice_state, fcu_request.payload_attributes);
 }
 awaitable<evmc::address> EngineApiBackend::etherbase() {
     co_return evmc::address{};

--- a/silkworm/sync/engine_api_backend.hpp
+++ b/silkworm/sync/engine_api_backend.hpp
@@ -33,9 +33,9 @@ class EngineApiBackend : public rpc::ethbackend::BackEnd {
     EngineApiBackend(const EngineApiBackend&) = delete;
     EngineApiBackend& operator=(const EngineApiBackend&) = delete;
 
-    awaitable<rpc::PayloadStatusV1> engine_new_payload_v1(const rpc::ExecutionPayloadV1& payload) override;
-    awaitable<rpc::ExecutionPayloadV1> engine_get_payload_v1(uint64_t payload_id) override;
-    awaitable<rpc::ForkChoiceUpdatedReplyV1> engine_forkchoice_updated_v1(const rpc::ForkChoiceUpdatedRequestV1& fcu_request) override;
+    awaitable<rpc::PayloadStatus> engine_new_payload(const rpc::ExecutionPayload& payload) override;
+    awaitable<rpc::ExecutionPayload> engine_get_payload(uint64_t payload_id) override;
+    awaitable<rpc::ForkChoiceUpdatedReply> engine_forkchoice_updated(const rpc::ForkChoiceUpdatedRequest& fcu_request) override;
     awaitable<evmc::address> etherbase() override;
     awaitable<uint64_t> protocol_version() override;
     awaitable<uint64_t> net_version() override;

--- a/silkworm/sync/sync_pos.hpp
+++ b/silkworm/sync/sync_pos.hpp
@@ -45,12 +45,12 @@ class PoSSync : public ChainSync {
     auto download_blocks() -> asio::awaitable<void>; /*[[long_running]]*/
 
     // public interface called by the external PoS client
-    auto new_payload_v1(const rpc::ExecutionPayloadV1&) -> asio::awaitable<rpc::PayloadStatusV1>;
-    auto fork_choice_update_v1(const rpc::ForkChoiceStateV1&, const std::optional<rpc::PayloadAttributesV1>&) -> asio::awaitable<rpc::ForkChoiceUpdatedReplyV1>;
-    auto get_payload_v1(uint64_t payloadId) -> asio::awaitable<rpc::ExecutionPayloadV1>;
+    auto new_payload(const rpc::ExecutionPayload&) -> asio::awaitable<rpc::PayloadStatus>;
+    auto fork_choice_update(const rpc::ForkChoiceState&, const std::optional<rpc::PayloadAttributes>&) -> asio::awaitable<rpc::ForkChoiceUpdatedReply>;
+    auto get_payload(uint64_t payloadId) -> asio::awaitable<rpc::ExecutionPayload>;
 
   private:
-    static auto make_execution_block(const rpc::ExecutionPayloadV1& payload) -> std::shared_ptr<Block>;
+    static auto make_execution_block(const rpc::ExecutionPayload& payload) -> std::shared_ptr<Block>;
     void do_sanity_checks(const BlockHeader& header, TotalDifficulty parent_td);
     auto has_bad_ancestor(const Hash& block_hash) -> std::tuple<bool, Hash>;
 };


### PR DESCRIPTION
This PR restores previous version-unaware naming for internal classes and functions dealing with Engine API because it seems better to handle different versions using simply a field, as it is done in internal gRPC `ethbackend`.

So for example in `ExecutionPayload` struct:
```
struct ExecutionPayload {
    uint32_t version{1};
    // ... omissis ...
    std::optional<std::vector<Withdrawal>> withdrawals{std::nullopt};  // present iff version=2
};
```
we use a dedicated field to track the version [this will be an enum in next PR] and optional fields for version-specific stuff (e.g. withdrawals).