### PR TITLE
infra: handle cancellation in awaitable promise and future

### DIFF
--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -284,8 +284,8 @@ TEST_CASE("awaitable future") {
 
         io.run();
 
-        CHECK_THROWS_AS(promise.set_value(42), std::runtime_error);
-        CHECK(code == boost::asio::experimental::channel_errc::channel_cancelled);
+        CHECK(promise.set_value(42) == false);
+        CHECK(code == boost::system::errc::operation_canceled);
     }
 }
 


### PR DESCRIPTION
This PR improves the cancellation handling in `AwaitablePromise` and `AwaitableFuture` classes:

- make them compatible the cancellation mechanism used by Asio async operations by remapping `channel_cancelled` error code in `operation_canceled` to abstract away implementation details (i.e. usage of `asio::basic_concurrent_channel`)
- close the underlying `asio::basic_concurrent_channel` in case of cancellation in order to make such condition detectable at the sender side (no runtime exception in this case because it is not a programming error)