### PR TITLE
sentry: use any_io_executor instead of io_context

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,6 +18,11 @@ IncludeCategories:
   - Regex:           '<silkworm/infra/concurrency/task\.hpp>'
     Priority:        30
 
+  # coroutine.hpp has to go before the boost headers,
+  # otherwise boost::asio fails to compile on GCC 12
+  - Regex:           '"task\.hpp"'
+    Priority:        30
+
   # Silkworm headers
   - Regex:           '<silkworm.*'
     Priority:        50

--- a/cmd/common/shutdown_signal.hpp
+++ b/cmd/common/shutdown_signal.hpp
@@ -20,16 +20,16 @@
 
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/signal_set.hpp>
 
 namespace silkworm::cmd::common {
 
 class ShutdownSignal {
   public:
-    explicit ShutdownSignal(boost::asio::io_context& io_context)
-        : signals_(io_context, SIGINT, SIGTERM) {}
+    explicit ShutdownSignal(boost::asio::any_io_executor executor)
+        : signals_(executor, SIGINT, SIGTERM) {}
 
     using SignalNumber = int;
 

--- a/cmd/dev/backend_kv_server.cpp
+++ b/cmd/dev/backend_kv_server.cpp
@@ -250,7 +250,7 @@ int main(int argc, char* argv[]) {
             tasks = server.async_run("bekv-server");
         }
 
-        ShutdownSignal shutdown_signal{context_pool.next_io_context()};
+        ShutdownSignal shutdown_signal{context_pool.next_io_context().get_executor()};
 
         // Go!
         auto run_future = boost::asio::co_spawn(

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -311,7 +311,7 @@ void download(const BitTorrentSettings& settings) {
     BitTorrentClient client{settings};
 
     boost::asio::io_context scheduler;
-    ShutdownSignal shutdown_signal{scheduler};
+    ShutdownSignal shutdown_signal{scheduler.get_executor()};
     shutdown_signal.on_signal([&](ShutdownSignal::SignalNumber /*num*/) {
         client.stop();
         SILK_DEBUG << "Torrent client stopped";

--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -75,9 +75,9 @@ void sentry_main(Settings settings) {
         [] { return std::make_unique<DummyServerCompletionQueue>(); },
     };
 
-    ShutdownSignal shutdown_signal{context_pool.next_io_context()};
+    ShutdownSignal shutdown_signal{context_pool.next_io_context().get_executor()};
 
-    Sentry sentry{std::move(settings), context_pool};
+    Sentry sentry{std::move(settings), context_pool.as_executor_pool()};
 
     auto run_future = boost::asio::co_spawn(
         context_pool.next_io_context(),

--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -1025,7 +1025,7 @@ int main(int argc, char* argv[]) {
         }};
 
         boost::asio::io_context scheduler;
-        silkworm::cmd::common::ShutdownSignal shutdown_signal{scheduler};
+        silkworm::cmd::common::ShutdownSignal shutdown_signal{scheduler.get_executor()};
         shutdown_signal.on_signal([&](silkworm::cmd::common::ShutdownSignal::SignalNumber /*num*/) {
             pump_stop = true;
             completion_stop = true;

--- a/silkworm/infra/common/asio_timer.hpp
+++ b/silkworm/infra/common/asio_timer.hpp
@@ -25,8 +25,8 @@
 // otherwise <boost/asio/detail/socket_types.hpp> dependency doesn't compile
 #define _DARWIN_C_SOURCE
 #endif
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/deadline_timer.hpp>
-#include <boost/asio/io_context.hpp>
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/infra/concurrency/signal_handler.hpp>
@@ -38,13 +38,18 @@ using namespace std::chrono_literals;
 //! \brief Implementation of an asynchronous timer relying on boost:asio
 class Timer {
   public:
-    //! \param asio_context [in] : boost's asio context
+    //! \param executor [in] : executor
     //! \param interval [in] : length of wait interval (in milliseconds)
     //! \param call_back [in] : the call back function to be called
     //! \param auto_start [in] : whether to start the timer immediately
-    explicit Timer(boost::asio::io_context& asio_context, uint32_t interval, std::function<bool()> call_back,
-                   bool auto_start = false)
-        : interval_(interval), timer_(asio_context), call_back_(std::move(call_back)) {
+    explicit Timer(
+        boost::asio::any_io_executor executor,
+        uint32_t interval,
+        std::function<bool()> call_back,
+        bool auto_start = false)
+        : interval_(interval),
+          timer_(std::move(executor)),
+          call_back_(std::move(call_back)) {
         SILKWORM_ASSERT(interval > 0);
         if (auto_start) {
             start();

--- a/silkworm/infra/concurrency/awaitable_condition_variable.cpp
+++ b/silkworm/infra/concurrency/awaitable_condition_variable.cpp
@@ -28,14 +28,14 @@ namespace silkworm::concurrency {
 
 class AwaitableConditionVariableImpl {
   public:
-    std::function<boost::asio::awaitable<void>()> waiter() {
+    std::function<Task<void>()> waiter() {
         size_t waiter_version;
         {
             std::scoped_lock lock(mutex_);
             waiter_version = version_;
         }
 
-        return [this, waiter_version]() -> boost::asio::awaitable<void> {
+        return [this, waiter_version]() -> Task<void> {
             auto executor = co_await boost::asio::this_coro::executor;
 
             decltype(waiters_)::iterator waiter;
@@ -81,7 +81,7 @@ AwaitableConditionVariable::~AwaitableConditionVariable() {
     [[maybe_unused]] int non_trivial_destructor;  // silent clang-tidy
 }
 
-std::function<boost::asio::awaitable<void>()> AwaitableConditionVariable::waiter() {
+std::function<Task<void>()> AwaitableConditionVariable::waiter() {
     return p_impl_->waiter();
 }
 

--- a/silkworm/infra/concurrency/awaitable_condition_variable.hpp
+++ b/silkworm/infra/concurrency/awaitable_condition_variable.hpp
@@ -19,11 +19,7 @@
 #include <functional>
 #include <memory>
 
-#include <silkworm/infra/concurrency/coroutine.hpp>
-
-#include <boost/asio/any_io_executor.hpp>
-#include <boost/asio/awaitable.hpp>
-#include <boost/asio/io_context.hpp>
+#include "task.hpp"
 
 namespace silkworm::concurrency {
 
@@ -57,7 +53,7 @@ class AwaitableConditionVariable {
     AwaitableConditionVariable();
     virtual ~AwaitableConditionVariable();
 
-    using Waiter = std::function<boost::asio::awaitable<void>()>;
+    using Waiter = std::function<Task<void>()>;
 
     Waiter waiter();
     void notify_all();

--- a/silkworm/infra/concurrency/awaitable_future_test.cpp
+++ b/silkworm/infra/concurrency/awaitable_future_test.cpp
@@ -22,6 +22,7 @@
 #include <boost/asio/cancellation_signal.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
+#include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
 #include "active_component.hpp"
@@ -32,8 +33,8 @@ namespace asio = boost::asio;
 using concurrency::AwaitableFuture;
 using concurrency::AwaitablePromise;
 
-auto create_promise_and_set_value(asio::io_context& io, int value) {
-    concurrency::AwaitablePromise<int> promise{io};
+auto create_promise_and_set_value(asio::any_io_executor executor, int value) {
+    concurrency::AwaitablePromise<int> promise{std::move(executor)};
     promise.set_value(value);
     return promise.get_future();
 }
@@ -46,10 +47,9 @@ class TestException : public std::runtime_error {
 TEST_CASE("awaitable future") {
     asio::io_context io;
     asio::io_context::work work{io};
+    AwaitablePromise<int> promise{io.get_executor()};
 
     SECTION("trivial use") {
-        AwaitablePromise<int> promise{io};
-
         auto future = promise.get_future();
 
         promise.set_value(42);
@@ -59,7 +59,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("variation of the trivial use") {
-        AwaitablePromise<int> promise{io};
         promise.set_value(42);
 
         auto future = promise.get_future();
@@ -69,7 +68,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("setting exception instead of value") {
-        AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
         promise.set_exception(std::make_exception_ptr(TestException()));
@@ -78,7 +76,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("variation of setting exception instead of value") {
-        AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
         try {
@@ -91,23 +88,19 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("setting value two times fails") {
-        AwaitablePromise<int> promise{io};
-
         promise.set_value(42);
 
         CHECK_THROWS(promise.set_value(43));
     }
 
     SECTION("setting exception two times fails") {
-        AwaitablePromise<int> promise{io};
-
         promise.set_exception(std::make_exception_ptr(TestException()));
 
         CHECK_THROWS(promise.set_exception(std::make_exception_ptr(TestException())));
     }
 
     SECTION("returning the future from a function") {
-        auto future = create_promise_and_set_value(io, 42);
+        auto future = create_promise_and_set_value(io.get_executor(), 42);
 
         auto value = future.get();
 
@@ -115,10 +108,10 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("returning the future from a function (variation)") {
-        auto returned_future = [&]() {
-            concurrency::AwaitablePromise<int> promise{io};
-            auto future = promise.get_future();
-            promise.set_value(42);
+        auto returned_future = [executor = io.get_executor()]() {
+            concurrency::AwaitablePromise<int> promise1{executor};
+            auto future = promise1.get_future();
+            promise1.set_value(42);
             return future;
         }();
 
@@ -128,7 +121,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("writing and reading from different threads") {
-        AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
         int value;
@@ -148,7 +140,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("writing and reading from different threads") {
-        AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
         int value;
@@ -174,7 +165,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("using coroutines in read in the same io_context, write before read") {
-        AwaitablePromise<int> promise{io};
         int value;
 
         asio::co_spawn(
@@ -193,7 +183,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("variation of using coroutines in the same io_context, write before read") {
-        AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
         int value;
@@ -212,7 +201,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("moving AwaitableFuture") {
-        AwaitablePromise<int> promise{io};
         auto future = promise.get_future();
 
         int value;
@@ -230,7 +218,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("using coroutine for both read and write, read before write") {
-        AwaitablePromise<int> promise{io};
         int value;
 
         asio::co_spawn(
@@ -256,7 +243,6 @@ TEST_CASE("awaitable future") {
     }
 
     SECTION("cancellation after read") {
-        AwaitablePromise<int> promise{io};
         int value;
         boost::system::error_code code;
 

--- a/silkworm/infra/concurrency/channel_test.cpp
+++ b/silkworm/infra/concurrency/channel_test.cpp
@@ -48,7 +48,7 @@ TResult run(io_context& context, awaitable<TResult> awaitable1) {
 
 TEST_CASE("Channel.close_and_send") {
     io_context context;
-    Channel<int> channel{context};
+    Channel<int> channel{context.get_executor()};
     channel.close();
     // boost::asio::experimental::error::channel_errors::channel_closed
     CHECK_THROWS_AS(run(context, channel.send(1)), boost::system::system_error);
@@ -56,7 +56,7 @@ TEST_CASE("Channel.close_and_send") {
 
 TEST_CASE("Channel.close_and_receive") {
     io_context context;
-    Channel<int> channel{context};
+    Channel<int> channel{context.get_executor()};
     channel.close();
     // boost::asio::experimental::error::channel_errors::channel_closed
     CHECK_THROWS_AS(run(context, channel.receive()), boost::system::system_error);

--- a/silkworm/infra/concurrency/executor_pool.hpp
+++ b/silkworm/infra/concurrency/executor_pool.hpp
@@ -16,33 +16,13 @@
 
 #pragma once
 
-#include <variant>
-
-#include "task.hpp"
-
 #include <boost/asio/any_io_executor.hpp>
-
-#include "channel.hpp"
 
 namespace silkworm::concurrency {
 
-// A simplified condition variable similar to Rust Tokio Notify:
-// https://docs.rs/tokio/1.25.0/tokio/sync/struct.Notify.html
-// Only one waiter is supported.
-class EventNotifier {
-  public:
-    explicit EventNotifier(boost::asio::any_io_executor executor) : channel_(std::move(executor), 1) {}
-
-    Task<void> wait() {
-        co_await channel_.receive();
-    }
-
-    void notify() {
-        channel_.try_send({});
-    }
-
-  private:
-    Channel<std::monostate> channel_;
+struct ExecutorPool {
+    virtual ~ExecutorPool() = default;
+    [[nodiscard]] virtual boost::asio::any_io_executor any_executor() = 0;
 };
 
 }  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/task_group.cpp
+++ b/silkworm/infra/concurrency/task_group.cpp
@@ -32,7 +32,7 @@ namespace silkworm::concurrency {
 
 using namespace boost::asio;
 
-void TaskGroup::spawn(any_io_executor&& executor, awaitable<void> task) {
+void TaskGroup::spawn(any_io_executor executor, awaitable<void> task) {
     std::scoped_lock lock(mutex_);
 
     if (is_closed_) {

--- a/silkworm/infra/concurrency/task_group_test.cpp
+++ b/silkworm/infra/concurrency/task_group_test.cpp
@@ -79,33 +79,37 @@ static TResult run(io_context& context, awaitable<TResult> awaitable1) {
 
 TEST_CASE("TaskGroup.0") {
     io_context context;
-    TaskGroup group{context, 0};
+    auto executor = context.get_executor();
+    TaskGroup group{executor, 0};
     CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
 }
 
 TEST_CASE("TaskGroup.1") {
     io_context context;
-    TaskGroup group{context, 1};
-    group.spawn(context, async_ok());
+    auto executor = context.get_executor();
+    TaskGroup group{executor, 1};
+    group.spawn(executor, async_ok());
     CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
 }
 
 TEST_CASE("TaskGroup.1.wait_until_cancelled") {
     io_context context;
-    TaskGroup group{context, 1};
+    auto executor = context.get_executor();
+    TaskGroup group{executor, 1};
     bool is_cancelled = false;
-    group.spawn(context, wait_until_cancelled(&is_cancelled));
+    group.spawn(executor, wait_until_cancelled(&is_cancelled));
     CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
     CHECK(is_cancelled);
 }
 
 TEST_CASE("TaskGroup.some.wait_until_cancelled") {
     io_context context;
-    TaskGroup group{context, 3};
+    auto executor = context.get_executor();
+    TaskGroup group{executor, 3};
     std::array<bool, 3> is_cancelled{};
-    group.spawn(context, wait_until_cancelled(&is_cancelled[0]));
-    group.spawn(context, wait_until_cancelled(&is_cancelled[1]));
-    group.spawn(context, wait_until_cancelled(&is_cancelled[2]));
+    group.spawn(executor, wait_until_cancelled(&is_cancelled[0]));
+    group.spawn(executor, wait_until_cancelled(&is_cancelled[1]));
+    group.spawn(executor, wait_until_cancelled(&is_cancelled[2]));
     CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
     CHECK(is_cancelled[0]);
     CHECK(is_cancelled[1]);
@@ -114,14 +118,15 @@ TEST_CASE("TaskGroup.some.wait_until_cancelled") {
 
 TEST_CASE("TaskGroup.some.mix") {
     io_context context;
-    TaskGroup group{context, 6};
+    auto executor = context.get_executor();
+    TaskGroup group{executor, 6};
     std::array<bool, 3> is_cancelled{};
-    group.spawn(context, async_ok());
-    group.spawn(context, wait_until_cancelled(&is_cancelled[0]));
-    group.spawn(context, async_ok());
-    group.spawn(context, wait_until_cancelled(&is_cancelled[1]));
-    group.spawn(context, async_ok());
-    group.spawn(context, wait_until_cancelled(&is_cancelled[2]));
+    group.spawn(executor, async_ok());
+    group.spawn(executor, wait_until_cancelled(&is_cancelled[0]));
+    group.spawn(executor, async_ok());
+    group.spawn(executor, wait_until_cancelled(&is_cancelled[1]));
+    group.spawn(executor, async_ok());
+    group.spawn(executor, wait_until_cancelled(&is_cancelled[2]));
     CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
     CHECK(is_cancelled[0]);
     CHECK(is_cancelled[1]);
@@ -130,9 +135,10 @@ TEST_CASE("TaskGroup.some.mix") {
 
 TEST_CASE("TaskGroup.spawn_after_close") {
     io_context context;
-    TaskGroup group{context, 1};
+    auto executor = context.get_executor();
+    TaskGroup group{executor, 1};
     CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
-    CHECK_THROWS_AS(group.spawn(context, async_ok()), TaskGroup::SpawnAfterCloseError);
+    CHECK_THROWS_AS(group.spawn(executor, async_ok()), TaskGroup::SpawnAfterCloseError);
 }
 
 }  // namespace silkworm::concurrency

--- a/silkworm/infra/grpc/client/client_context_pool.hpp
+++ b/silkworm/infra/grpc/client/client_context_pool.hpp
@@ -24,7 +24,6 @@
 
 #include <agrpc/asio_grpc.hpp>
 #include <boost/asio/executor_work_guard.hpp>
-#include <boost/asio/io_context.hpp>
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/infra/concurrency/context_pool.hpp>

--- a/silkworm/infra/grpc/server/call.hpp
+++ b/silkworm/infra/grpc/server/call.hpp
@@ -23,9 +23,6 @@
 #include <utility>
 
 #include <agrpc/repeatedly_request.hpp>
-#include <boost/asio/deadline_timer.hpp>
-#include <boost/asio/io_context.hpp>
-#include <boost/date_time/posix_time/posix_time_io.hpp>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>

--- a/silkworm/infra/grpc/server/server_context_pool.hpp
+++ b/silkworm/infra/grpc/server/server_context_pool.hpp
@@ -22,7 +22,6 @@
 #include <ostream>
 
 #include <agrpc/asio_grpc.hpp>
-#include <boost/asio/io_context.hpp>
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/infra/concurrency/context_pool.hpp>

--- a/silkworm/node/stagedsync/execution_engine.cpp
+++ b/silkworm/node/stagedsync/execution_engine.cpp
@@ -138,14 +138,14 @@ auto ExecutionEngine::verify_chain(Hash head_block_hash) -> concurrency::Awaitab
 
     if (last_fork_choice_.hash == head_block_hash) {
         SILK_DEBUG << "ExecutionEngine: chain " << head_block_hash.to_hex() << " already verified";
-        concurrency::AwaitablePromise<VerificationResult> promise{io_context_};
+        concurrency::AwaitablePromise<VerificationResult> promise{io_context_.get_executor()};
         promise.set_value(ValidChain{last_fork_choice_});
         return promise.get_future();
     }
 
     if (!fork_tracking_active_) {
         auto verification = main_chain_.verify_chain(head_block_hash);  // BLOCKING
-        concurrency::AwaitablePromise<VerificationResult> promise{io_context_};
+        concurrency::AwaitablePromise<VerificationResult> promise{io_context_.get_executor()};
         promise.set_value(std::move(verification));
         return promise.get_future();
     }
@@ -154,12 +154,12 @@ auto ExecutionEngine::verify_chain(Hash head_block_hash) -> concurrency::Awaitab
     if (fork == forks_.end()) {
         if (main_chain_.is_canonical(head_block_hash)) {
             SILK_DEBUG << "ExecutionEngine: chain " << head_block_hash.to_hex() << " already verified";
-            concurrency::AwaitablePromise<VerificationResult> promise{io_context_};
+            concurrency::AwaitablePromise<VerificationResult> promise{io_context_.get_executor()};
             promise.set_value(ValidChain{last_fork_choice_});
             return promise.get_future();
         } else {
             SILK_WARN << "ExecutionEngine: chain " << head_block_hash.to_hex() << " not found at verification time";
-            concurrency::AwaitablePromise<VerificationResult> promise{io_context_};
+            concurrency::AwaitablePromise<VerificationResult> promise{io_context_.get_executor()};
             promise.set_value(ValidationError{});
             return promise.get_future();
         }

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -30,8 +30,6 @@
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
-#include <silkworm/infra/common/asio_timer.hpp>
-#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -19,7 +19,9 @@
 #include <boost/format.hpp>
 #include <magic_enum.hpp>
 
+#include <silkworm/infra/common/asio_timer.hpp>
 #include <silkworm/infra/common/environment.hpp>
+#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/stagedsync/stages/stage_blockhashes.hpp>
 #include <silkworm/node/stagedsync/stages/stage_bodies.hpp>
 #include <silkworm/node/stagedsync/stages/stage_execution.hpp>
@@ -46,7 +48,7 @@ class ExecutionPipeline::LogTimer : public Timer {
   public:
     LogTimer(ExecutionPipeline* pipeline)
         : Timer{
-              pipeline->node_settings_->asio_context,
+              pipeline->node_settings_->asio_context.get_executor(),
               pipeline->node_settings_->sync_loop_log_interval_seconds * 1'000,
               [this] { return execute(); },
               true},

--- a/silkworm/node/stagedsync/execution_pipeline.hpp
+++ b/silkworm/node/stagedsync/execution_pipeline.hpp
@@ -21,8 +21,6 @@
 #include <vector>
 
 #include <silkworm/core/types/hash.hpp>
-#include <silkworm/infra/common/asio_timer.hpp>
-#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
@@ -64,4 +62,5 @@ class ExecutionPipeline : public Stoppable {
     std::string get_log_prefix() const;  // Returns the current log lines prefix on behalf of current stage
     class LogTimer;                      // Timer for async log scheduling
 };
+
 }  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/forks/canonical_chain.hpp
+++ b/silkworm/node/stagedsync/forks/canonical_chain.hpp
@@ -25,8 +25,6 @@
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
-#include <silkworm/infra/common/asio_timer.hpp>
-#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>

--- a/silkworm/node/stagedsync/forks/extending_fork.cpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.cpp
@@ -96,7 +96,7 @@ void ExtendingFork::extend_with(Hash head_hash, const Block& block) {
 auto ExtendingFork::verify_chain() -> concurrency::AwaitableFuture<VerificationResult> {
     propagate_exception_if_any();
 
-    concurrency::AwaitablePromise<VerificationResult> promise{io_context_};  // note: promise uses an external io_context
+    concurrency::AwaitablePromise<VerificationResult> promise{io_context_.get_executor()};  // note: promise uses an external io_context
     auto awaitable_future = promise.get_future();
 
     post(*executor_, [this, promise_ = std::move(promise)]() mutable {
@@ -117,7 +117,7 @@ auto ExtendingFork::fork_choice(Hash head_block_hash, std::optional<Hash> finali
     -> concurrency::AwaitableFuture<bool> {
     propagate_exception_if_any();
 
-    concurrency::AwaitablePromise<bool> promise{io_context_};  // note: promise uses an external io_context
+    concurrency::AwaitablePromise<bool> promise{io_context_.get_executor()};  // note: promise uses an external io_context
     auto awaitable_future = promise.get_future();
 
     post(*executor_, [this, promise_ = std::move(promise), head_block_hash, finalized_block_hash]() mutable {

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/infra/common/ensure.hpp>
+#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 
 #include "extending_fork.hpp"

--- a/silkworm/node/stagedsync/forks/main_chain.hpp
+++ b/silkworm/node/stagedsync/forks/main_chain.hpp
@@ -27,8 +27,6 @@
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
-#include <silkworm/infra/common/asio_timer.hpp>
-#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/db/memory_mutation.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -22,7 +22,6 @@
 
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/measure.hpp>
-#include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/common/preverified_hashes.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 #include <silkworm/node/db/stages.hpp>

--- a/silkworm/sentry/common/socket_stream.hpp
+++ b/silkworm/sentry/common/socket_stream.hpp
@@ -19,7 +19,6 @@
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <boost/asio/any_io_executor.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
 #include <silkworm/core/common/base.hpp>
@@ -28,9 +27,7 @@ namespace silkworm::sentry {
 
 class SocketStream {
   public:
-    explicit SocketStream(boost::asio::any_io_executor&& executor) : socket_(executor) {}
-    explicit SocketStream(boost::asio::any_io_executor& executor) : socket_(executor) {}
-    explicit SocketStream(boost::asio::io_context& io_context) : socket_(io_context) {}
+    explicit SocketStream(boost::asio::any_io_executor executor) : socket_(std::move(executor)) {}
 
     SocketStream(SocketStream&&) = default;
     SocketStream& operator=(SocketStream&&) = default;

--- a/silkworm/sentry/discovery/discovery.cpp
+++ b/silkworm/sentry/discovery/discovery.cpp
@@ -32,7 +32,7 @@ using namespace boost::asio;
 class DiscoveryImpl {
   public:
     explicit DiscoveryImpl(
-        std::function<boost::asio::any_io_executor()> executor_pool,
+        concurrency::ExecutorPool& executor_pool,
         std::vector<EnodeUrl> peer_urls,
         bool with_dynamic_discovery,
         const std::filesystem::path& data_dir_path,
@@ -64,7 +64,7 @@ class DiscoveryImpl {
 };
 
 DiscoveryImpl::DiscoveryImpl(
-    std::function<boost::asio::any_io_executor()> executor_pool,
+    concurrency::ExecutorPool& executor_pool,
     std::vector<EnodeUrl> peer_urls,
     bool with_dynamic_discovery,
     const std::filesystem::path& data_dir_path,
@@ -74,8 +74,8 @@ DiscoveryImpl::DiscoveryImpl(
     : peer_urls_(std::move(peer_urls)),
       with_dynamic_discovery_(with_dynamic_discovery),
       data_dir_path_(data_dir_path),
-      node_db_(executor_pool()),
-      disc_v4_discovery_(executor_pool(), disc_v4_port, node_key, node_url, node_db_.interface()) {
+      node_db_(executor_pool.any_executor()),
+      disc_v4_discovery_(executor_pool.any_executor(), disc_v4_port, node_key, node_url, node_db_.interface()) {
 }
 
 Task<void> DiscoveryImpl::run() {
@@ -159,7 +159,7 @@ Task<void> DiscoveryImpl::on_peer_disconnected(EccPublicKey peer_public_key, boo
 }
 
 Discovery::Discovery(
-    std::function<boost::asio::any_io_executor()> executor_pool,
+    concurrency::ExecutorPool& executor_pool,
     std::vector<EnodeUrl> peer_urls,
     bool with_dynamic_discovery,
     const std::filesystem::path& data_dir_path,
@@ -167,7 +167,7 @@ Discovery::Discovery(
     std::function<EnodeUrl()> node_url,
     uint16_t disc_v4_port)
     : p_impl_(std::make_unique<DiscoveryImpl>(
-          std::move(executor_pool),
+          executor_pool,
           std::move(peer_urls),
           with_dynamic_discovery,
           data_dir_path,

--- a/silkworm/sentry/discovery/discovery.hpp
+++ b/silkworm/sentry/discovery/discovery.hpp
@@ -23,8 +23,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/any_io_executor.hpp>
-
+#include <silkworm/infra/concurrency/executor_pool.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/enode_url.hpp>
@@ -36,7 +35,7 @@ class DiscoveryImpl;
 class Discovery {
   public:
     explicit Discovery(
-        std::function<boost::asio::any_io_executor()> executor_pool,
+        concurrency::ExecutorPool& executor_pool,
         std::vector<EnodeUrl> peer_urls,
         bool with_dynamic_discovery,
         const std::filesystem::path& data_dir_path,

--- a/silkworm/sentry/grpc/server/server_calls.hpp
+++ b/silkworm/sentry/grpc/server/server_calls.hpp
@@ -52,7 +52,6 @@
 
 namespace silkworm::sentry::grpc::server {
 
-using boost::asio::io_context;
 namespace protobuf = google::protobuf;
 namespace proto = ::sentry;
 namespace proto_types = ::types;

--- a/silkworm/sentry/message_receiver.hpp
+++ b/silkworm/sentry/message_receiver.hpp
@@ -21,7 +21,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/io_context.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/strand.hpp>
 
 #include <silkworm/infra/concurrency/channel.hpp>
@@ -38,9 +38,9 @@ namespace silkworm::sentry {
 
 class MessageReceiver : public PeerManagerObserver {
   public:
-    MessageReceiver(boost::asio::io_context& io_context, size_t max_peers)
-        : message_calls_channel_(io_context),
-          strand_(boost::asio::make_strand(io_context)),
+    MessageReceiver(boost::asio::any_io_executor executor, size_t max_peers)
+        : message_calls_channel_(executor),
+          strand_(boost::asio::make_strand(executor)),
           peer_tasks_(strand_, max_peers),
           unsubscription_tasks_(strand_, 1000) {}
 
@@ -64,7 +64,7 @@ class MessageReceiver : public PeerManagerObserver {
     Task<void> on_peer_added_in_strand(std::shared_ptr<rlpx::Peer> peer);
 
     concurrency::Channel<api::router::MessagesCall> message_calls_channel_;
-    boost::asio::strand<boost::asio::io_context::executor_type> strand_;
+    boost::asio::strand<boost::asio::any_io_executor> strand_;
     concurrency::TaskGroup peer_tasks_;
     concurrency::TaskGroup unsubscription_tasks_;
 

--- a/silkworm/sentry/message_sender.hpp
+++ b/silkworm/sentry/message_sender.hpp
@@ -18,7 +18,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/io_context.hpp>
+#include <boost/asio/any_io_executor.hpp>
 
 #include <silkworm/infra/concurrency/channel.hpp>
 #include <silkworm/sentry/api/router/send_message_call.hpp>
@@ -29,8 +29,8 @@ namespace silkworm::sentry {
 
 class MessageSender {
   public:
-    explicit MessageSender(boost::asio::io_context& io_context)
-        : send_message_channel_(io_context) {}
+    explicit MessageSender(boost::asio::any_io_executor executor)
+        : send_message_channel_(std::move(executor)) {}
 
     concurrency::Channel<api::router::SendMessageCall>& send_message_channel() {
         return send_message_channel_;

--- a/silkworm/sentry/peer_manager.cpp
+++ b/silkworm/sentry/peer_manager.cpp
@@ -234,8 +234,7 @@ Task<void> PeerManager::connect_peer(EnodeUrl peer_url, bool is_static_peer, std
     auto _ = gsl::finally([this, peer_url] { this->connecting_peer_urls_.erase(peer_url); });
 
     try {
-        auto& client_context = context_pool_.next_io_context();
-        auto peer1 = co_await concurrency::co_spawn_sw(client_context, client->connect(peer_url, is_static_peer), use_awaitable);
+        auto peer1 = co_await concurrency::co_spawn_sw(executor_pool_.any_executor(), client->connect(peer_url, is_static_peer), use_awaitable);
         auto peer = std::shared_ptr(std::move(peer1));
         co_await client_peer_channel_.send(peer);
     } catch (const boost::system::system_error& ex) {

--- a/silkworm/sentry/peer_manager_api.hpp
+++ b/silkworm/sentry/peer_manager_api.hpp
@@ -22,7 +22,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/io_context.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/strand.hpp>
 
 #include <silkworm/infra/concurrency/awaitable_future.hpp>
@@ -44,17 +44,17 @@ namespace silkworm::sentry {
 class PeerManagerApi : public PeerManagerObserver {
   public:
     explicit PeerManagerApi(
-        boost::asio::io_context& io_context,
+        boost::asio::any_io_executor executor,
         PeerManager& peer_manager)
         : peer_manager_(peer_manager),
-          peer_count_calls_channel_(io_context),
-          peers_calls_channel_(io_context),
-          peer_calls_channel_(io_context),
-          peer_penalize_calls_channel_(io_context),
-          peer_events_calls_channel_(io_context),
-          strand_(boost::asio::make_strand(io_context)),
+          peer_count_calls_channel_(executor),
+          peers_calls_channel_(executor),
+          peer_calls_channel_(executor),
+          peer_penalize_calls_channel_(executor),
+          peer_events_calls_channel_(executor),
+          strand_(boost::asio::make_strand(executor)),
           events_unsubscription_tasks_(strand_, 1000),
-          peer_events_channel_(io_context, 1000) {}
+          peer_events_channel_(executor, 1000) {}
 
     static Task<void> run(std::shared_ptr<PeerManagerApi> self);
 
@@ -109,7 +109,7 @@ class PeerManagerApi : public PeerManagerObserver {
     };
 
     std::list<Subscription> events_subscriptions_;
-    boost::asio::strand<boost::asio::io_context::executor_type> strand_;
+    boost::asio::strand<boost::asio::any_io_executor> strand_;
     concurrency::TaskGroup events_unsubscription_tasks_;
     Channel<api::PeerEvent> peer_events_channel_;
 };

--- a/silkworm/sentry/rlpx/peer.cpp
+++ b/silkworm/sentry/rlpx/peer.cpp
@@ -40,7 +40,7 @@ using namespace std::chrono_literals;
 using namespace boost::asio;
 
 Peer::Peer(
-    any_io_executor&& executor,
+    any_io_executor executor,
     SocketStream stream,
     EccKeyPair node_key,
     std::string client_id,

--- a/silkworm/sentry/rlpx/peer.hpp
+++ b/silkworm/sentry/rlpx/peer.hpp
@@ -23,7 +23,6 @@
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <boost/asio/any_io_executor.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/strand.hpp>
 
@@ -47,7 +46,7 @@ namespace silkworm::sentry::rlpx {
 class Peer {
   public:
     Peer(
-        boost::asio::any_io_executor&& executor,
+        boost::asio::any_io_executor executor,
         SocketStream stream,
         EccKeyPair node_key,
         std::string client_id,
@@ -57,52 +56,6 @@ class Peer {
         std::optional<EccPublicKey> peer_public_key,
         bool is_inbound,
         bool is_static);
-
-    Peer(
-        boost::asio::any_io_executor& executor,
-        SocketStream stream,
-        EccKeyPair node_key,
-        std::string client_id,
-        uint16_t node_listen_port,
-        std::unique_ptr<Protocol> protocol,
-        std::optional<EnodeUrl> url,
-        std::optional<EccPublicKey> peer_public_key,
-        bool is_inbound,
-        bool is_static)
-        : Peer(
-              boost::asio::any_io_executor{executor},
-              std::move(stream),
-              std::move(node_key),
-              std::move(client_id),
-              node_listen_port,
-              std::move(protocol),
-              std::move(url),
-              std::move(peer_public_key),
-              is_inbound,
-              is_static) {}
-
-    Peer(
-        boost::asio::io_context& io_context,
-        SocketStream stream,
-        EccKeyPair node_key,
-        std::string client_id,
-        uint16_t node_listen_port,
-        std::unique_ptr<Protocol> protocol,
-        std::optional<EnodeUrl> url,
-        std::optional<EccPublicKey> peer_public_key,
-        bool is_inbound,
-        bool is_static)
-        : Peer(
-              boost::asio::any_io_executor{io_context.get_executor()},
-              std::move(stream),
-              std::move(node_key),
-              std::move(client_id),
-              node_listen_port,
-              std::move(protocol),
-              std::move(url),
-              std::move(peer_public_key),
-              is_inbound,
-              is_static) {}
 
     ~Peer();
 

--- a/silkworm/sentry/rlpx/server.cpp
+++ b/silkworm/sentry/rlpx/server.cpp
@@ -29,18 +29,18 @@ namespace silkworm::sentry::rlpx {
 using namespace boost::asio;
 
 Server::Server(
-    io_context& io_context,
+    any_io_executor executor,
     uint16_t port)
     : ip_(ip::address{ip::address_v4::any()}),
       port_(port),
-      peer_channel_(io_context) {}
+      peer_channel_(std::move(executor)) {}
 
 ip::tcp::endpoint Server::listen_endpoint() const {
     return ip::tcp::endpoint{ip_, port_};
 }
 
 Task<void> Server::run(
-    silkworm::rpc::ServerContextPool& context_pool,
+    concurrency::ExecutorPool& executor_pool,
     EccKeyPair node_key,
     std::string client_id,
     std::function<std::unique_ptr<Protocol>()> protocol_factory) {
@@ -66,15 +66,15 @@ Task<void> Server::run(
     log::Info("sentry") << "rlpx::Server is listening at " << node_url.to_string();
 
     while (acceptor.is_open()) {
-        auto& client_context = context_pool.next_io_context();
-        SocketStream stream{client_context};
+        auto client_executor = executor_pool.any_executor();
+        SocketStream stream{client_executor};
         co_await acceptor.async_accept(stream.socket(), use_awaitable);
 
         auto remote_endpoint = stream.socket().remote_endpoint();
         log::Debug("sentry") << "rlpx::Server client connected from " << remote_endpoint;
 
         auto peer = std::make_shared<Peer>(
-            client_context,
+            client_executor,
             std::move(stream),
             node_key,
             client_id,

--- a/silkworm/sentry/rlpx/server.hpp
+++ b/silkworm/sentry/rlpx/server.hpp
@@ -22,12 +22,11 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
 #include <silkworm/infra/concurrency/channel.hpp>
-#include <silkworm/infra/grpc/server/server_context_pool.hpp>
+#include <silkworm/infra/concurrency/executor_pool.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 
 #include "peer.hpp"
@@ -38,11 +37,11 @@ namespace silkworm::sentry::rlpx {
 class Server final {
   public:
     Server(
-        boost::asio::io_context& io_context,
+        boost::asio::any_io_executor executor,
         uint16_t port);
 
     Task<void> run(
-        silkworm::rpc::ServerContextPool& context_pool,
+        concurrency::ExecutorPool& executor_pool,
         EccKeyPair node_key,
         std::string client_id,
         std::function<std::unique_ptr<Protocol>()> protocol_factory);

--- a/silkworm/sentry/sentry.hpp
+++ b/silkworm/sentry/sentry.hpp
@@ -16,11 +16,12 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <silkworm/infra/grpc/server/server_context_pool.hpp>
+#include <silkworm/infra/concurrency/executor_pool.hpp>
 
 #include "api/common/sentry_client.hpp"
 #include "settings.hpp"
@@ -31,7 +32,7 @@ class SentryImpl;
 
 class Sentry final : public api::SentryClient {
   public:
-    explicit Sentry(Settings settings, silkworm::rpc::ServerContextPool& context_pool);
+    explicit Sentry(Settings settings, concurrency::ExecutorPool& executor_pool);
     ~Sentry() override;
 
     Sentry(const Sentry&) = delete;

--- a/silkworm/sentry/status_manager.hpp
+++ b/silkworm/sentry/status_manager.hpp
@@ -18,7 +18,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/io_context.hpp>
+#include <boost/asio/any_io_executor.hpp>
 
 #include <silkworm/infra/concurrency/channel.hpp>
 #include <silkworm/sentry/common/atomic_value.hpp>
@@ -29,8 +29,8 @@ namespace silkworm::sentry {
 
 class StatusManager {
   public:
-    StatusManager(boost::asio::io_context& io_context)
-        : status_channel_(io_context),
+    StatusManager(boost::asio::any_io_executor executor)
+        : status_channel_(std::move(executor)),
           status_(eth::StatusData{}) {}
 
     Task<void> wait_for_status();

--- a/silkworm/sync/sentry_client.hpp
+++ b/silkworm/sync/sentry_client.hpp
@@ -24,8 +24,8 @@
 
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/signals2.hpp>
 
 #include <silkworm/infra/concurrency/task_group.hpp>
@@ -44,7 +44,7 @@ namespace silkworm {
 class SentryClient {
   public:
     explicit SentryClient(
-        boost::asio::io_context& io_context,
+        boost::asio::any_io_executor executor,
         std::shared_ptr<silkworm::sentry::api::SentryClient> sentry_client);
 
     SentryClient(const SentryClient&) = delete;
@@ -109,7 +109,7 @@ class SentryClient {
     // notifying registered subscribers
     boost::asio::awaitable<void> publish(const silkworm::sentry::api::MessageFromPeer& message_from_peer);
 
-    boost::asio::io_context& io_context_;
+    boost::asio::any_io_executor executor_;
     std::shared_ptr<silkworm::sentry::api::SentryClient> sentry_client_;
     concurrency::TaskGroup tasks_;
 

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -24,13 +24,13 @@
 
 namespace silkworm::chainsync {
 
-Sync::Sync(boost::asio::io_context& io_context,
+Sync::Sync(boost::asio::any_io_executor executor,
            mdbx::env_managed& chaindata_env,
            execution::Client& execution,
            const std::shared_ptr<silkworm::sentry::api::SentryClient>& sentry_client,
            const ChainConfig& config,
            const EngineRpcSettings& rpc_settings)
-    : sync_sentry_client_{io_context, sentry_client},
+    : sync_sentry_client_{std::move(executor), sentry_client},
       block_exchange_{sync_sentry_client_, db::ROAccess{chaindata_env}, config} {
     // If terminal total difficulty is present in chain config, the network will use Proof-of-Stake sooner or later
     if (config.terminal_total_difficulty) {

--- a/silkworm/sync/sync.hpp
+++ b/silkworm/sync/sync.hpp
@@ -19,8 +19,8 @@
 #include <memory>
 #include <optional>
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/io_context.hpp>
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -46,7 +46,7 @@ struct EngineRpcSettings {
 
 class Sync {
   public:
-    Sync(boost::asio::io_context& io_context,
+    Sync(boost::asio::any_io_executor executor,
          mdbx::env_managed& chaindata_env,
          execution::Client& execution,
          const std::shared_ptr<silkworm::sentry::api::SentryClient>& sentry_client,


### PR DESCRIPTION
use an any_io_executor factory instead of ServerContextPool,
and any_io_executor instead of io_context