### PR TITLE
snapshots: fix crash in DataModel::for_last_n_headers

### DIFF
--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -1157,12 +1157,14 @@ void DataModel::for_last_n_headers(size_t n, std::function<void(BlockHeader&&)> 
         return;
     }
 
+    auto block_number_in_snapshots = repository_ ? repository_->max_block_available() : 0;
+
     // We've reached the first header in db but still need to read more from snapshots
-    if (last_read_number_from_db) {
-        ensure(*last_read_number_from_db == repository_->max_block_available() + 1,
+    if (repository_ && last_read_number_from_db) {
+        ensure(*last_read_number_from_db == block_number_in_snapshots + 1,
                "db and snapshot block numbers are not contiguous");
     }
-    auto block_number_in_snapshots = repository_->max_block_available();
+
     while (read_count < n) {
         auto header{read_header_from_snapshot(block_number_in_snapshots)};
         if (!header) return;

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -94,6 +94,10 @@ boost::asio::awaitable<void> Sync::start_block_exchange() {
 }
 
 boost::asio::awaitable<void> Sync::start_chain_sync() {
+    if (!engine_rpc_server_) {
+        return chain_sync_->async_run();
+    }
+
     // The ChainSync async loop *must* run onto the Engine RPC server unique execution context
     // This is *strictly* required by the current design assumptions in PoSSync
     auto& engine_rpc_ioc = engine_rpc_server_->context_pool().next_io_context();


### PR DESCRIPTION
repository_ is null if started with --snapshots.enabled=false