### PR TITLE
node: expose empty + size methods in db::ROCursor

### DIFF
--- a/silkworm/node/db/mdbx.cpp
+++ b/silkworm/node/db/mdbx.cpp
@@ -334,8 +334,6 @@ bool PooledCursor::is_dangling() const {
 
 size_t PooledCursor::size() const { return get_map_stat().ms_entries; }
 
-bool PooledCursor::empty() const { return size() == 0; }
-
 ::mdbx::map_handle PooledCursor::map() const {
     return ::mdbx::cursor::map();
 }

--- a/silkworm/node/db/memory_mutation_cursor.cpp
+++ b/silkworm/node/db/memory_mutation_cursor.cpp
@@ -50,6 +50,10 @@ void MemoryMutationCursor::bind(ROTxn& txn, const MapConfig& config) {
     return memory_cursor_->map();
 }
 
+size_t MemoryMutationCursor::size() const {
+    return cursor_->size();
+}
+
 bool MemoryMutationCursor::is_multi_value() const {
     return cursor_->is_multi_value();
 }

--- a/silkworm/node/db/memory_mutation_cursor.hpp
+++ b/silkworm/node/db/memory_mutation_cursor.hpp
@@ -36,8 +36,8 @@ class MemoryMutationCursor : public RWCursorDupSort {
 
     [[nodiscard]] ::mdbx::map_handle map() const override;
 
+    [[nodiscard]] size_t size() const override;
     [[nodiscard]] bool is_multi_value() const override;
-
     [[nodiscard]] bool is_dangling() const override;
 
     CursorResult to_first() override;

--- a/silkworm/node/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/node/db/memory_mutation_cursor_test.cpp
@@ -113,11 +113,15 @@ TEST_CASE("MemoryMutationCursor: initialization", "[silkworm][node][db][memory_m
 
         // Check initial state
         MemoryMutationCursor mutation_cursor1{test1.mutation, kTestMap};
-        CHECK_NOTHROW(!mutation_cursor1.is_table_cleared());
-        CHECK_NOTHROW(!mutation_cursor1.is_entry_deleted(Slice{}));
+        CHECK(mutation_cursor1.size() == 2);
+        CHECK(!mutation_cursor1.empty());
+        CHECK(!mutation_cursor1.is_table_cleared());
+        CHECK(!mutation_cursor1.is_entry_deleted(Slice{}));
         MemoryMutationCursor mutation_cursor2{test1.mutation, kTestMultiMap};
-        CHECK_NOTHROW(!mutation_cursor2.is_table_cleared());
-        CHECK_NOTHROW(!mutation_cursor2.is_entry_deleted(Slice{}));
+        CHECK(mutation_cursor2.size() == 4);
+        CHECK(!mutation_cursor2.empty());
+        CHECK(!mutation_cursor2.is_table_cleared());
+        CHECK(!mutation_cursor2.is_entry_deleted(Slice{}));
 
         // Create many cursors
         std::vector<std::unique_ptr<MemoryMutationCursor>> memory_cursors;
@@ -129,9 +133,9 @@ TEST_CASE("MemoryMutationCursor: initialization", "[silkworm][node][db][memory_m
         // Check predefined tables
         for (const auto& table : table::kChainDataTables) {
             MemoryMutationCursor mutation_cursor{test1.mutation, table};
-            CHECK_NOTHROW(has_map(test1.mutation, table.name));
-            CHECK_NOTHROW(!mutation_cursor.is_table_cleared());
-            CHECK_NOTHROW(!mutation_cursor.is_entry_deleted(Slice{}));
+            CHECK(has_map(test1.mutation, table.name));
+            CHECK(!mutation_cursor.is_table_cleared());
+            CHECK(!mutation_cursor.is_entry_deleted(Slice{}));
         }
     }
 


### PR DESCRIPTION
follow some clang-tidy suggestions