### PR TITLE
cmd, api, node: snapshot refactoring

### DIFF
--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -186,13 +186,13 @@ void decode_segment(const SnapSettings& settings, int repetitions) {
         for (int i{0}; i < repetitions; ++i) {
             switch (snap_file->type()) {
                 case SnapshotType::headers: {
-                    snapshot = std::make_unique<HeaderSnapshot>(snap_file->path(), snap_file->block_from(), snap_file->block_to());
+                    snapshot = std::make_unique<HeaderSnapshot>(*snap_file);
                 } break;
                 case SnapshotType::bodies: {
-                    snapshot = std::make_unique<BodySnapshot>(snap_file->path(), snap_file->block_from(), snap_file->block_to());
+                    snapshot = std::make_unique<BodySnapshot>(*snap_file);
                 } break;
                 default: {
-                    snapshot = std::make_unique<TransactionSnapshot>(snap_file->path(), snap_file->block_from(), snap_file->block_to());
+                    snapshot = std::make_unique<TransactionSnapshot>(*snap_file);
                 }
             }
             snapshot->reopen_segment();

--- a/silkworm/api/silkworm_api.cpp
+++ b/silkworm/api/silkworm_api.cpp
@@ -55,8 +55,7 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle* handle, SilkwormChainS
     }
     // TODO(canepat) HeaderSnapshot must be created w/ segment_address+segment_length because mmap already done by Erigon
     // TODO(canepat) The same holds for its index
-    auto headers_segment = std::make_unique<snapshot::HeaderSnapshot>(
-        headers_segment_path->path(), headers_segment_path->block_from(), headers_segment_path->block_to());
+    auto headers_segment = std::make_unique<snapshot::HeaderSnapshot>(*headers_segment_path);
     headers_segment->reopen_segment();  // TODO(canepat) must not be called hence throw exception if called when snapshot already mapped
     headers_segment->reopen_index();    // TODO(canepat) must not be called hence throw exception if called when snapshot already mapped
 
@@ -67,8 +66,7 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle* handle, SilkwormChainS
     }
     // TODO(canepat) BodySnapshot must be created w/ segment_address+segment_length because mmap already done by Erigon
     // TODO(canepat) The same holds for its index
-    auto bodies_segment = std::make_unique<snapshot::BodySnapshot>(
-        bodies_segment_path->path(), bodies_segment_path->block_from(), bodies_segment_path->block_to());
+    auto bodies_segment = std::make_unique<snapshot::BodySnapshot>(*bodies_segment_path);
     bodies_segment->reopen_segment();  // TODO(canepat) must not be called hence throw exception if called when snapshot already mapped
     bodies_segment->reopen_index();    // TODO(canepat) must not be called hence throw exception if called when snapshot already mapped
 
@@ -79,8 +77,7 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle* handle, SilkwormChainS
     }
     // TODO(canepat) TransactionSnapshot must be created w/ segment_address+segment_length because mmap already done by Erigon
     // TODO(canepat) The same holds for its index
-    auto transactions_segment = std::make_unique<snapshot::TransactionSnapshot>(
-        transactions_segment_path->path(), transactions_segment_path->block_from(), transactions_segment_path->block_to());
+    auto transactions_segment = std::make_unique<snapshot::TransactionSnapshot>(*transactions_segment_path);
     transactions_segment->reopen_segment();  // TODO(canepat) must not be called hence throw exception if called when snapshot already mapped
     transactions_segment->reopen_index();    // TODO(canepat) must not be called hence throw exception if called when snapshot already mapped
 

