### PR TITLE
infra: fix infra_test spamming the test log

### DIFF
--- a/silkworm/infra/grpc/common/util_test.cpp
+++ b/silkworm/infra/grpc/common/util_test.cpp
@@ -90,6 +90,9 @@ TEST_CASE("gpr_silkworm_log", "[silkworm][rpc][util]") {
         gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
         CHECK_NOTHROW(gpr_log(FILE_NAME, LINE_NUMBER, GPR_LOG_SEVERITY_DEBUG, "debug message"));
     }
+
+    // restore the GRPC default log level to not affect logging coming from the other tests
+    gpr_set_log_verbosity(GPR_LOG_SEVERITY_ERROR);
 }
 #endif  // SILKWORM_SANITIZE
 


### PR DESCRIPTION
"gpr_silkworm_log" test was setting the log level to DEBUG, and causing the version_test.cpp to output a lot of GRPC logs such as:

D0613 22:01:14.032745000 4493108736 lb_policy_registry.cc:48 registering LB policy factory for ...

see:
https://github.com/torquem-ch/silkworm/actions/runs/5260251264/jobs/9506908032