### PR TITLE
rpcdaemon: get block by hash with snapshot

### DIFF
--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -238,16 +238,31 @@ awaitable<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::jso
 
     try {
         ethdb::TransactionDatabase tx_database{*tx};
+        auto chain_storage = tx->create_storage(tx_database, backend_);
 
-        const auto block_with_hash = co_await core::read_block_by_hash(*block_cache_, tx_database, block_hash);
-        const auto block_number = block_with_hash->block.header.number;
-        const auto total_difficulty = co_await core::rawdb::read_total_difficulty(tx_database, block_hash, block_number);
-        const Block extended_block{*block_with_hash, total_difficulty, full_tx};
+        const auto cached_block = block_cache_->get(block_hash);
+        uint64_t block_number{0};
+        bool block_read = true;
+        std::shared_ptr<BlockWithHash> block_with_hash;
+        if (cached_block) {
+            block_with_hash = *cached_block;
+        } else {
+            block_with_hash = std::make_shared<BlockWithHash>();
+            block_read = co_await chain_storage->read_block(block_hash, block_with_hash->block);
+            if (block_read) {
+                block_with_hash->hash = block_with_hash->block.header.hash();
+            }
+        }
 
-        reply = make_json_content(request["id"], extended_block);
-    } catch (const std::invalid_argument& iv) {
-        SILK_WARN << "invalid_argument: " << iv.what() << " processing request: " << request.dump();
-        reply = make_json_content(request["id"], {});
+        if (block_read) {
+            block_number = block_with_hash->block.header.number;
+            const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
+            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            const Block extended_block{*block_with_hash, *total_difficulty, full_tx};
+            reply = make_json_content(request["id"], extended_block);
+        } else {
+            reply = make_json_content(request["id"], {});
+        }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         reply = make_json_error(request["id"], 100, e.what());
@@ -281,26 +296,28 @@ awaitable<void> EthereumRpcApi::handle_eth_get_block_by_number(const nlohmann::j
 
         auto chain_storage = tx->create_storage(tx_database, backend_);
         const auto block_hash{co_await chain_storage->read_canonical_hash(block_number)};
-        ensure_pre_condition(block_hash.has_value(), "block number " + std::to_string(block_number) + " is not canonical");
+        if (block_hash) {
+            ensure_pre_condition(block_hash.has_value(), "block number " + std::to_string(block_number) + " is not canonical");
 
-        const auto cached_block = block_cache_->get(*block_hash);
-        std::shared_ptr<BlockWithHash> block_with_hash;
-        if (cached_block) {
-            block_with_hash = *cached_block;
+            const auto cached_block = block_cache_->get(*block_hash);
+            std::shared_ptr<BlockWithHash> block_with_hash;
+            if (cached_block) {
+                block_with_hash = *cached_block;
+            } else {
+                block_with_hash = std::make_shared<BlockWithHash>();
+                const bool block_read = co_await chain_storage->read_block(*block_hash, block_number, block_with_hash->block);
+                ensure(block_read, "cannot find block for number " + std::to_string(block_number));
+                block_with_hash->hash = block_with_hash->block.header.hash();
+            }
+            const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
+            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            const Block extended_block{*block_with_hash, *total_difficulty, full_tx};
+
+            reply = make_json_content(request["id"], extended_block);
         } else {
-            block_with_hash = std::make_shared<BlockWithHash>();
-            const bool block_read = co_await chain_storage->read_block(*block_hash, block_number, block_with_hash->block);
-            ensure(block_read, "cannot find block for number " + std::to_string(block_number));
-            block_with_hash->hash = block_with_hash->block.header.hash();
+            SILK_WARN << "read_canonical_hash invalid block_number" << block_number << "\n";
+            reply = make_json_content(request["id"], {});
         }
-        const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-        ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
-        const Block extended_block{*block_with_hash, *total_difficulty, full_tx};
-
-        reply = make_json_content(request["id"], extended_block);
-    } catch (const std::invalid_argument& iv) {
-        SILK_WARN << "invalid_argument: " << iv.what() << " processing request: " << request.dump();
-        reply = make_json_content(request["id"], nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         reply = make_json_error(request["id"], 100, e.what());

--- a/tests/integration/goerly/eth_getBlockByNumber/test_12.json
+++ b/tests/integration/goerly/eth_getBlockByNumber/test_12.json
@@ -1,0 +1,18 @@
+[
+  {
+    "request": {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "method": "eth_getBlockByNumber",
+      "params": [
+        "0xFFFFFF",
+        false
+      ]
+    },
+    "response": {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": null
+    }
+  }
+]


### PR DESCRIPTION
This PR contains: 
- getBlockByHash modified to support snapshot
- modified code of getBlockByNumber to manage case of  block number not found as expected case