### PR TITLE
sync: workarounds for difficulty and total difficulty in header chain

### DIFF
--- a/silkworm/sync/internals/header_chain.cpp
+++ b/silkworm/sync/internals/header_chain.cpp
@@ -232,7 +232,7 @@ auto HeaderChain::verify(const Link& link) -> VerificationResult {
     }
 
     bool with_future_timestamp_check = true;
-    auto result = rule_set_->validate_block_header(*link.header, chain_state_, with_future_timestamp_check);
+    const auto result = rule_set_->validate_block_header(*link.header, chain_state_, with_future_timestamp_check);
 
     if (result != ValidationResult::kOk) {
         if (result == ValidationResult::kUnknownParent) {
@@ -559,7 +559,9 @@ auto HeaderChain::find_bad_header(const std::vector<BlockHeader>& headers) -> bo
             log::Warning("HeaderStage") << "received malformed header: " << header.number;
             return true;
         }
-        if (header.difficulty == 0) {
+        // TODO(canepat) IMHO we should remove the following check entirely, alternatively check must be based on TD
+        // Quick-and-dirty validity check based on header difficulty and hard-coded Ethereum PoS merge block
+        if (header.difficulty == 0 and header.number < 15'537'393) {
             log::Warning("HeaderStage") << "received header w/ zero difficulty, block num=" << header.number;
             return true;
         }

--- a/silkworm/sync/internals/header_only_state.cpp
+++ b/silkworm/sync/internals/header_only_state.cpp
@@ -20,12 +20,12 @@ namespace silkworm {
 
 // A Chain_State implementation tied to WorkingChain needs
 
-CustomHeaderOnlyChainState::CustomHeaderOnlyChainState(OldestFirstLinkMap& persistedLinkQueue)
-    : persistedLinkQueue_(persistedLinkQueue) {}
+CustomHeaderOnlyChainState::CustomHeaderOnlyChainState(OldestFirstLinkMap& persisted_link_queue)
+    : persisted_link_queue_{persisted_link_queue} {}
 
 std::optional<BlockHeader> CustomHeaderOnlyChainState::read_header(BlockNum block_number,
                                                                    const evmc::bytes32& hash) const noexcept {
-    auto [initial_link, final_link] = persistedLinkQueue_.equal_range(block_number);
+    auto [initial_link, final_link] = persisted_link_queue_.equal_range(block_number);
 
     for (auto link = initial_link; link != final_link; link++) {
         if (link->second->blockHeight == block_number && link->second->hash == hash) {
@@ -43,8 +43,9 @@ bool CustomHeaderOnlyChainState::read_body(BlockNum, const evmc::bytes32&, Block
 
 std::optional<intx::uint256> CustomHeaderOnlyChainState::total_difficulty(uint64_t,
                                                                           const evmc::bytes32&) const noexcept {
-    // TODO (mriccobene): to implement
-    return {0};
+    // TODO(canepat) replace with proper implementation
+    // Always returning TTD works when using PoS sync and snapshots w/ max block > PoS merge block
+    return intx::from_string<intx::uint256>("58750000000000000000000");
 }
 
 // A better Chain_State implementation

--- a/silkworm/sync/internals/header_only_state.hpp
+++ b/silkworm/sync/internals/header_only_state.hpp
@@ -26,10 +26,10 @@ namespace silkworm {
 // A Chain_State implementation tied to WorkingChain needs
 
 class CustomHeaderOnlyChainState : public BlockState {
-    OldestFirstLinkMap& persistedLinkQueue_;  // not nice
+    OldestFirstLinkMap& persisted_link_queue_;  // not nice
 
   public:
-    CustomHeaderOnlyChainState(OldestFirstLinkMap& persistedLinkQueue);
+    CustomHeaderOnlyChainState(OldestFirstLinkMap& persisted_link_queue);
 
     std::optional<BlockHeader> read_header(uint64_t block_number,
                                            const evmc::bytes32& block_hash) const noexcept override;


### PR DESCRIPTION
Currently there are two issues in `sync` module related to block header difficulty:

- missing implementation of `State::total_difficulty` in header chain state subclass
- wrong check on header difficulty when PoS is activated

This PR does *not* solve such issues, but introduces two workarounds that at least do the job for Ethereum mainnet when using snapshots with max block greater or equal to 16'000'000.