### PR TITLE
node: reduce number of parameters and refactor write_tx_lookup

### DIFF
--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -586,13 +586,12 @@ void write_senders(RWTxn& txn, const evmc::bytes32& hash, const BlockNum& block_
     target->upsert(to_slice(key), to_slice(data));
 }
 
-void write_tx_lookup(RWTxn& txn, const BlockNum& block_number, const Block& block) {
+void write_tx_lookup(RWTxn& txn, const Block& block) {
     auto target = txn.rw_cursor(table::kTxLookup);
-    Bytes data;
+    const auto block_number_bytes = db::block_key(block.header.number);
     for (const auto& block_txn : block.transactions) {
         auto tx_key = block_txn.hash();
-        auto tx_data = db::block_key(block_number);
-        target->upsert(to_slice(tx_key.bytes), to_slice(tx_data));
+        target->upsert(to_slice(tx_key.bytes), to_slice(block_number_bytes));
     }
 }
 

--- a/silkworm/node/db/access_layer.hpp
+++ b/silkworm/node/db/access_layer.hpp
@@ -148,7 +148,7 @@ std::vector<evmc::address> read_senders(ROTxn& txn, BlockNum block_number, const
 void parse_senders(ROTxn& txn, const Bytes& key, std::vector<Transaction>& out);
 void write_senders(RWTxn& txn, const evmc::bytes32& hash, const BlockNum& number, const Block& block);
 
-void write_tx_lookup(RWTxn& txn, const BlockNum& block_number, const Block& block);
+void write_tx_lookup(RWTxn& txn, const Block& block);
 void write_receipts(RWTxn& txn, const std::vector<silkworm::Receipt>& receipts, const BlockNum& block_number);
 
 // See Erigon ReadTransactions

--- a/silkworm/silkrpc/commands/rpc_api_test.cpp
+++ b/silkworm/silkrpc/commands/rpc_api_test.cpp
@@ -191,10 +191,10 @@ void populate_blocks(db::RWTxn& txn, const std::filesystem::path& tests_dir) {
         db::write_senders(txn, block_hash, block.header.number, block);
 
         // FIX 4: populate tx lookup table and create receipts
+        db::write_tx_lookup(txn, block);
         std::vector<silkworm::Receipt> receipts;
         uint64_t cumulative_gas_used = 0;
         for (auto& block_txn : block.transactions) {
-            db::write_tx_lookup(txn, block.header.number, block);
             cumulative_gas_used += block_txn.gas_limit;
             silkworm::Receipt receipt{.type = block_txn.type, .success = true, .cumulative_gas_used = cumulative_gas_used, .bloom = block.header.logs_bloom};
             receipts.emplace_back(receipt);


### PR DESCRIPTION
node: add roundtrip unit test for block body w/ withdrawals
rpcdaemon: refactor RPC IO unit test