### PR TITLE
snapshots: fix TemporaryFile for unit tests on Windows

### DIFF
--- a/silkworm/node/snapshot/index_test.cpp
+++ b/silkworm/node/snapshot/index_test.cpp
@@ -24,9 +24,6 @@
 
 namespace silkworm::snapshot {
 
-// Exclude tests from Windows build
-#ifndef _WIN32
-
 TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
     test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     test::TemporarySnapshotFile tmp_snapshot_file{"v1-014500-015000-headers.seg"};
@@ -140,7 +137,5 @@ TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
     TransactionIndex tx_index{txs_snapshot_path};
     CHECK_NOTHROW(tx_index.build());
 }
-
-#endif  // _WIN32
 
 }  // namespace silkworm::snapshot

--- a/silkworm/node/snapshot/repository_test.cpp
+++ b/silkworm/node/snapshot/repository_test.cpp
@@ -25,9 +25,6 @@
 
 namespace silkworm::snapshot {
 
-// Exclude tests from Windows build
-#ifndef _WIN32
-
 TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][node][snapshot]") {
     test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     CHECK_NOTHROW(SnapshotRepository{SnapshotSettings{}});
@@ -203,7 +200,5 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
         CHECK(repository.find_body_segment(repository.max_block_available() + 1) == nullptr);
     }
 }
-
-#endif  // _WIN32
 
 }  // namespace silkworm::snapshot

--- a/silkworm/node/snapshot/snapshot_test.cpp
+++ b/silkworm/node/snapshot/snapshot_test.cpp
@@ -42,9 +42,6 @@ class Snapshot_ForTest : public Snapshot {
     void close_index() override {}
 };
 
-// Exclude tests from Windows build
-#ifndef _WIN32
-
 TEST_CASE("Snapshot::Snapshot", "[silkworm][node][snapshot][snapshot]") {
     SECTION("valid") {
         std::vector<std::pair<BlockNum, BlockNum>> block_ranges{
@@ -176,7 +173,5 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
         CHECK(transaction->to == 0xe9ae6ec1117bbfeb89302ce7e632597bc595efae_address);
     }
 }
-
-#endif  // _WIN32
 
 }  // namespace silkworm::snapshot

--- a/silkworm/node/test/files.hpp
+++ b/silkworm/node/test/files.hpp
@@ -30,9 +30,9 @@ class TemporaryFile {
   public:
     explicit TemporaryFile() : path_{TemporaryDirectory::get_unique_temporary_path()}, stream_{path_, std::ios::binary} {}
     explicit TemporaryFile(const std::string& filename)
-        : path_{TemporaryDirectory::get_os_temporary_path() / filename}, stream_{path_} {}
+        : path_{TemporaryDirectory::get_os_temporary_path() / filename}, stream_{path_, std::ios::binary} {}
     explicit TemporaryFile(const std::filesystem::path& tmp_dir, const std::string& filename)
-        : path_{tmp_dir / filename}, stream_{path_} {}
+        : path_{tmp_dir / filename}, stream_{path_, std::ios::binary} {}
     ~TemporaryFile() { stream_.close(); }
 
     const std::filesystem::path& path() const noexcept { return path_; }


### PR DESCRIPTION
Fix TemporaryFile on Win specifying binary mode; 
re-enable snapshots tests