### PR TITLE
node: fix pipeline state using stop_at_block env var

### DIFF
--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -238,6 +238,10 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
         }
 
         log::Info("ExecPipeline") << "Forward done ---------------------------";
+
+        const auto stop_at_block = Environment::get_stop_at_block();  // User can specify to stop at some block
+        if (stop_at_block && stop_at_block <= head_header_number_) return Stage::Result::kStoppedByEnv;
+
         return result;
 
     } catch (const std::exception& ex) {

--- a/silkworm/node/stagedsync/stages/stage_finish.cpp
+++ b/silkworm/node/stagedsync/stages/stage_finish.cpp
@@ -33,15 +33,7 @@ Stage::Result Finish::forward(db::RWTxn& txn) {
         auto execution_stage_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress >= execution_stage_progress) {
             // Nothing to process
-            const auto stop_at_block = Environment::get_stop_at_block();  // User can specify to stop at some block
-            if (stop_at_block && stop_at_block <= execution_stage_progress) return Stage::Result::kStoppedByEnv;
             return ret;
-        } else if (previous_progress > execution_stage_progress) {
-            // Something bad had happened.
-            std::string what{std::string(stage_name_) + " progress " + std::to_string(previous_progress) +
-                             " while " + std::string(db::stages::kExecutionKey) + " stage " +
-                             std::to_string(execution_stage_progress)};
-            throw StageError(Stage::Result::kInvalidProgress, what);
         }
 
         throw_if_stopping();


### PR DESCRIPTION
Pipeline state must be computed even when we stop due to stop_at_block environment var