### PR TITLE
core: erigon names for tx types

### DIFF
--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -205,7 +205,7 @@ Transaction StateTransition::get_transaction(const ExpectedSubState& expected_su
         txn.max_fee_per_gas = intx::from_string<intx::uint256>(j_transaction.at("gasPrice").get<std::string>());
         txn.max_priority_fee_per_gas = intx::from_string<intx::uint256>(j_transaction.at("gasPrice").get<std::string>());
     } else {
-        txn.type = TransactionType::kEip1559;
+        txn.type = TransactionType::kDynamicFee;
         txn.max_fee_per_gas = intx::from_string<intx::uint256>(j_transaction.at("maxFeePerGas").get<std::string>());
         txn.max_priority_fee_per_gas = intx::from_string<intx::uint256>(j_transaction.at("maxPriorityFeePerGas").get<std::string>());
     }
@@ -248,7 +248,7 @@ Transaction StateTransition::get_transaction(const ExpectedSubState& expected_su
         }
 
         if (txn.type == TransactionType::kLegacy) {
-            txn.type = TransactionType::kEip2930;
+            txn.type = TransactionType::kAccessList;
         }
     }
 

--- a/silkworm/core/common/test_util.cpp
+++ b/silkworm/core/common/test_util.cpp
@@ -37,7 +37,7 @@ std::vector<Transaction> sample_transactions() {
     transactions[0].s =
         intx::from_string<intx::uint256>("0x1fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804");
 
-    transactions[1].type = TransactionType::kEip1559;
+    transactions[1].type = TransactionType::kDynamicFee;
     transactions[1].nonce = 1;
     transactions[1].max_priority_fee_per_gas = 5 * kGiga;
     transactions[1].max_fee_per_gas = 30 * kGiga;
@@ -74,7 +74,7 @@ std::vector<Receipt> sample_receipts() {
         },
     };
 
-    receipts[1].type = TransactionType::kEip1559;
+    receipts[1].type = TransactionType::kDynamicFee;
     receipts[1].success = true;
     receipts[1].cumulative_gas_used = 0xbeadd0;
     receipts[1].logs = {};

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Execute two blocks") {
 
     static constexpr auto kEncoder = [](Bytes& to, const Receipt& r) { rlp::encode(to, r); };
     std::vector<Receipt> receipts{
-        {TransactionType::kEip1559, true, block.header.gas_used, {}, {}},
+        {TransactionType::kDynamicFee, true, block.header.gas_used, {}, {}},
     };
     block.header.receipts_root = trie::root_hash(receipts, kEncoder);
 
