### PR TITLE
build: update GRPC to 1.48.0 + fix llvm installation in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
       - run:
           name: "Install dependencies"
           command: |
+            sudo apt-get update
             sudo apt-get install -y m4 texinfo bison
       - run:
           name: "Cmake"
@@ -78,7 +79,8 @@ commands:
       - run:
           name: "Install gcc"
           command: |
-            sudo apt -y install gcc-$GCC_VERSION g++-$GCC_VERSION
+            sudo apt-get update
+            sudo apt-get install -y gcc-$GCC_VERSION g++-$GCC_VERSION
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 100 --slave /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION
 
   # libc++ is an alternative standard library needed for coroutines support on Clang
@@ -88,7 +90,8 @@ commands:
       - run:
           name: "Install llvm"
           command: |
-            sudo apt -y install llvm-$CLANG_VERSION libc++-$CLANG_VERSION-dev libc++abi-$CLANG_VERSION-dev clang-$CLANG_VERSION
+            sudo apt-get update
+            sudo apt-get install -y llvm-$CLANG_VERSION libc++-$CLANG_VERSION-dev libc++abi-$CLANG_VERSION-dev clang-$CLANG_VERSION
             sudo ln -sfv /usr/bin/clang-$CLANG_VERSION /usr/bin/clang
             sudo ln -sfv /usr/bin/clang++-$CLANG_VERSION /usr/bin/clang++
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,7 +5,7 @@ benchmark/1.6.1
 boost/1.81.0
 catch2/2.13.9
 cli11/2.2.0
-grpc/1.46.3
+grpc/1.48.0
 gtest/1.12.1
 jwt-cpp/0.6.0
 mimalloc/2.0.9


### PR DESCRIPTION
This uses a prebuilt version from conancenter.

apt-get update to fix "Install llvm" failure:

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/g/gcc-11/libobjc-11-dev_11.3.0-1ubuntu1%7e22.04_amd64.deb 404 Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?