### PR TITLE
build: move libtorrent back to third_party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 [submodule "third_party/ethash"]
 	path = third_party/ethash
 	url = https://github.com/chfast/ethash.git
+[submodule "third_party/libtorrent"]
+	path = third_party/libtorrent
+	url = https://github.com/arvidn/libtorrent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,13 @@ if(NOT SILKWORM_CORE_ONLY)
   # Silence CMake policy warnings in submodules
   set(CMAKE_POLICY_DEFAULT_CMP0048 NEW) # project() command manages VERSION variables
   set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # Honor visibility properties for all target types
+
+  find_package(Boost REQUIRED)
+  # Define Boost::headers target if missing because libtorrent needs it
+  if(NOT TARGET Boost::headers)
+    add_library(Boost::headers INTERFACE IMPORTED)
+    target_include_directories(Boost::headers INTERFACE ${Boost_INCLUDE_DIRS})
+  endif()
 endif()
 
 add_subdirectory(third_party)

--- a/cmd/dev/CMakeLists.txt
+++ b/cmd/dev/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(absl REQUIRED)
 find_package(Boost REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(gRPC REQUIRED)
-find_package(LibtorrentRasterbar REQUIRED)
 find_package(magic_enum REQUIRED)
 find_package(Protobuf REQUIRED)
 
@@ -65,9 +64,7 @@ add_executable(scan_txs scan_txs.cpp)
 target_link_libraries(scan_txs PRIVATE silkworm_node CLI11::CLI11 absl::time)
 
 add_executable(snapshots snapshots.cpp)
-target_link_libraries(
-  snapshots PRIVATE silkworm_node cmd_common LibtorrentRasterbar::torrent-rasterbar magic_enum::magic_enum
-)
+target_link_libraries(snapshots PRIVATE silkworm_node cmd_common torrent-rasterbar magic_enum::magic_enum)
 
 add_executable(toolbox toolbox.cpp)
 target_link_libraries(toolbox PRIVATE silkworm_node CLI11::CLI11 magic_enum::magic_enum)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -9,7 +9,6 @@ gmp/6.2.1
 grpc/1.48.0
 gtest/1.12.1
 jwt-cpp/0.6.0
-libtorrent/2.0.8
 magic_enum/0.8.2
 mimalloc/2.0.9
 ms-gsl/4.0.0

--- a/silkworm/node/CMakeLists.txt
+++ b/silkworm/node/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(asio-grpc REQUIRED)
 find_package(Boost REQUIRED container thread)
 find_package(nlohmann_json REQUIRED)
 find_package(gRPC REQUIRED)
-find_package(LibtorrentRasterbar REQUIRED)
 find_package(magic_enum REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(roaring REQUIRED)
@@ -102,7 +101,7 @@ set(SILKWORM_NODE_PUBLIC_LIBS
     nlohmann_json::nlohmann_json
     protobuf::libprotobuf
     roaring::roaring
-    LibtorrentRasterbar::torrent-rasterbar
+    torrent-rasterbar
 )
 
 # cmake-format: off

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -164,6 +164,10 @@ if(NOT SILKWORM_CORE_ONLY)
   target_include_directories(mdbx-static INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/libmdbx)
   target_compile_definitions(mdbx-static PUBLIC CONSTEXPR_ASSERT=assert)
 
+  # libtorrent
+  add_subdirectory(libtorrent)
+  target_compile_options(torrent-rasterbar PRIVATE -w)
+
   add_subdirectory(cbor-cpp)
   add_subdirectory(glaze)
 endif()


### PR DESCRIPTION
This partially reverts PR #1199 because apparently the version of libtorrent from Conan is causing a failure in [linux-clang-address-sanitizer](https://app.circleci.com/pipelines/github/torquem-ch/silkworm/7660/workflows/e8cbfd41-c549-4efc-9a04-f4ad0f8ad195/jobs/33993).