### PR TITLE
infra: fix silkworm_infra_test_util build on macOS

### DIFF
--- a/silkworm/infra/test_util/dummy.cpp
+++ b/silkworm/infra/test_util/dummy.cpp
@@ -1,0 +1,17 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Empty compilation unit just to make silkworm_infra_test_util build under macOS


### PR DESCRIPTION
Quick fix to restore build on macOS platform with Apple clang version 14.0.3 (clang-1403.0.22.14.1) by adding dummy empty compilation unit:
```
[ 48%] Linking CXX static library libsilkworm_infra_test_util.a
ar: no archive members specified
usage:  ar -d [-TLsv] archive file ...
	ar -m [-TLsv] archive file ...
	ar -m [-abiTLsv] position archive file ...
	ar -p [-TLsv] archive [file ...]
	ar -q [-cTLsv] archive file ...
```

This is not ideal because of the dummy source file and the following warning:
```
warning: /Library/Developer/CommandLineTools/usr/bin/ranlib: archive library: libsilkworm_infra_test_util.a the table of contents is empty (no object file members in the library define global symbols)
```