### PR TITLE
sync: fix crash in Sync::start_chain_sync

### DIFF
--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -94,6 +94,10 @@ boost::asio::awaitable<void> Sync::start_block_exchange() {
 }
 
 boost::asio::awaitable<void> Sync::start_chain_sync() {
+    if (!engine_rpc_server_) {
+        return chain_sync_->async_run();
+    }
+
     // The ChainSync async loop *must* run onto the Engine RPC server unique execution context
     // This is *strictly* required by the current design assumptions in PoSSync
     auto& engine_rpc_ioc = engine_rpc_server_->context_pool().next_io_context();


### PR DESCRIPTION
engine_rpc_server_ is null, because Sync::force_pow() is called and resets it