--- a/silkworm/node/snapshot/index.cpp
+++ b/silkworm/node/snapshot/index.cpp
@@ -100,14 +100,14 @@ bool BodyIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView
 void TransactionIndex::build() {
     SILK_INFO << "TransactionIndex::build path: " << segment_path_.path().string() << " start";
 
-    const SnapshotPath bodies_segment = SnapshotPath::from(segment_path_.path().parent_path(),
-                                                           segment_path_.version(),
-                                                           segment_path_.block_from(),
-                                                           segment_path_.block_to(),
-                                                           SnapshotType::bodies);
-    SILK_INFO << "TransactionIndex::build bodies_segment path: " << bodies_segment.path().string();
+    const SnapshotPath bodies_segment_path = SnapshotPath::from(segment_path_.path().parent_path(),
+                                                                segment_path_.version(),
+                                                                segment_path_.block_from(),
+                                                                segment_path_.block_to(),
+                                                                SnapshotType::bodies);
+    SILK_INFO << "TransactionIndex::build bodies_segment path: " << bodies_segment_path.path().string();
 
-    BodySnapshot bodies_snapshot{bodies_segment.path(), bodies_segment.block_from(), bodies_segment.block_to()};
+    BodySnapshot bodies_snapshot{bodies_segment_path};
     bodies_snapshot.reopen_segment();
     const auto [first_tx_id, expected_tx_count] = bodies_snapshot.compute_txs_amount();
     SILK_INFO << "TransactionIndex::build first_tx_id: " << first_tx_id << " expected_tx_count: " << expected_tx_count;
@@ -145,7 +145,7 @@ void TransactionIndex::build() {
         .etl_optimal_size = etl::kOptimalBufferSize / 2};
     RecSplit8 tx_hash_to_block_rs{tx_hash_to_block_rs_settings, 1};
 
-    huffman::Decompressor bodies_decoder{bodies_segment.path()};
+    huffman::Decompressor bodies_decoder{bodies_segment_path.path()};
     bodies_decoder.open();
 
     using DoubleReadAheadFunc = std::function<bool(huffman::Decompressor::Iterator, huffman::Decompressor::Iterator)>;

--- a/silkworm/node/snapshot/path.cpp
+++ b/silkworm/node/snapshot/path.cpp
@@ -25,6 +25,7 @@
 #include <boost/format.hpp>
 #include <magic_enum.hpp>
 
+#include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 
 namespace silkworm::snapshot {
@@ -54,7 +55,7 @@ std::optional<SnapshotPath> SnapshotPath::parse(fs::path path) {
     }
 
     // Expected scaled block format: <dddddd>
-    if (scaled_from.size() > 6 || scaled_to.size() > 6) {
+    if (scaled_from.size() != 6 || scaled_to.size() != 6) {
         return std::nullopt;
     }
 
@@ -71,6 +72,11 @@ std::optional<SnapshotPath> SnapshotPath::parse(fs::path path) {
         return std::nullopt;
     }
     const BlockNum block_to{scaled_block_to * kFileNameBlockScaleFactor};
+
+    // Expected proper block range: [block_from, block_to)
+    if (block_to <= block_from) {
+        return std::nullopt;
+    }
 
     // Expected tag format: headers|bodies|transactions (parsing relies on magic_enum, so SnapshotType items must match exactly)
     std::string_view tag_str{tag.data(), tag.size()};
@@ -101,7 +107,9 @@ fs::path SnapshotPath::build_filename(uint8_t version, BlockNum block_from, Bloc
 }
 
 SnapshotPath::SnapshotPath(fs::path path, uint8_t version, BlockNum block_from, BlockNum block_to, SnapshotType type)
-    : path_(std::move(path)), version_(version), block_from_(block_from), block_to_(block_to), type_(type) {}
+    : path_(std::move(path)), version_(version), block_from_(block_from), block_to_(block_to), type_(type) {
+    ensure(block_to > block_from, "SnapshotPath: block_to less than block_from");
+}
 
 bool operator<(const SnapshotPath& lhs, const SnapshotPath& rhs) {
     if (lhs.version_ != rhs.version_) {

--- a/silkworm/node/snapshot/path_test.cpp
+++ b/silkworm/node/snapshot/path_test.cpp
@@ -23,11 +23,11 @@
 
 namespace silkworm::snapshot {
 
-TEST_CASE("SnapshotPath::segment_size", "[silkworm][snapshot][snapshot]") {
+TEST_CASE("SnapshotPath::segment_size", "[silkworm][node][snapshot]") {
     CHECK(SnapshotPath::segment_size() == kDefaultSegmentSize);
 }
 
-TEST_CASE("SnapshotPath::SnapshotPath", "[silkworm][snapshot][snapshot]") {
+TEST_CASE("SnapshotPath::parse", "[silkworm][node][snapshot]") {
     SECTION("invalid") {
         const char* invalid_filenames[]{
             "",
@@ -42,6 +42,7 @@ TEST_CASE("SnapshotPath::SnapshotPath", "[silkworm][snapshot][snapshot]") {
             "v1--015000-headers.seg",
             "v1-014500015000-headers.seg",
             "v1-014500-1-headers.seg",
+            "v1-014500-010000-headers.seg",
             "v1-014500--headers.seg",
             "v1-014500-01500a-headers.seg",
             "v1-014500-015000-.seg",
@@ -86,6 +87,13 @@ TEST_CASE("SnapshotPath::SnapshotPath", "[silkworm][snapshot][snapshot]") {
                 CHECK(index_file.type() == filename_expectation.type);
             }
         }
+    }
+}
+
+TEST_CASE("SnapshotPath::from", "[silkworm][node][snapshot]") {
+    SECTION("invalid") {
+        CHECK_THROWS_AS(SnapshotPath::from(std::filesystem::path{}, kSnapshotV1, 1'000, 999, SnapshotType::headers),
+                        std::logic_error);
     }
 }
 

--- a/silkworm/node/snapshot/repository.cpp
+++ b/silkworm/node/snapshot/repository.cpp
@@ -308,7 +308,7 @@ const T* SnapshotRepository::find_segment(const SnapshotsByPath<T>& segments, Bl
 template <ConcreteSnapshot T>
 bool SnapshotRepository::reopen(SnapshotsByPath<T>& segments, const SnapshotPath& seg_file) {
     if (segments.find(seg_file.path()) == segments.end()) {
-        auto segment = std::make_unique<T>(seg_file.path(), seg_file.block_from(), seg_file.block_to());
+        auto segment = std::make_unique<T>(seg_file);
         segment->reopen_segment();
         if (segment->empty()) return false;
         segments[seg_file.path()] = std::move(segment);

--- a/silkworm/node/snapshot/snapshot.hpp
+++ b/silkworm/node/snapshot/snapshot.hpp
@@ -26,6 +26,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/infra/common/os.hpp>
 #include <silkworm/node/db/util.hpp>
 #include <silkworm/node/huffman/decompressor.hpp>
 #include <silkworm/node/recsplit/rec_split.hpp>
@@ -35,16 +36,16 @@ namespace silkworm::snapshot {
 
 class Snapshot {
   public:
-    static constexpr uint64_t kPageSize{4096};
+    static inline const auto kPageSize{os::page_size()};
 
-    explicit Snapshot(std::filesystem::path path, BlockNum block_from, BlockNum block_to);
+    explicit Snapshot(SnapshotPath path);
     virtual ~Snapshot() = default;
 
-    [[nodiscard]] virtual SnapshotPath path() const = 0;
-    [[nodiscard]] std::filesystem::path fs_path() const { return path_; }
+    [[nodiscard]] SnapshotPath path() const { return path_; }
+    [[nodiscard]] std::filesystem::path fs_path() const { return path_.path(); }
 
-    [[nodiscard]] BlockNum block_from() const { return block_from_; }
-    [[nodiscard]] BlockNum block_to() const { return block_to_; }
+    [[nodiscard]] BlockNum block_from() const { return path_.block_from(); }
+    [[nodiscard]] BlockNum block_to() const { return path_.block_to(); }
 
     [[nodiscard]] bool empty() const { return item_count() == 0; }
     [[nodiscard]] std::size_t item_count() const { return decoder_.words_count(); }
@@ -74,19 +75,15 @@ class Snapshot {
     void close_segment();
     virtual void close_index() = 0;
 
-    std::filesystem::path path_;
-    BlockNum block_from_{0};
-    BlockNum block_to_{0};
+    SnapshotPath path_;
     huffman::Decompressor decoder_;
 };
 
 class HeaderSnapshot : public Snapshot {
   public:
-    explicit HeaderSnapshot(std::filesystem::path path, BlockNum block_from, BlockNum block_to)
-        : Snapshot(std::move(path), block_from, block_to) {}
+    explicit HeaderSnapshot(SnapshotPath path) : Snapshot(std::move(path)) {}
     ~HeaderSnapshot() override { close(); }
 
-    [[nodiscard]] SnapshotPath path() const override;
     [[nodiscard]] const succinct::RecSplitIndex* idx_header_hash() const { return idx_header_hash_.get(); }
 
     using Walker = std::function<bool(const BlockHeader* header)>;
@@ -112,11 +109,9 @@ using StoredBlockBody = db::detail::BlockBodyForStorage;
 
 class BodySnapshot : public Snapshot {
   public:
-    explicit BodySnapshot(std::filesystem::path path, BlockNum block_from, BlockNum block_to)
-        : Snapshot(std::move(path), block_from, block_to) {}
+    explicit BodySnapshot(SnapshotPath path) : Snapshot(std::move(path)) {}
     ~BodySnapshot() override { close(); }
 
-    [[nodiscard]] SnapshotPath path() const override;
     [[nodiscard]] const succinct::RecSplitIndex* idx_body_number() const { return idx_body_number_.get(); }
 
     using Walker = std::function<bool(BlockNum number, const StoredBlockBody* body)>;
@@ -141,11 +136,9 @@ class BodySnapshot : public Snapshot {
 
 class TransactionSnapshot : public Snapshot {
   public:
-    explicit TransactionSnapshot(std::filesystem::path path, BlockNum block_from, BlockNum block_to)
-        : Snapshot(std::move(path), block_from, block_to) {}
+    explicit TransactionSnapshot(SnapshotPath path) : Snapshot(std::move(path)) {}
     ~TransactionSnapshot() override { close(); }
 
-    [[nodiscard]] SnapshotPath path() const override;
     [[nodiscard]] const succinct::RecSplitIndex* idx_txn_hash() const { return idx_txn_hash_.get(); }
     [[nodiscard]] const succinct::RecSplitIndex* idx_txn_hash_2_block() const { return idx_txn_hash_2_block_.get(); }
 

--- a/silkworm/node/snapshot/snapshot_test.cpp
+++ b/silkworm/node/snapshot/snapshot_test.cpp
@@ -30,15 +30,24 @@ namespace silkworm::snapshot {
 
 using namespace std::chrono_literals;
 
+static const SnapshotPath kValidHeadersSegmentPath{*SnapshotPath::parse("v1-014500-015000-headers.seg")};
+
+class SnapshotPath_ForTest : public SnapshotPath {
+  public:
+    SnapshotPath_ForTest(BlockNum block_from, BlockNum block_to)
+        : SnapshotPath(SnapshotPath::from(TemporaryDirectory::get_os_temporary_path(),
+                                          kSnapshotV1,
+                                          block_from,
+                                          block_to,
+                                          SnapshotType::headers)) {}
+};
+
 class Snapshot_ForTest : public Snapshot {
   public:
-    Snapshot_ForTest(std::filesystem::path path, BlockNum block_from, BlockNum block_to)
-        : Snapshot(std::move(path), block_from, block_to) {}
+    explicit Snapshot_ForTest(SnapshotPath path) : Snapshot(path) {}
+    explicit Snapshot_ForTest(std::filesystem::path path) : Snapshot(*SnapshotPath::parse(path)) {}
+    Snapshot_ForTest(BlockNum block_from, BlockNum block_to) : Snapshot(SnapshotPath_ForTest{block_from, block_to}) {}
     ~Snapshot_ForTest() override { close(); }
-
-    [[nodiscard]] SnapshotPath path() const override {
-        return SnapshotPath::from(path_.parent_path(), kSnapshotV1, block_from_, block_to_, SnapshotType::headers);
-    }
 
     void reopen_index() override {}
     void close_index() override {}
@@ -54,11 +63,11 @@ static auto move_last_write_time(const std::filesystem::path& p, const std::chro
 TEST_CASE("Snapshot::Snapshot", "[silkworm][node][snapshot][snapshot]") {
     SECTION("valid") {
         std::vector<std::pair<BlockNum, BlockNum>> block_ranges{
-            {0, 0},
+            {0, 1},
             {1'000, 2'000}};
         for (const auto& [block_from, block_to] : block_ranges) {
-            Snapshot_ForTest snapshot{std::filesystem::path{}, block_from, block_to};
-            CHECK(snapshot.fs_path().empty());
+            Snapshot_ForTest snapshot{block_from, block_to};
+            CHECK(!snapshot.fs_path().empty());
             CHECK(snapshot.block_from() == block_from);
             CHECK(snapshot.block_to() == block_to);
             CHECK(snapshot.item_count() == 0);
@@ -66,22 +75,28 @@ TEST_CASE("Snapshot::Snapshot", "[silkworm][node][snapshot][snapshot]") {
         }
     }
     SECTION("invalid") {
-        CHECK_THROWS_AS(Snapshot_ForTest(std::filesystem::path{}, 1'000, 999), std::logic_error);
+        std::vector<std::pair<BlockNum, BlockNum>> block_ranges{
+            {0, 0},
+            {1'000, 1'000},
+            {1'000, 999}};
+        for (const auto& [block_from, block_to] : block_ranges) {
+            CHECK_THROWS_AS(Snapshot_ForTest(block_from, block_to), std::logic_error);
+        }
     }
 }
 
 TEST_CASE("Snapshot::reopen_segment", "[silkworm][node][snapshot][snapshot]") {
     test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-    test::TemporarySnapshotFile tmp_snapshot_file{test::SnapshotHeader{}};
-    auto snapshot{std::make_unique<Snapshot_ForTest>(tmp_snapshot_file.path(), 0, 0)};
-    snapshot->reopen_segment();
+    test::TemporarySnapshotFile tmp_snapshot_file{kValidHeadersSegmentPath.filename(), test::SnapshotHeader{}};
+    Snapshot_ForTest snapshot{tmp_snapshot_file.path()};
+    snapshot.reopen_segment();
 }
 
 TEST_CASE("Snapshot::for_each_item", "[silkworm][node][snapshot][snapshot]") {
     test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-    test::HelloWorldSnapshotFile hello_world_snapshot_file{};
+    test::HelloWorldSnapshotFile hello_world_snapshot_file{kValidHeadersSegmentPath.filename()};
     huffman::Decompressor decoder{hello_world_snapshot_file.path()};
-    Snapshot_ForTest tmp_snapshot{hello_world_snapshot_file.path(), 1'000, 2'000};
+    Snapshot_ForTest tmp_snapshot{hello_world_snapshot_file.path()};
     tmp_snapshot.reopen_segment();
     CHECK(!tmp_snapshot.empty());
     CHECK(tmp_snapshot.item_count() == 1);
@@ -95,9 +110,9 @@ TEST_CASE("Snapshot::for_each_item", "[silkworm][node][snapshot][snapshot]") {
 
 TEST_CASE("Snapshot::close", "[silkworm][node][snapshot][snapshot]") {
     test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-    test::HelloWorldSnapshotFile hello_world_snapshot_file{};
+    test::HelloWorldSnapshotFile hello_world_snapshot_file{kValidHeadersSegmentPath.filename()};
     huffman::Decompressor decoder{hello_world_snapshot_file.path()};
-    Snapshot_ForTest tmp_snapshot{hello_world_snapshot_file.path(), 1'000, 2'000};
+    Snapshot_ForTest tmp_snapshot{hello_world_snapshot_file.path()};
     tmp_snapshot.reopen_segment();
     CHECK_NOTHROW(tmp_snapshot.close());
 }
@@ -110,7 +125,7 @@ TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][ind
     HeaderIndex header_index{header_snapshot_path};
     REQUIRE_NOTHROW(header_index.build());
 
-    HeaderSnapshot header_snapshot{header_snapshot_path.path(), header_snapshot_path.block_from(), header_snapshot_path.block_to()};
+    HeaderSnapshot header_snapshot{header_snapshot_path};
     header_snapshot.reopen_segment();
     header_snapshot.reopen_index();
 
@@ -148,7 +163,7 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
     BodyIndex body_index{body_snapshot_path};
     REQUIRE_NOTHROW(body_index.build());
 
-    BodySnapshot body_snapshot{body_snapshot_path.path(), body_snapshot_path.block_from(), body_snapshot_path.block_to()};
+    BodySnapshot body_snapshot{body_snapshot_path};
     body_snapshot.reopen_segment();
     body_snapshot.reopen_index();
 
@@ -171,7 +186,7 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
     TransactionIndex tx_index{tx_snapshot_path};
     REQUIRE_NOTHROW(tx_index.build());
 
-    TransactionSnapshot tx_snapshot{tx_snapshot_path.path(), tx_snapshot_path.block_from(), tx_snapshot_path.block_to()};
+    TransactionSnapshot tx_snapshot{tx_snapshot_path};
     tx_snapshot.reopen_segment();
     tx_snapshot.reopen_index();
     const auto transaction = tx_snapshot.txn_by_id(7'341'272);
@@ -190,7 +205,7 @@ TEST_CASE("HeaderSnapshot::reopen_index regeneration", "[silkworm][node][snapsho
     HeaderIndex header_index{header_snapshot_path};
     REQUIRE_NOTHROW(header_index.build());
 
-    HeaderSnapshot header_snapshot{header_snapshot_path.path(), header_snapshot_path.block_from(), header_snapshot_path.block_to()};
+    HeaderSnapshot header_snapshot{header_snapshot_path};
     header_snapshot.reopen_segment();
     header_snapshot.reopen_index();
     REQUIRE(std::filesystem::exists(header_snapshot.path().index_file().path()));
@@ -212,7 +227,7 @@ TEST_CASE("BodySnapshot::reopen_index regeneration", "[silkworm][node][snapshot]
     BodyIndex body_index{body_snapshot_path};
     REQUIRE_NOTHROW(body_index.build());
 
-    BodySnapshot body_snapshot{body_snapshot_path.path(), body_snapshot_path.block_from(), body_snapshot_path.block_to()};
+    BodySnapshot body_snapshot{body_snapshot_path};
     body_snapshot.reopen_segment();
     body_snapshot.reopen_index();
     CHECK(std::filesystem::exists(body_snapshot.path().index_file().path()));
@@ -234,7 +249,7 @@ TEST_CASE("TransactionSnapshot::reopen_index regeneration", "[silkworm][node][sn
     TransactionIndex tx_index{tx_snapshot_path1};
     REQUIRE_NOTHROW(tx_index.build());
 
-    TransactionSnapshot tx_snapshot{tx_snapshot_path1.path(), tx_snapshot_path1.block_from(), tx_snapshot_path1.block_to()};
+    TransactionSnapshot tx_snapshot{tx_snapshot_path1};
     tx_snapshot.reopen_segment();
     tx_snapshot.reopen_index();
     CHECK(std::filesystem::exists(tx_snapshot.path().index_file().path()));

--- a/silkworm/node/test/snapshots.hpp
+++ b/silkworm/node/test/snapshots.hpp
@@ -158,6 +158,8 @@ class TemporarySnapshotFile {
 class HelloWorldSnapshotFile : public TemporarySnapshotFile {
   public:
     explicit HelloWorldSnapshotFile() : TemporarySnapshotFile{kHeader, kBody} {}
+    explicit HelloWorldSnapshotFile(const std::string& filename)
+        : TemporarySnapshotFile{filename, kHeader, kBody} {}
     explicit HelloWorldSnapshotFile(const std::filesystem::path& tmp_dir, const std::string& filename)
         : TemporarySnapshotFile{tmp_dir, filename, kHeader, kBody} {}
 


### PR DESCRIPTION
This PR contains:

- some refactoring to use less parameters in `Snapshot` constructors
- stricter checks in `SnapshotPath` when built from file system path