### PR TITLE
Handle unusual call failures to system contracts

### DIFF
--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -342,6 +342,9 @@ ValidationResult validate_requests_root(const BlockHeader& header, const std::ve
         system_txn.data = Bytes{};
         system_txn.set_sender(kSystemAddress);
         const auto withdrawals = evm.execute(system_txn, kSystemCallGasLimit);
+        if (withdrawals.status != EVMC_SUCCESS) {
+            return ValidationResult::kSystemCallFailed;
+        }
         evm.state().destruct_touched_dead();
         requests.add_request(FlatRequestType::kWithdrawalRequest, withdrawals.data);
     }
@@ -354,6 +357,9 @@ ValidationResult validate_requests_root(const BlockHeader& header, const std::ve
         system_txn.data = Bytes{};
         system_txn.set_sender(kSystemAddress);
         const auto consolidations = evm.execute(system_txn, kSystemCallGasLimit);
+        if (consolidations.status != EVMC_SUCCESS) {
+            return ValidationResult::kSystemCallFailed;
+        }
         evm.state().destruct_touched_dead();
         requests.add_request(FlatRequestType::kConsolidationRequest, consolidations.data);
     }

--- a/silkworm/core/protocol/validation.hpp
+++ b/silkworm/core/protocol/validation.hpp
@@ -104,6 +104,9 @@ enum class [[nodiscard]] ValidationResult {
     // EIP-7702 Set EOA account code
     kIncorrectAuthorization,
 
+    // EIP-6110 and EIP-7002 system call failures
+    kSystemCallFailed,
+
     // Bor validation errors. See https://github.com/erigontech/erigon/blob/main/consensus/bor/bor.go
     kMissingVanity,          // Block's extra-data section is shorter than 32 bytes, which is required to store the signer vanity
     kMissingSignature,       // Block's extra-data section doesn't seem to contain a 65 byte secp256k1 signature


### PR DESCRIPTION
Recently EIPs 6110 and 7002 have been extended and failed calls to system contracts should invalidate entire block.