### PR TITLE
build: use intx as conan package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,9 +33,6 @@
 [submodule "third_party/blst"]
 	path = third_party/blst
 	url = https://github.com/supranational/blst.git
-[submodule "third_party/intx"]
-	path = third_party/intx
-	url = https://github.com/chfast/intx.git
 [submodule "third_party/ethash"]
 	path = third_party/ethash
 	url = https://github.com/chfast/ethash.git

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -20,6 +20,7 @@ snappy/1.1.7
 sqlitecpp/3.3.0
 tl-expected/1.1.0
 tomlplusplus/3.3.0
+intx/0.10.1
 
 [generators]
 cmake_find_package

--- a/silkworm/core/CMakeLists.txt
+++ b/silkworm/core/CMakeLists.txt
@@ -17,6 +17,7 @@
 find_package(Microsoft.GSL REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(tl-expected REQUIRED)
+find_package(intx REQUIRED)
 
 if(MSVC)
   add_compile_options(/EHsc)

--- a/silkworm/silkrpc/CMakeLists.txt
+++ b/silkworm/silkrpc/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SILKRPC_PUBLIC_LIBRARIES
     Boost::container
     Boost::thread
     protobuf::libprotobuf
+    intx::intx
     pico_http_parser
 )
 

--- a/silkworm/silkrpc/CMakeLists.txt
+++ b/silkworm/silkrpc/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(gRPC REQUIRED)
 find_package(jwt-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(roaring REQUIRED)
+find_package(intx REQUIRED)
 
 # Silkrpc library
 file(
@@ -57,7 +58,6 @@ set(SILKRPC_PUBLIC_LIBRARIES
     Boost::container
     Boost::thread
     protobuf::libprotobuf
-    intx::intx
     pico_http_parser
 )
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
 endif()
 
 # evmone with dependencies
-add_subdirectory(intx)
+find_package(intx REQUIRED)
 
 option(ETHASH_BUILD_GLOBAL_CONTEXT "" OFF)
 add_subdirectory(ethash)


### PR DESCRIPTION
intx/0.10.1 has been added to conan-center: https://github.com/conan-io/conan-center-index/pull/18858, we can use conan to manage it instead of git submodule