### PR TITLE
rpcdaemon: exclude RPC IO tests from ASAN/TSAN builds

### DIFF
--- a/silkworm/silkrpc/commands/rpc_api_test.cpp
+++ b/silkworm/silkrpc/commands/rpc_api_test.cpp
@@ -309,6 +309,8 @@ static const std::vector<std::string> tests_to_ignore = {
     "eth_sendRawTransaction",     // call to oracle fails, needs fixing or mocking
 };
 
+// Exclude tests from sanitizer builds due to ASAN/TSAN warnings inside gRPC library
+#ifndef SILKWORM_SANITIZE
 TEST_CASE("rpc_api io (all files)", "[silkrpc][rpc_api]") {
     auto tests_dir = get_tests_dir();
     for (const auto& test_file : std::filesystem::recursive_directory_iterator(tests_dir)) {
@@ -391,5 +393,6 @@ TEST_CASE("rpc_api io (individual)", "[silkrpc][rpc_api][ignore]") {
     db->close();
     std::filesystem::remove_all(db_dir);
 }
+#endif  // SILKWORM_SANITIZE
 
 }  // namespace silkworm::rpc::commands


### PR DESCRIPTION
Exclude RPC IO tests from being compiled and run in CI sanitiser builds because of ASAN/TSAN errors inside gRPC library.

This happens in some other unit tests of ours and probably could be avoided by rebuilding gRPC library w/ sanitiser support in our CI sanitiser builds, but this requires time to be done and above all would result in longer build times for our integration CI. As a consequence, we decided to simply skip the offending tests just in CI sanitiser builds.