### PR TITLE
rpcdaemon: modify ethbackend version from 3.2 to 3.3

### DIFF
--- a/silkworm/infra/grpc/common/version.hpp
+++ b/silkworm/infra/grpc/common/version.hpp
@@ -37,7 +37,7 @@ struct ProtocolVersion {
 };
 
 constexpr auto kKvServiceApiVersion = ProtocolVersion{6, 2, 0};
-constexpr auto kEthBackEndServiceApiVersion = ProtocolVersion{3, 2, 0};
+constexpr auto kEthBackEndServiceApiVersion = ProtocolVersion{3, 3, 0};
 constexpr auto kMiningServiceApiVersion = ProtocolVersion{1, 0, 0};
 constexpr auto kTxPoolServiceApiVersion = ProtocolVersion{1, 0, 0};
 

--- a/silkworm/infra/grpc/common/version_test.cpp
+++ b/silkworm/infra/grpc/common/version_test.cpp
@@ -97,7 +97,7 @@ TEST_CASE("ETHBACKEND protocol version match", "[silkrpc][protocol][wait_for_eth
     std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub{std::make_unique<::remote::FixIssue24351_MockETHBACKENDStub>()};
     types::VersionReply reply;
     reply.set_major(3);
-    reply.set_minor(2);
+    reply.set_minor(3);
 
     EXPECT_CALL(*dynamic_cast<::remote::FixIssue24351_MockETHBACKENDStub*>(stub.get()), Version(_, _, _)).WillOnce(DoAll(SetArgPointee<2>(reply), Return(grpc::Status::OK)));
     const auto version_result{wait_for_ethbackend_protocol_check(stub)};
@@ -111,7 +111,7 @@ TEST_CASE("ETHBACKEND protocol version with server stub", "[silkrpc][protocol][w
       public:
         ::grpc::Status Version(::grpc::ServerContext*, const ::google::protobuf::Empty*, ::types::VersionReply* response) override {
             response->set_major(3);
-            response->set_minor(2);
+            response->set_minor(3);
             response->set_patch(0);
             return ::grpc::Status::OK;
         }


### PR DESCRIPTION
To interface erigon 2.48.1