### PR TITLE
core: correct type of len in silkworm_rmd160

### DIFF
--- a/silkworm/core/crypto/rmd160.c
+++ b/silkworm/core/crypto/rmd160.c
@@ -368,8 +368,8 @@ void silkworm_rmd160(uint8_t out[20], const uint8_t* ptr, uint32_t len) {
     rmd160_init(buf);
 
     uint32_t current[16];
-    for (unsigned remaining = len; remaining >= 64; remaining -= 64) {
-        for (unsigned i = 0; i < 16; ++i) {
+    for (size_t remaining = len; remaining >= 64; remaining -= 64) {
+        for (size_t i = 0; i < 16; ++i) {
             current[i] = load32(ptr);
             ptr += 4;
         }
@@ -378,7 +378,7 @@ void silkworm_rmd160(uint8_t out[20], const uint8_t* ptr, uint32_t len) {
 
     rmd160_finish(buf, ptr, len);
 
-    for (unsigned i = 0; i < 20; i += 4) {
+    for (size_t i = 0; i < 20; i += 4) {
         out[i] = buf[i >> 2];
         out[i + 1] = buf[i >> 2] >> 8;
         out[i + 2] = buf[i >> 2] >> 16;

--- a/silkworm/core/crypto/rmd160.c
+++ b/silkworm/core/crypto/rmd160.c
@@ -362,13 +362,13 @@ static inline uint32_t load32(const void* src) {
     return w;
 }
 
-void silkworm_rmd160(uint8_t out[20], const uint8_t* ptr, size_t len) {
+void silkworm_rmd160(uint8_t out[20], const uint8_t* ptr, uint32_t len) {
     uint32_t buf[160 / 32];
 
     rmd160_init(buf);
 
     uint32_t current[16];
-    for (size_t remaining = len; remaining >= 64; remaining -= 64) {
+    for (unsigned remaining = len; remaining >= 64; remaining -= 64) {
         for (unsigned i = 0; i < 16; ++i) {
             current[i] = load32(ptr);
             ptr += 4;

--- a/silkworm/core/crypto/rmd160.h
+++ b/silkworm/core/crypto/rmd160.h
@@ -44,7 +44,7 @@
 extern "C" {
 #endif
 
-void silkworm_rmd160(uint8_t out[20], const uint8_t* input, size_t len);
+void silkworm_rmd160(uint8_t out[20], const uint8_t* input, uint32_t len);
 
 #if defined(__cplusplus)
 }

--- a/silkworm/core/execution/precompile.cpp
+++ b/silkworm/core/execution/precompile.cpp
@@ -92,7 +92,8 @@ uint64_t rip160_gas(ByteView input, evmc_revision) noexcept {
 
 std::optional<Bytes> rip160_run(ByteView input) noexcept {
     Bytes out(32, 0);
-    silkworm_rmd160(&out[12], input.data(), input.length());
+    SILKWORM_ASSERT(input.length() <= std::numeric_limits<uint32_t>::max());
+    silkworm_rmd160(&out[12], input.data(), static_cast<uint32_t>(input.length()));
     return out;
 }
 


### PR DESCRIPTION
The type of `len` in `rmd160_finish` is `uint32_t`, so it should be the same in `silkworm_rmd160`.