### PR TITLE
CI: remove extra apt packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,6 @@ commands:
           name: "Install compiler"
           command: cmake/setup/compiler_install.sh <<parameters.compiler_id>> <<parameters.compiler_version>>
       - run:
-          name: "Install dependencies"
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y m4 texinfo bison
-      - run:
           name: "Cmake"
           working_directory: ~/build
           command: |

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ and adding its binary to PATH:
 
     export "PATH=$HOME/Library/Python/3.9/bin:$PATH"
 
-* Tools for [gmplib](https://gmplib.org/): `sudo apt-get install -y m4 texinfo bison`
-
 
 Once the prerequisites are installed, bootstrap cmake by running
 ```


### PR DESCRIPTION
m4 texinfo bison are not required anymore, because GMP comes prebuilt from Conan.