### PR TITLE
infra: rethrow unhandled exceptions from TaskGroup::wait

### DIFF
--- a/silkworm/infra/concurrency/task_group.cpp
+++ b/silkworm/infra/concurrency/task_group.cpp
@@ -56,12 +56,13 @@ void TaskGroup::spawn(any_io_executor executor, Task<void> task) {
 }
 
 Task<void> TaskGroup::wait() {
-    // wait until cancelled
+    // wait until cancelled or a task throws an exception
+    std::exception_ptr ex_ptr;
     try {
-        co_await completions_.receive();
+        ex_ptr = co_await exceptions_.receive();
     } catch (const boost::system::system_error& ex) {
         if (ex.code() == boost::system::errc::operation_canceled) {
-            close();
+            ex_ptr = std::current_exception();
         } else {
             log::Error() << "TaskGroup::wait system_error: " << ex.what();
             throw;
@@ -69,17 +70,23 @@ Task<void> TaskGroup::wait() {
     }
 
     co_await this_coro::reset_cancellation_state();
+    close();
 
     // wait for all tasks completions
     while (!is_completed()) {
-        auto completed_task_id = co_await completions_.receive();
+        auto [completed_task_id, result_ex_ptr] = co_await completions_.receive();
+
         {
             std::scoped_lock lock(mutex_);
             tasks_.erase(completed_task_id);
         }
+
+        if (result_ex_ptr) {
+            ex_ptr = result_ex_ptr;
+        }
     }
 
-    throw boost::system::system_error(make_error_code(boost::system::errc::operation_canceled));
+    std::rethrow_exception(ex_ptr);
 }
 
 void TaskGroup::close() {
@@ -90,30 +97,35 @@ void TaskGroup::close() {
     }
 }
 
-void TaskGroup::on_complete(std::size_t task_id, const std::exception_ptr& ex_ptr) {
-    // rethrow exception unless it is an expected operation_canceled
+static bool is_operation_cancelled_error(const std::exception_ptr& ex_ptr) {
     try {
-        if (ex_ptr) {
-            std::rethrow_exception(ex_ptr);
-        }
+        std::rethrow_exception(ex_ptr);
     } catch (const boost::system::system_error& e) {
-        if (e.code() != boost::system::errc::operation_canceled) {
-            log::Error() << "TaskGroup::on_complete system_error: " << e.what();
-            throw;
-        }
-    } catch (const std::exception& e) {
-        log::Error() << "TaskGroup::on_complete exception: " << e.what();
-        throw;
+        return (e.code() == boost::system::errc::operation_canceled);
+    } catch (...) {
+        return false;
     }
+}
+
+void TaskGroup::on_complete(std::size_t task_id, const std::exception_ptr& ex_ptr) {
+    bool is_cancelled = ex_ptr && is_operation_cancelled_error(ex_ptr);
 
     std::scoped_lock lock(mutex_);
     if (is_closed_) {
-        bool ok = completions_.try_send(task_id);
+        // if a task threw during cancellation - rethrow from wait()
+        auto result_ex_ptr = (ex_ptr && !is_cancelled) ? ex_ptr : std::exception_ptr{};
+
+        bool ok = completions_.try_send({task_id, result_ex_ptr});
         if (!ok) {
             throw std::runtime_error("TaskGroup::on_complete: completions queue is full, unexpected max_tasks limit breach");
         }
     } else {
         tasks_.erase(task_id);
+
+        // if a task threw - rethrow from wait()
+        if (ex_ptr && !is_cancelled) {
+            exceptions_.try_send(ex_ptr);
+        }
     }
 }
 

--- a/silkworm/infra/concurrency/task_group.hpp
+++ b/silkworm/infra/concurrency/task_group.hpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <mutex>
 #include <stdexcept>
+#include <utility>
 
 #include "task.hpp"
 
@@ -66,7 +67,8 @@ namespace silkworm::concurrency {
 class TaskGroup {
   public:
     TaskGroup(boost::asio::any_io_executor executor, std::size_t max_tasks)
-        : completions_(std::move(executor), max_tasks) {}
+        : completions_(executor, max_tasks),
+          exceptions_(executor, 1) {}
 
     TaskGroup(const TaskGroup&) = delete;
     TaskGroup& operator=(const TaskGroup&) = delete;
@@ -91,7 +93,8 @@ class TaskGroup {
     bool is_closed_{false};
     std::size_t last_task_id_{0};
     std::map<std::size_t, boost::asio::cancellation_signal> tasks_;
-    concurrency::Channel<std::size_t> completions_;
+    concurrency::Channel<std::pair<std::size_t, std::exception_ptr>> completions_;
+    concurrency::Channel<std::exception_ptr> exceptions_;
 };
 
 }  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/task_group_test.cpp
+++ b/silkworm/infra/concurrency/task_group_test.cpp
@@ -18,24 +18,24 @@
 
 #include <array>
 #include <chrono>
-#include <future>
 #include <stdexcept>
+#include <string_view>
 
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/this_coro.hpp>
-#include <boost/asio/use_future.hpp>
+#include <boost/system/errc.hpp>
 #include <boost/system/system_error.hpp>
 #include <catch2/catch.hpp>
 
 #include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
+#include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
+#include <silkworm/infra/test_util/task_runner.hpp>
 
 namespace silkworm::concurrency {
 
 using namespace boost::asio;
 using namespace std::chrono_literals;
-using namespace concurrency::awaitable_wait_for_all;
+using namespace awaitable_wait_for_all;
 
 static Task<void> async_ok() {
     co_await this_coro::executor;
@@ -62,62 +62,55 @@ static Task<void> wait_until_cancelled(bool* is_cancelled) {
     }
 }
 
-template <typename TResult>
-static TResult run(io_context& context, Task<TResult> awaitable1) {
-    auto task = co_spawn(
-        context,
-        std::move(awaitable1),
-        use_future);
-
-    while (task.wait_for(0s) == std::future_status::timeout) {
-        context.poll_one();
-    }
-
-    return task.get();
+static Task<void> sleep(std::chrono::milliseconds duration) {
+    auto executor = co_await this_coro::executor;
+    steady_timer timer(executor);
+    timer.expires_after(duration);
+    co_await timer.async_wait(use_awaitable);
 }
 
 TEST_CASE("TaskGroup.0") {
-    io_context context;
-    auto executor = context.get_executor();
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
     TaskGroup group{executor, 0};
-    CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
+    CHECK_THROWS_AS(runner.run(group.wait() && async_throw()), TestException);
 }
 
 TEST_CASE("TaskGroup.1") {
-    io_context context;
-    auto executor = context.get_executor();
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
     TaskGroup group{executor, 1};
     group.spawn(executor, async_ok());
-    CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
+    CHECK_THROWS_AS(runner.run(group.wait() && async_throw()), TestException);
 }
 
 TEST_CASE("TaskGroup.1.wait_until_cancelled") {
-    io_context context;
-    auto executor = context.get_executor();
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
     TaskGroup group{executor, 1};
     bool is_cancelled = false;
     group.spawn(executor, wait_until_cancelled(&is_cancelled));
-    CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
+    CHECK_THROWS_AS(runner.run(group.wait() && async_throw()), TestException);
     CHECK(is_cancelled);
 }
 
 TEST_CASE("TaskGroup.some.wait_until_cancelled") {
-    io_context context;
-    auto executor = context.get_executor();
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
     TaskGroup group{executor, 3};
     std::array<bool, 3> is_cancelled{};
     group.spawn(executor, wait_until_cancelled(&is_cancelled[0]));
     group.spawn(executor, wait_until_cancelled(&is_cancelled[1]));
     group.spawn(executor, wait_until_cancelled(&is_cancelled[2]));
-    CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
+    CHECK_THROWS_AS(runner.run(group.wait() && async_throw()), TestException);
     CHECK(is_cancelled[0]);
     CHECK(is_cancelled[1]);
     CHECK(is_cancelled[2]);
 }
 
 TEST_CASE("TaskGroup.some.mix") {
-    io_context context;
-    auto executor = context.get_executor();
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
     TaskGroup group{executor, 6};
     std::array<bool, 3> is_cancelled{};
     group.spawn(executor, async_ok());
@@ -126,18 +119,79 @@ TEST_CASE("TaskGroup.some.mix") {
     group.spawn(executor, wait_until_cancelled(&is_cancelled[1]));
     group.spawn(executor, async_ok());
     group.spawn(executor, wait_until_cancelled(&is_cancelled[2]));
-    CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
+    CHECK_THROWS_AS(runner.run(group.wait() && async_throw()), TestException);
     CHECK(is_cancelled[0]);
     CHECK(is_cancelled[1]);
     CHECK(is_cancelled[2]);
 }
 
 TEST_CASE("TaskGroup.spawn_after_close") {
-    io_context context;
-    auto executor = context.get_executor();
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
     TaskGroup group{executor, 1};
-    CHECK_THROWS_AS(run(context, group.wait() && async_throw()), TestException);
+    CHECK_THROWS_AS(runner.run(group.wait() && async_throw()), TestException);
     CHECK_THROWS_AS(group.spawn(executor, async_ok()), TaskGroup::SpawnAfterCloseError);
+}
+
+TEST_CASE("TaskGroup.task_exception_is_rethrown") {
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
+    TaskGroup group{executor, 1};
+    group.spawn(executor, async_throw());
+
+    auto test = [&]() -> Task<bool> {
+        try {
+            co_await group.wait();
+            co_return false;
+        } catch (const TestException&) {
+            co_return true;
+        }
+    };
+    CHECK(runner.run(test()));
+}
+
+TEST_CASE("TaskGroup.task_cancelled_exception_is_ignored") {
+    using namespace awaitable_wait_for_one;
+
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
+    TaskGroup group{executor, 1};
+
+    auto task = [&]() -> Task<void> {
+        co_await boost::asio::this_coro::executor;
+        throw boost::system::system_error(make_error_code(boost::system::errc::operation_canceled));
+    };
+    group.spawn(executor, task());
+
+    CHECK_NOTHROW(runner.run(group.wait() || sleep(1ms)));
+}
+
+TEST_CASE("TaskGroup.task_exception_during_cancellation_is_rethrown") {
+    test_util::TaskRunner runner;
+    auto executor = runner.executor();
+    TaskGroup group{executor, 1};
+
+    auto task = [&]() -> Task<void> {
+        bool is_cancelled = false;
+        co_await wait_until_cancelled(&is_cancelled);
+        if (is_cancelled) {
+            throw std::runtime_error("exception_during_cancellation");
+        }
+    };
+    group.spawn(executor, task());
+    group.spawn(executor, async_throw());
+
+    auto test = [&]() -> Task<bool> {
+        try {
+            co_await group.wait();
+            co_return false;
+        } catch (const TestException&) {
+            co_return false;
+        } catch (const std::runtime_error& ex) {
+            co_return (ex.what() == std::string_view{"exception_during_cancellation"});
+        }
+    };
+    CHECK(runner.run(test()));
 }
 
 }  // namespace silkworm::concurrency


### PR DESCRIPTION
Before this if a task didn't have a top level try/catch, it would lead to the io_context exiting.
Now the semantics is similar to awaitable_wait_for_all &&: if one of the tasks throws,
we cancel the other tasks and rethrow the exception to the `wait()` suspension point.
