### PR TITLE
windows: raise tests file descriptors limit

### DIFF
--- a/cmd/test/unit_test.cpp
+++ b/cmd/test/unit_test.cpp
@@ -14,16 +14,5 @@
    limitations under the License.
 */
 
-#include <cstdio>
-
-#define CATCH_CONFIG_RUNNER
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
-
-int main(int argc, char* argv[]) {
-#ifdef _WIN32
-    _setmaxstdio(1024);
-#endif
-
-    Catch::Session session;
-    return session.run(argc, argv);
-}

--- a/cmd/test/unit_test.cpp
+++ b/cmd/test/unit_test.cpp
@@ -14,5 +14,16 @@
    limitations under the License.
 */
 
-#define CATCH_CONFIG_MAIN
+#include <cstdio>
+
+#define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+
+int main(int argc, char* argv[]) {
+#ifdef _WIN32
+    _setmaxstdio(1024);
+#endif
+
+    Catch::Session session;
+    return session.run(argc, argv);
+}

--- a/silkworm/node/backend/remote/backend_kv_server_test.cpp
+++ b/silkworm/node/backend/remote/backend_kv_server_test.cpp
@@ -895,7 +895,10 @@ TEST_CASE("BackEndKvServer E2E: trigger server-side write error", "[silkworm][no
 TEST_CASE("BackEndKvServer E2E: Tx max simultaneous readers exceeded", "[silkworm][node][rpc]") {
     // This check can be improved in Catch2 version 3.3.0 where SKIP is available
     if (os::max_file_descriptors() < 1024) {
-        FAIL("insufficient number of process file descriptors, increase to 1024 at least");
+        bool ok = os::set_max_file_descriptors(1024);
+        if (!ok) {
+            FAIL("insufficient number of process file descriptors, increase to 1024 has failed");
+        }
     }
 
     BackEndKvE2eTest test;


### PR DESCRIPTION
backend_kv_server_test.cpp(898): FAILED:
explicitly with message:
  insufficient number of process file descriptors, increase to 1024 at least
