### PR TITLE
node: extract header/body/transaction data from snapshots

### DIFF
--- a/silkworm/node/huffman/decompressor.hpp
+++ b/silkworm/node/huffman/decompressor.hpp
@@ -243,10 +243,15 @@ class Decompressor {
         return compressed_file_->last_write_time();
     }
 
+    [[nodiscard]] bool is_open() const { return bool(compressed_file_); }
+
     void open();
 
     //! Read the data stream eagerly applying the specified function, expected read in sequential order
     bool read_ahead(ReadAheadFuncRef fn);
+
+    //! Get an iterator to the compressed data
+    [[nodiscard]] Iterator make_iterator() const { return Iterator{this}; }
 
     void close();
 

--- a/silkworm/node/snapshot/index_test.cpp
+++ b/silkworm/node/snapshot/index_test.cpp
@@ -31,6 +31,14 @@ TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
     CHECK_THROWS_AS(header_index.build(), std::logic_error);
 }
 
+TEST_CASE("BodyIndex::build OK", "[silkworm][snapshot][index]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile valid_body_snapshot{};
+    test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};  // necessary to tweak the block numbers
+    BodyIndex body_index{body_snapshot_path};
+    CHECK_NOTHROW(body_index.build());
+}
+
 TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][index]") {
     test::SetLogVerbosityGuard guard{log::Level::kNone};
     constexpr const char* kBodiesSnapshotFileName{"v1-014500-015000-bodies.seg"};

--- a/silkworm/node/snapshot/snapshot.cpp
+++ b/silkworm/node/snapshot/snapshot.cpp
@@ -19,6 +19,8 @@
 #include <magic_enum.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/infra/common/decoding_exception.hpp>
+#include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/snapshot/path.hpp>
 
@@ -60,6 +62,19 @@ bool Snapshot::for_each_item(const Snapshot::WordItemFunc& fn) {
     });
 }
 