@@ -58,7 +58,7 @@ TEST_CASE("Execute two blocks") {
     block.transactions.resize(1);
     block.transactions[0].data = deployment_code;
     block.transactions[0].gas_limit = block.header.gas_limit;
-    block.transactions[0].type = TransactionType::kEip1559;
+    block.transactions[0].type = TransactionType::kDynamicFee;
     block.transactions[0].max_priority_fee_per_gas = 0;
     block.transactions[0].max_fee_per_gas = 20 * kGiga;
 

--- a/silkworm/core/protocol/intrinsic_gas_test.cpp
+++ b/silkworm/core/protocol/intrinsic_gas_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("EIP-2930 intrinsic gas") {
     };
 
     UnsignedTransaction txn{
-        .type = TransactionType::kEip2930,
+        .type = TransactionType::kAccessList,
         .chain_id = 5,
         .nonce = 7,
         .max_priority_fee_per_gas = 30000000000,

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -29,9 +29,9 @@ namespace silkworm::protocol {
 bool transaction_type_is_supported(TransactionType type, evmc_revision rev) {
     static constexpr evmc_revision kMinRevisionByType[]{
         EVMC_FRONTIER,  // kLegacy
-        EVMC_BERLIN,    // kEip2930
-        EVMC_LONDON,    // kEip1559
-        EVMC_CANCUN,    // kEip4844
+        EVMC_BERLIN,    // kAccessList
+        EVMC_LONDON,    // kDynamicFee
+        EVMC_CANCUN,    // kBlob
     };
     const auto i{static_cast<std::size_t>(type)};
     return i < std::size(kMinRevisionByType) && rev >= kMinRevisionByType[i];
@@ -91,7 +91,7 @@ ValidationResult pre_validate_transaction(const Transaction& txn, const evmc_rev
     }
 
     // EIP-4844: Shard Blob Transactions
-    if (txn.type == TransactionType::kEip4844) {
+    if (txn.type == TransactionType::kBlob) {
         if (txn.blob_versioned_hashes.empty()) {
             return ValidationResult::kNoBlobs;
         }

--- a/silkworm/core/protocol/validation_test.cpp
+++ b/silkworm/core/protocol/validation_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Validate transaction types") {
     CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas, data_gas_price) ==
           ValidationResult::kUnsupportedTransactionType);
 
-    txn.type = TransactionType::kEip2930;
+    txn.type = TransactionType::kAccessList;
     CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, 1, base_fee_per_gas, data_gas_price) ==
           ValidationResult::kUnsupportedTransactionType);
     CHECK(pre_validate_transaction(txn, EVMC_BERLIN, 1, base_fee_per_gas, data_gas_price) !=
@@ -49,7 +49,7 @@ TEST_CASE("Validate transaction types") {
     CHECK(pre_validate_transaction(txn, EVMC_LONDON, 1, base_fee_per_gas, data_gas_price) !=
           ValidationResult::kUnsupportedTransactionType);
 
-    txn.type = TransactionType::kEip1559;
+    txn.type = TransactionType::kDynamicFee;
     CHECK(pre_validate_transaction(txn, EVMC_ISTANBUL, 1, base_fee_per_gas, data_gas_price) ==
           ValidationResult::kUnsupportedTransactionType);
     CHECK(pre_validate_transaction(txn, EVMC_BERLIN, 1, base_fee_per_gas, data_gas_price) ==
@@ -63,7 +63,7 @@ TEST_CASE("Validate max_fee_per_gas") {
     const std::optional<intx::uint256> data_gas_price{std::nullopt};
 
     Transaction txn;
-    txn.type = TransactionType::kEip1559;
+    txn.type = TransactionType::kDynamicFee;
 
     txn.max_priority_fee_per_gas = 500'000'000;
     txn.max_fee_per_gas = 700'000'000;

--- a/silkworm/core/types/block_test.cpp
+++ b/silkworm/core/types/block_test.cpp
@@ -77,7 +77,7 @@ TEST_CASE("BlockBody RLP 2") {
     body.transactions[0].r = 0x48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353_u256;
     body.transactions[0].s = 0x1fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804_u256;
 
-    body.transactions[1].type = TransactionType::kEip1559;
+    body.transactions[1].type = TransactionType::kDynamicFee;
     body.transactions[1].nonce = 1;
     body.transactions[1].max_priority_fee_per_gas = 5 * kGiga;
     body.transactions[1].max_fee_per_gas = 30 * kGiga;
@@ -168,7 +168,7 @@ TEST_CASE("EIP-2718 Block RLP") {
     CHECK(block.transactions[0].type == TransactionType::kLegacy);
     CHECK(block.transactions[0].access_list.empty());
 
-    CHECK(block.transactions[1].type == TransactionType::kEip2930);
+    CHECK(block.transactions[1].type == TransactionType::kAccessList);
     CHECK(block.transactions[1].access_list.size() == 1);
 }
 

--- a/silkworm/core/types/transaction.cpp
+++ b/silkworm/core/types/transaction.cpp
@@ -78,7 +78,7 @@ namespace rlp {
         }
 
         h.payload_length += length(txn.nonce);
-        if (txn.type == TransactionType::kEip1559 || txn.type == TransactionType::kEip4844) {
+        if (txn.type == TransactionType::kDynamicFee || txn.type == TransactionType::kBlob) {
             h.payload_length += length(txn.max_priority_fee_per_gas);
         }
         h.payload_length += length(txn.max_fee_per_gas);
@@ -89,7 +89,7 @@ namespace rlp {
 
         if (txn.type != TransactionType::kLegacy) {
             h.payload_length += length(txn.access_list);
-            if (txn.type == TransactionType::kEip4844) {
+            if (txn.type == TransactionType::kBlob) {
                 h.payload_length += length(txn.max_fee_per_data_gas);
                 h.payload_length += length(txn.blob_versioned_hashes);
             }
@@ -156,7 +156,7 @@ namespace rlp {
         encode(to, txn.chain_id.value_or(0));
 
         encode(to, txn.nonce);
-        if (txn.type != TransactionType::kEip2930) {
+        if (txn.type != TransactionType::kAccessList) {
             encode(to, txn.max_priority_fee_per_gas);
         }
         encode(to, txn.max_fee_per_gas);
@@ -170,7 +170,7 @@ namespace rlp {
         encode(to, txn.data);
         encode(to, txn.access_list);
 
-        if (txn.type == TransactionType::kEip4844) {
+        if (txn.type == TransactionType::kBlob) {
             encode(to, txn.max_fee_per_data_gas);
             encode(to, txn.blob_versioned_hashes);
         }
@@ -223,9 +223,9 @@ namespace rlp {
     }
 
     static DecodingResult eip2718_decode(ByteView& from, Transaction& to) noexcept {
-        if (to.type != TransactionType::kEip2930 &&
-            to.type != TransactionType::kEip1559 &&
-            to.type != TransactionType::kEip4844) {
+        if (to.type != TransactionType::kAccessList &&
+            to.type != TransactionType::kDynamicFee &&
+            to.type != TransactionType::kBlob) {
             return tl::unexpected{DecodingError::kUnsupportedTransactionType};
         }
 
@@ -247,7 +247,7 @@ namespace rlp {
             return res;
         }
 
-        if (to.type == TransactionType::kEip2930) {
+        if (to.type == TransactionType::kAccessList) {
             to.max_fee_per_gas = to.max_priority_fee_per_gas;
         } else if (DecodingResult res{decode(from, to.max_fee_per_gas, Leftover::kAllow)}; !res) {
             return res;
@@ -271,7 +271,7 @@ namespace rlp {
             return res;
         }
 
-        if (to.type != TransactionType::kEip4844) {
+        if (to.type != TransactionType::kBlob) {
             to.max_fee_per_data_gas = 0;
             to.blob_versioned_hashes.clear();
         } else if (DecodingResult res{decode_items(from, to.max_fee_per_data_gas, to.blob_versioned_hashes)}; !res) {

--- a/silkworm/core/types/transaction.hpp
+++ b/silkworm/core/types/transaction.hpp
@@ -27,7 +27,7 @@
 
 namespace silkworm {
 
-// https://eips.ethereum.org/EIPS/eip-2930
+// EIP-2930: Optional access lists
 struct AccessListEntry {
     evmc::address account{};
     std::vector<evmc::bytes32> storage_keys{};
@@ -39,9 +39,9 @@ struct AccessListEntry {
 // https://github.com/ethereum/eth1.0-specs/tree/master/lists/signature-types
 enum class TransactionType : uint8_t {
     kLegacy = 0,
-    kEip2930 = 1,
-    kEip1559 = 2,
-    kEip4844 = 3,
+    kAccessList = 1,  // EIP-2930
+    kDynamicFee = 2,  // EIP-1559
+    kBlob = 3,        // EIP-4844
 };
 
 struct UnsignedTransaction {

--- a/silkworm/core/types/transaction_test.cpp
+++ b/silkworm/core/types/transaction_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Legacy Transaction RLP") {
 
 TEST_CASE("EIP-2930 Transaction RLP") {
     Transaction txn{
-        {.type = TransactionType::kEip2930,
+        {.type = TransactionType::kAccessList,
          .chain_id = 5,
          .nonce = 7,
          .max_priority_fee_per_gas = 30000000000,
@@ -139,7 +139,7 @@ TEST_CASE("EIP-2930 Transaction RLP") {
 
 TEST_CASE("EIP-1559 Transaction RLP") {
     Transaction txn{
-        {.type = TransactionType::kEip1559,
+        {.type = TransactionType::kDynamicFee,
          .chain_id = 5,
          .nonce = 7,
          .max_priority_fee_per_gas = 10000000000,
@@ -166,7 +166,7 @@ TEST_CASE("EIP-1559 Transaction RLP") {
 
 TEST_CASE("EIP-4844 Transaction RLP") {
     Transaction txn{
-        {.type = TransactionType::kEip4844,
+        {.type = TransactionType::kBlob,
          .chain_id = 5,
          .nonce = 7,
          .max_priority_fee_per_gas = 10000000000,

--- a/silkworm/node/db/access_layer_test.cpp
+++ b/silkworm/node/db/access_layer_test.cpp
@@ -52,7 +52,7 @@ static BlockBody sample_block_body() {
     body.transactions[0].s =
         intx::from_string<intx::uint256>("0x1fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804");
 
-    body.transactions[1].type = TransactionType::kEip1559;
+    body.transactions[1].type = TransactionType::kDynamicFee;
     body.transactions[1].nonce = 1;
     body.transactions[1].max_priority_fee_per_gas = 5 * kGiga;
     body.transactions[1].max_fee_per_gas = 30 * kGiga;

--- a/silkworm/silkrpc/common/util_test.cpp
+++ b/silkworm/silkrpc/common/util_test.cpp
@@ -134,7 +134,7 @@ TEST_CASE("check_tx_fee_less_cap returns false", "[silkrpc][common][util]") {
 
 TEST_CASE("is_replay_protected(tx legacy) returns true", "[silkrpc][common][util]") {
     const Transaction txn{
-        {.type = TransactionType::kEip2930,
+        {.type = TransactionType::kAccessList,
          .nonce = 0,
          .max_priority_fee_per_gas = 50'000 * kGiga,
          .max_fee_per_gas = 50'000 * kGiga,

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -238,7 +238,7 @@ void to_json(nlohmann::json& json, const Transaction& transaction) {
     }
     json["type"] = rpc::to_quantity(uint64_t(transaction.type));
 
-    if (transaction.type == silkworm::TransactionType::kEip1559) {
+    if (transaction.type == silkworm::TransactionType::kDynamicFee) {
         json["maxPriorityFeePerGas"] = rpc::to_quantity(transaction.max_priority_fee_per_gas);
         json["maxFeePerGas"] = rpc::to_quantity(transaction.max_fee_per_gas);
     }

--- a/silkworm/silkrpc/json/types_test.cpp
+++ b/silkworm/silkrpc/json/types_test.cpp
@@ -329,7 +329,7 @@ TEST_CASE("serialize block with baseFeePerGas", "[silkrpc][to_json]") {
     body.transactions[0].s =
         intx::from_string<intx::uint256>("0x1fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804");
 
-    body.transactions[1].type = TransactionType::kEip1559;
+    body.transactions[1].type = TransactionType::kDynamicFee;
     body.transactions[1].nonce = 1;
     body.transactions[1].max_priority_fee_per_gas = 5 * kGiga;
     body.transactions[1].max_fee_per_gas = 30 * kGiga;
@@ -874,7 +874,7 @@ TEST_CASE("serialize legacy transaction (type=0)", "[silkrpc][to_json]") {
 
 TEST_CASE("serialize EIP-2930 transaction (type=1)", "[silkrpc][to_json]") {
     silkworm::Transaction txn1{
-        {.type = TransactionType::kEip2930,
+        {.type = TransactionType::kAccessList,
          .chain_id = 1,
          .nonce = 0,
          .max_priority_fee_per_gas = 20000000000,
@@ -916,7 +916,7 @@ TEST_CASE("serialize EIP-2930 transaction (type=1)", "[silkrpc][to_json]") {
 
     silkworm::rpc::Transaction txn2{
         {
-            {.type = TransactionType::kEip2930,
+            {.type = TransactionType::kAccessList,
              .chain_id = 1,
              .nonce = 0,
              .max_priority_fee_per_gas = 20000000000,
@@ -971,7 +971,7 @@ TEST_CASE("serialize EIP-2930 transaction (type=1)", "[silkrpc][to_json]") {
 
 TEST_CASE("serialize EIP-1559 transaction (type=2)", "[silkrpc][to_json]") {
     silkworm::Transaction txn1{
-        {.type = TransactionType::kEip1559,
+        {.type = TransactionType::kDynamicFee,
          .chain_id = 1,
          .nonce = 0,
          .max_priority_fee_per_gas = 50'000 * kGiga,

--- a/silkworm/silkrpc/types/transaction_test.cpp
+++ b/silkworm/silkrpc/types/transaction_test.cpp
@@ -52,7 +52,7 @@ TEST_CASE("print type-2 transaction", "[silkrpc][types][transaction]") {
     // https://etherscan.io/tx/0x4b408a48f927f03a63502fb63f7d42c5c4783737ebe8d084cef157575d40f344
     Transaction txn{
         {
-            {.type = TransactionType::kEip1559,
+            {.type = TransactionType::kDynamicFee,
              .chain_id = 1,
              .nonce = 371,
              .max_priority_fee_per_gas = 1 * kGiga,
@@ -77,7 +77,7 @@ TEST_CASE("print type-2 transaction", "[silkrpc][types][transaction]") {
 TEST_CASE("print type-2 silkworm::transaction", "[silkrpc][types][silkworm::transaction]") {
     // https://etherscan.io/tx/0x4b408a48f927f03a63502fb63f7d42c5c4783737ebe8d084cef157575d40f344
     silkworm::Transaction txn{
-        {.type = TransactionType::kEip1559,
+        {.type = TransactionType::kDynamicFee,
          .chain_id = 1,
          .nonce = 371,
          .max_priority_fee_per_gas = 1 * kGiga,


### PR DESCRIPTION
Use the same names as Erigon does. For example, "DynamicFee" is arguably prettier/more explanatory than "eip1559".