### PR TITLE
rpcdaemon: use shared chaindata MDBX env in embedded execution

### DIFF
--- a/silkworm/silkrpc/core/remote_state.cpp
+++ b/silkworm/silkrpc/core/remote_state.cpp
@@ -17,6 +17,7 @@
 #include "remote_state.hpp"
 
 #include <future>
+#include <stdexcept>
 #include <unordered_map>
 #include <utility>
 
@@ -127,7 +128,7 @@ std::optional<silkworm::BlockHeader> RemoteState::read_header(uint64_t block_num
     SILK_DEBUG << "RemoteState::read_header block_number=" << block_number << " block_hash=" << block_hash;
     try {
         std::future<std::optional<silkworm::BlockHeader>> result{boost::asio::co_spawn(executor_, async_state_.read_header(block_number, block_hash), boost::asio::use_future)};
-        const auto optional_header{result.get()};
+        auto optional_header{result.get()};
         SILK_DEBUG << "RemoteState::read_header block_number=" << block_number << " block_hash=" << block_hash;
         return optional_header;
     } catch (const std::exception& e) {
@@ -162,18 +163,15 @@ std::optional<intx::uint256> RemoteState::total_difficulty(uint64_t block_number
 }
 
 evmc::bytes32 RemoteState::state_root_hash() const {
-    SILK_DEBUG << "RemoteState::state_root_hash";
-    return evmc::bytes32{};
+    throw std::logic_error{"RemoteState::state_root_hash not yet implemented"};
 }
 
 uint64_t RemoteState::current_canonical_block() const {
-    SILK_DEBUG << "RemoteState::current_canonical_block";
-    return 0;
+    throw std::logic_error{"RemoteState::current_canonical_block not yet implemented"};
 }
 
-std::optional<evmc::bytes32> RemoteState::canonical_hash(uint64_t block_number) const {
-    SILK_DEBUG << "RemoteState::canonical_hash block_number=" << block_number;
-    return std::nullopt;
+std::optional<evmc::bytes32> RemoteState::canonical_hash(uint64_t /*block_number*/) const {
+    throw std::logic_error{"RemoteState::canonical_hash not yet implemented"};
 }
 
 }  // namespace silkworm::rpc::state

--- a/silkworm/silkrpc/core/remote_state_test.cpp
+++ b/silkworm/silkrpc/core/remote_state_test.cpp
@@ -208,8 +208,7 @@ TEST_CASE("async remote buffer", "[silkrpc][core][remote_buffer]") {
         const uint64_t block_number = 1'000'000;
         boost::asio::any_io_executor current_executor = io_context.get_executor();
         RemoteState remote_state(current_executor, db_reader, block_number);
-        auto canonical_block = remote_state.current_canonical_block();
-        CHECK(canonical_block == 0);
+        CHECK_THROWS_AS(remote_state.current_canonical_block(), std::logic_error);
         io_context.stop();
         io_context_thread.join();
     }
@@ -223,8 +222,7 @@ TEST_CASE("async remote buffer", "[silkrpc][core][remote_buffer]") {
         const uint64_t block_number = 1'000'000;
         boost::asio::any_io_executor current_executor = io_context.get_executor();
         RemoteState remote_state(current_executor, db_reader, block_number);
-        auto canonical_block = remote_state.canonical_hash(block_number);
-        CHECK(canonical_block == std::nullopt);
+        CHECK_THROWS_AS(remote_state.canonical_hash(block_number), std::logic_error);
         io_context.stop();
         io_context_thread.join();
     }
@@ -238,8 +236,7 @@ TEST_CASE("async remote buffer", "[silkrpc][core][remote_buffer]") {
         const uint64_t block_number = 1'000'000;
         boost::asio::any_io_executor current_executor = io_context.get_executor();
         RemoteState remote_state(current_executor, db_reader, block_number);
-        auto root_hash = remote_state.state_root_hash();
-        CHECK(root_hash == evmc::bytes32{});
+        CHECK_THROWS_AS(remote_state.state_root_hash(), std::logic_error);
         io_context.stop();
         io_context_thread.join();
     }

--- a/silkworm/silkrpc/daemon.hpp
+++ b/silkworm/silkrpc/daemon.hpp
@@ -48,7 +48,7 @@ class Daemon {
   public:
     static int run(const DaemonSettings& settings, const DaemonInfo& info = {});
 
-    explicit Daemon(DaemonSettings settings);
+    explicit Daemon(DaemonSettings settings, std::shared_ptr<mdbx::env_managed> chaindata_env = nullptr);
 
     Daemon(const Daemon&) = delete;
     Daemon& operator=(const Daemon&) = delete;

--- a/silkworm/silkrpc/ethdb/file/local_cursor.cpp
+++ b/silkworm/silkrpc/ethdb/file/local_cursor.cpp
@@ -42,13 +42,12 @@ boost::asio::awaitable<KeyValue> LocalCursor::seek(ByteView key) {
     SILK_DEBUG << "LocalCursor::seek result: " << db::detail::dump_mdbx_result(result);
 
     if (result) {
-        SILK_DEBUG << "LocalCursor::seek found: "
-                   << " key: " << key << " value: " << byte_view_of_string(result.value.as_string());
+        SILK_DEBUG << "LocalCursor::seek found: key: " << key << " value: " << byte_view_of_string(result.value.as_string());
         co_return KeyValue{bytes_of_string(result.key.as_string()), bytes_of_string(result.value.as_string())};
     } else {
-        SILK_ERROR << "LocalCursor::seek !result key: " << key;
+        SILK_DEBUG << "LocalCursor::seek not found key: " << key;
+        co_return KeyValue{};
     }
-    co_return KeyValue{};
 }
 
 boost::asio::awaitable<KeyValue> LocalCursor::seek_exact(ByteView key) {

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -25,7 +25,7 @@
 namespace silkworm::chainsync {
 
 Sync::Sync(boost::asio::io_context& io_context,
-           mdbx::env& chaindata_env,
+           mdbx::env_managed& chaindata_env,
            execution::Client& execution,
            const std::shared_ptr<silkworm::sentry::api::api_common::SentryClient>& sentry_client,
            const ChainConfig& config,
@@ -50,7 +50,13 @@ Sync::Sync(boost::asio::io_context& io_context,
             .num_workers = 1,  // single-client so just one worker should be OK
             .jwt_secret_file = rpc_settings.jwt_secret_file,
         };
-        engine_rpc_server_ = std::make_unique<rpc::Daemon>(engine_rpc_settings);
+        // TODO(canepat) replace customized std::shared_ptr by using ::mdbx::env instead of
+        //  std::shared_ptr<::mdbx::env_managed> in silkrpc classes (e.g. LocalState)
+        struct env_custom_deleter {
+            void operator()(mdbx::env_managed*) {}
+        };
+        std::shared_ptr<mdbx::env_managed> env_ptr{&chaindata_env, env_custom_deleter{}};
+        engine_rpc_server_ = std::make_unique<rpc::Daemon>(engine_rpc_settings, env_ptr);
 
         // Create the synchronization algorithm based on Casper + LMD-GHOST, i.e. PoS
         auto pos_sync = std::make_unique<PoSSync>(block_exchange_, execution);

--- a/silkworm/sync/sync.hpp
+++ b/silkworm/sync/sync.hpp
@@ -46,7 +46,7 @@ struct EngineRpcSettings {
 class Sync {
   public:
     Sync(boost::asio::io_context& io_context,
-         mdbx::env& chaindata_env,
+         mdbx::env_managed& chaindata_env,
          execution::Client& execution,
          const std::shared_ptr<silkworm::sentry::api::api_common::SentryClient>& sentry_client,
          const ChainConfig& config,


### PR DESCRIPTION
rpcdaemon: throw in unimplemented methods