+std::optional<Snapshot::WordItem> Snapshot::next_item(uint64_t offset) const {
+    auto data_iterator = decoder_.make_iterator();
+    data_iterator.reset(offset);
+
+    std::optional<WordItem> item;
+    if (!data_iterator.has_next()) {
+        return item;
+    }
+    item = WordItem{};
+    item->offset = data_iterator.next(item->value);
+    return item;
+}
+
 void Snapshot::close() {
     close_segment();
     close_index();
@@ -75,21 +90,65 @@ SnapshotPath HeaderSnapshot::path() const {
 }
 
 bool HeaderSnapshot::for_each_header(const Walker& walker) {
-    return for_each_item([walker](const WordItem& item) -> bool {
-        ByteView encoded_header{item.value.data() + 1, item.value.length() - 1};
-        SILK_DEBUG << "for_each_header encoded_header: " << to_hex(encoded_header);
+    return for_each_item([this, walker](const WordItem& item) -> bool {
         BlockHeader header;
-        const auto decode_result = rlp::decode(encoded_header, header);
-        if (!decode_result) {
-            SILK_DEBUG << "for_each_header decode_result error: " << magic_enum::enum_name(decode_result.error());
+        const auto decode_ok = decode_header(item, header);
+        if (!decode_ok) {
             return false;
         }
-        SILK_DEBUG << "for_each_header header number: " << header.number << " hash:" << to_hex(header.hash());
         return walker(&header);
     });
 }
 
+std::optional<BlockHeader> HeaderSnapshot::next_header(uint64_t offset) const {
+    const auto item = next_item(offset);
+    std::optional<BlockHeader> header;
+    if (!item) {
+        return header;
+    }
+    header = BlockHeader{};
+    const auto decode_ok = decode_header(*item, *header);
+    if (!decode_ok) {
+        return {};
+    }
+    return header;
+}
+
+std::optional<BlockHeader> HeaderSnapshot::header_by_hash(const Hash& block_hash) const {
+    // First, get the header ordinal position in snapshot by using block hash as MPHF index
+    const auto block_header_position = idx_header_hash_->lookup(block_hash);
+    // Then, get the header offset in snapshot by using ordinal lookup
+    const auto block_header_offset = idx_header_hash_->ordinal_lookup(block_header_position);
+    // Finally, read the next header at specified offset
+    return next_header(block_header_offset);
+}
+
+std::optional<BlockHeader> HeaderSnapshot::header_by_number(BlockNum block_height) const {
+    // First, calculate the header ordinal position relative to the first block height within snapshot
+    const auto block_header_position = block_height - idx_header_hash_->base_data_id();
+    // Then, get the header offset in snapshot by using ordinal lookup
+    const auto block_header_offset = idx_header_hash_->ordinal_lookup(block_header_position);
+    // Finally, read the next header at specified offset
+    return next_header(block_header_offset);
+}
+
+bool HeaderSnapshot::decode_header(const Snapshot::WordItem& item, BlockHeader& header) const {
+    // Skip first byte in data as it is encoding start tag.
+    ByteView encoded_header{item.value.data() + 1, item.value.length() - 1};
+    SILK_TRACE << "decode_header number: " << (block_from_ + item.position) << " encoded_header: " << to_hex(encoded_header);
+    const auto decode_result = rlp::decode(encoded_header, header);
+    if (!decode_result) {
+        SILK_TRACE << "decode_header number: " << (block_from_ + item.position) << " error: " << magic_enum::enum_name(decode_result.error());
+        return false;
+    }
+    SILKWORM_ASSERT(header.number == (block_from_ + item.position));
+    SILK_TRACE << "decode_header header number: " << header.number << " hash:" << to_hex(header.hash());
+    return true;
+}
+
 void HeaderSnapshot::reopen_index() {
+    ensure(decoder_.is_open(), "HeaderSnapshot::reopen_index segment not open: call reopen_segment");
+
     close_index();
 
     const auto header_index_path = path().index_file();
@@ -112,11 +171,9 @@ SnapshotPath BodySnapshot::path() const {
 
 bool BodySnapshot::for_each_body(const Walker& walker) {
     return for_each_item([&](const WordItem& item) -> bool {
+        db::detail::BlockBodyForStorage body;
+        success_or_throw(decode_body(item, body));
         const BlockNum number = block_from_ + item.position;
-        ByteView body_rlp{item.value.data(), item.value.length()};
-        SILK_DEBUG << "for_each_body number: " << number << " body_rlp: " << to_hex(body_rlp);
-        db::detail::BlockBodyForStorage body = db::detail::decode_stored_block_body(body_rlp);
-        SILK_DEBUG << "for_each_body number: " << number << " txn_count: " << body.txn_count << " base_txn_id:" << body.base_txn_id;
         return walker(number, &body);
     });
 }
@@ -124,7 +181,7 @@ bool BodySnapshot::for_each_body(const Walker& walker) {
 std::pair<uint64_t, uint64_t> BodySnapshot::compute_txs_amount() {
     uint64_t first_tx_id{0}, last_tx_id{0}, last_txs_amount{0};
 
-    const bool read_ok = for_each_body([&](BlockNum number, const db::detail::BlockBodyForStorage* body) {
+    const bool read_ok = for_each_body([&](BlockNum number, const StoredBlockBody* body) {
         if (number == block_from_) {
             first_tx_id = body->base_txn_id;
         }
@@ -142,7 +199,40 @@ std::pair<uint64_t, uint64_t> BodySnapshot::compute_txs_amount() {
     return {first_tx_id, last_tx_id + last_txs_amount - first_tx_id};
 }
 
+std::optional<StoredBlockBody> BodySnapshot::next_body(uint64_t offset) const {
+    const auto item = next_item(offset);
+    std::optional<StoredBlockBody> stored_body;
+    if (!item) {
+        return stored_body;
+    }
+    stored_body = StoredBlockBody{};
+    const auto decode_ok = decode_body(*item, *stored_body);
+    if (!decode_ok) {
+        return {};
+    }
+    return stored_body;
+}
+
+std::optional<StoredBlockBody> BodySnapshot::stored_body_by_number(BlockNum block_height) const {
+    // First, calculate the body ordinal position relative to the first block height within snapshot
+    const auto block_body_position = block_height - idx_body_number_->base_data_id();
+    // Then, get the body offset in snapshot by using ordinal lookup
+    const auto block_body_offset = idx_body_number_->ordinal_lookup(block_body_position);
+    // Finally, read the next body at specified offset
+    return next_body(block_body_offset);
+}
+
+DecodingResult BodySnapshot::decode_body(const Snapshot::WordItem& item, StoredBlockBody& body) const {
+    ByteView body_rlp{item.value.data(), item.value.length()};
+    SILK_TRACE << "decode_body number: " << (block_from_ + item.position) << " body_rlp: " << to_hex(body_rlp);
+    const auto result = db::detail::decode_stored_block_body(body_rlp, body);
+    SILK_TRACE << "decode_body number: " << (block_from_ + item.position) << " txn_count: " << body.txn_count << " base_txn_id:" << body.base_txn_id;
+    return result;
+}
+
 void BodySnapshot::reopen_index() {
+    ensure(decoder_.is_open(), "BodySnapshot::reopen_index segment not open: call reopen_segment");
+
     close_index();
 
     const auto body_index_path = path().index_file();
@@ -163,7 +253,49 @@ SnapshotPath TransactionSnapshot::path() const {
     return SnapshotPath::from(path_.parent_path(), kSnapshotV1, block_from_, block_to_, SnapshotType::transactions);
 }
 
+[[nodiscard]] std::optional<Transaction> TransactionSnapshot::next_txn(uint64_t offset) const {
+    const auto item = next_item(offset);
+    std::optional<Transaction> transaction;
+    if (!item) {
+        return transaction;
+    }
+    transaction = Transaction{};
+    const auto decode_ok = decode_txn(*item, *transaction);
+    if (!decode_ok) {
+        return {};
+    }
+    return transaction;
+}
+
+std::optional<Transaction> TransactionSnapshot::txn_by_hash(const Hash& block_hash) const {
+    // First, get the transaction ordinal position in snapshot by using block hash as MPHF index
+    const auto txn_position = idx_txn_hash_->lookup(block_hash);
+    // Then, get the transaction offset in snapshot by using ordinal lookup
+    const auto txn_offset = idx_txn_hash_->ordinal_lookup(txn_position);
+    // Finally, read the next transaction at specified offset
+    return next_txn(txn_offset);
+}
+
+std::optional<Transaction> TransactionSnapshot::txn_by_id(uint64_t txn_id) const {
+    // First, calculate the transaction ordinal position relative to the first block height within snapshot
+    const auto txn_position = txn_id - idx_txn_hash_->base_data_id();
+    // Then, get the transaction offset in snapshot by using ordinal lookup
+    const auto txn_offset = idx_txn_hash_->ordinal_lookup(txn_position);
+    // Finally, read the next transaction at specified offset
+    return next_txn(txn_offset);
+}
+
+DecodingResult TransactionSnapshot::decode_txn(const Snapshot::WordItem& item, Transaction& tx) const {
+    ByteView tx_rlp{item.value.data(), item.value.length()};
+    SILK_TRACE << "decode_txn number: " << (block_from_ + item.position) << " tx_rlp: " << to_hex(tx_rlp);
+    const auto result = rlp::decode(tx_rlp, tx);
+    SILK_TRACE << "decode_txn number: " << (block_from_ + item.position);
+    return result;
+}
+
 void TransactionSnapshot::reopen_index() {
+    ensure(decoder_.is_open(), "TransactionSnapshot::reopen_index segment not open: call reopen_segment");
+
     close_index();
 
     const auto tx_hash_index_path = path().index_file_for_type(SnapshotType::transactions);

--- a/silkworm/node/snapshot/snapshot.hpp
+++ b/silkworm/node/snapshot/snapshot.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -62,6 +63,7 @@ class Snapshot {
     };
     using WordItemFunc = std::function<bool(WordItem&)>;
     bool for_each_item(const WordItemFunc& fn);
+    [[nodiscard]] std::optional<WordItem> next_item(uint64_t offset) const;
 
     void close();
 
@@ -86,16 +88,24 @@ class HeaderSnapshot : public Snapshot {
 
     using Walker = std::function<bool(const BlockHeader* header)>;
     bool for_each_header(const Walker& walker);
+    [[nodiscard]] std::optional<BlockHeader> next_header(uint64_t offset) const;
+
+    [[nodiscard]] std::optional<BlockHeader> header_by_hash(const Hash& block_hash) const;
+    [[nodiscard]] std::optional<BlockHeader> header_by_number(BlockNum block_height) const;
 
     void reopen_index() override;
 
   protected:
+    bool decode_header(const Snapshot::WordItem& item, BlockHeader& header) const;
+
     void close_index() override;
 
   private:
     //! Index header_hash -> headers_segment_offset
     std::unique_ptr<succinct::RecSplitIndex> idx_header_hash_;
 };
+
+using StoredBlockBody = db::detail::BlockBodyForStorage;
 
 class BodySnapshot : public Snapshot {
   public:
@@ -106,14 +116,19 @@ class BodySnapshot : public Snapshot {
     [[nodiscard]] SnapshotPath path() const override;
     [[nodiscard]] const succinct::RecSplitIndex* idx_body_number() const { return idx_body_number_.get(); }
 
-    using Walker = std::function<bool(BlockNum number, const db::detail::BlockBodyForStorage* body)>;
+    using Walker = std::function<bool(BlockNum number, const StoredBlockBody* body)>;
     bool for_each_body(const Walker& walker);
+    [[nodiscard]] std::optional<StoredBlockBody> next_body(uint64_t offset) const;
 
     std::pair<uint64_t, uint64_t> compute_txs_amount();
+
+    [[nodiscard]] std::optional<StoredBlockBody> stored_body_by_number(BlockNum block_height) const;
 
     void reopen_index() override;
 
   protected:
+    DecodingResult decode_body(const Snapshot::WordItem& item, StoredBlockBody& body) const;
+
     void close_index() override;
 
   private:
@@ -131,9 +146,16 @@ class TransactionSnapshot : public Snapshot {
     [[nodiscard]] const succinct::RecSplitIndex* idx_txn_hash() const { return idx_txn_hash_.get(); }
     [[nodiscard]] const succinct::RecSplitIndex* idx_txn_hash_2_block() const { return idx_txn_hash_2_block_.get(); }
 
+    [[nodiscard]] std::optional<Transaction> next_txn(uint64_t offset) const;
+
+    [[nodiscard]] std::optional<Transaction> txn_by_hash(const Hash& block_hash) const;
+    [[nodiscard]] std::optional<Transaction> txn_by_id(uint64_t txn_id) const;
+
     void reopen_index() override;
 
   protected:
+    DecodingResult decode_txn(const Snapshot::WordItem& item, Transaction& tx) const;
+
     void close_index() override;
 
   private:

--- a/silkworm/node/snapshot/snapshot_test.cpp
+++ b/silkworm/node/snapshot/snapshot_test.cpp
@@ -93,4 +93,22 @@ TEST_CASE("Snapshot::close", "[silkworm][snapshot][snapshot]") {
     CHECK_NOTHROW(tmp_snapshot.close());
 }
 
+TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][snapshot][index]") {
+    test::SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile valid_body_snapshot{};
+    test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};  // necessary to tweak the block numbers
+    BodyIndex body_index{body_snapshot_path};
+    CHECK_NOTHROW(body_index.build());
+
+    BodySnapshot body_snapshot{body_snapshot_path.path(), body_snapshot_path.block_from(), body_snapshot_path.block_to()};
+    body_snapshot.reopen_segment();
+    body_snapshot.reopen_index();
+    const auto body_for_storage = body_snapshot.stored_body_by_number(1'500'013);
+    CHECK(body_for_storage);
+    if (body_for_storage) {
+        CHECK(body_for_storage->base_txn_id == 7'341'273);
+        CHECK(body_for_storage->txn_count == 1);
+    }
+}
+
 }  // namespace silkworm::snapshot

--- a/silkworm/node/test/snapshots.hpp
+++ b/silkworm/node/test/snapshots.hpp
@@ -173,7 +173,12 @@ class HelloWorldSnapshotFile : public TemporarySnapshotFile {
     };
 };
 
+// SampleBodySnapshotFile + SampleBodySnapshotFile + SampleTransactionSnapshotFile
+// Sample snapshot files for mainnet block 1'500'013 containing 1 tx: https://etherscan.io/block/1500013
+
 //! Sample Bodies snapshot file: it contains body for block 1'500'013 on mainnet
+//! The main simplification here is that this snapshot contains 14 repeated block bodies: the first
+//! 13 are fillers (all equal to 1'500'013 for simplicity) just for positioning the 14-th correctly
 class SampleBodySnapshotFile : public TemporarySnapshotFile {
   public:
     inline static constexpr const char* kBodiesSnapshotFileName{"v1-001500-001500-bodies.seg"};
@@ -213,29 +218,31 @@ class SampleTransactionSnapshotFile : public TemporarySnapshotFile {
           ) {}
 };
 
-class HeaderSnapshotPath : public SnapshotPath {
+class SampleSnapshotPath : public SnapshotPath {
   public:
-    HeaderSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
-        : SnapshotPath(std::move(path), /*.version=*/1, from, to, SnapshotType::headers) {}
+    SampleSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to, SnapshotType type)
+        : SnapshotPath(std::move(path), /*.version=*/1, from, to, type) {}
 };
 
-class BodySnapshotPath : public SnapshotPath {
+//! Sample Header snapshot path injecting custom from/to blocks to override 500'000 block range
+class SampleHeaderSnapshotPath : public SampleSnapshotPath {
   public:
-    BodySnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
-        : SnapshotPath(std::move(path), /*.version=*/1, from, to, SnapshotType::bodies) {}
+    explicit SampleHeaderSnapshotPath(std::filesystem::path path)
+        : SampleSnapshotPath(std::move(path), 1'500'000, 1'500'014, SnapshotType::headers) {}
 };
 
-class TransactionSnapshotPath : public SnapshotPath {
+//! Sample Body snapshot path injecting custom from/to blocks to override 500'000 block range
+class SampleBodySnapshotPath : public SampleSnapshotPath {
   public:
-    TransactionSnapshotPath(std::filesystem::path path, BlockNum from, BlockNum to)
-        : SnapshotPath(std::move(path), /*.version=*/1, from, to, SnapshotType::transactions) {}
+    explicit SampleBodySnapshotPath(std::filesystem::path path)
+        : SampleSnapshotPath(std::move(path), 1'500'000, 1'500'014, SnapshotType::bodies) {}
 };
 
 //! Sample Transaction snapshot path injecting custom from/to blocks to override 500'000 block range
-class SampleTransactionSnapshotPath : public test::TransactionSnapshotPath {
+class SampleTransactionSnapshotPath : public SampleSnapshotPath {
   public:
     explicit SampleTransactionSnapshotPath(std::filesystem::path path)
-        : test::TransactionSnapshotPath(std::move(path), 1'500'000, 1'500'014) {}
+        : SampleSnapshotPath(std::move(path), 1'500'000, 1'500'014, SnapshotType::transactions) {}
 };
 
 }  // namespace silkworm::test


### PR DESCRIPTION
- expose iterator from Huffman decompressor
- extract header/body/transaction data from snapshots
- add unit tests for body snapshot and index