### PR TITLE
Gracefully stop node on shutdown signal

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -1,6 +1,10 @@
 // Copyright 2025 The Silkworm Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <future>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -20,8 +24,6 @@
 #include <silkworm/infra/cli/common.hpp>
 #include <silkworm/infra/cli/shutdown_signal.hpp>
 #include <silkworm/infra/common/log.hpp>
-#include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
-#include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/node/cli/node_options.hpp>
 #include <silkworm/node/node.hpp>
@@ -33,7 +35,6 @@ using namespace silkworm;
 using silkworm::BlockNum;
 using silkworm::DataDirectory;
 using silkworm::human_size;
-using silkworm::cmd::common::ShutdownSignal;
 
 const char* current_exception_name() {
 #ifdef WIN32
@@ -182,11 +183,16 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], node::Se
     settings.sentry_settings.network_id = node_settings.network_id;
 }
 
+Task<void> wait_for_shutdown_signal(node::Node& execution_node, std::atomic_bool& shutdown_requested) {
+    co_await cmd::common::ShutdownSignal::wait();
+    shutdown_requested.store(true, std::memory_order_relaxed);
+    SILK_INFO << "Shutdown signal observed; stopping Silkworm";
+    execution_node.request_stop();
+}
+
 // main
 int main(int argc, char* argv[]) {
     using namespace std::chrono;
-    using namespace silkworm::concurrency::awaitable_wait_for_one;
-    using namespace silkworm::concurrency::awaitable_wait_for_all;
 
     std::set_terminate([]() {
         try {
@@ -218,6 +224,7 @@ int main(int argc, char* argv[]) {
         silkworm::rpc::ClientContextPool context_pool{
             settings.server_settings.context_pool_settings,
         };
+        std::atomic_bool shutdown_requested{false};
 
         silkworm::node::Node execution_node{
             context_pool,
@@ -226,14 +233,46 @@ int main(int argc, char* argv[]) {
 
         // Go!
         auto run_future = boost::asio::co_spawn(
+            context_pool.any_executor(), execution_node.run(), boost::asio::use_future);
+        auto signal_future = boost::asio::co_spawn(
             context_pool.any_executor(),
-            execution_node.run() || ShutdownSignal::wait(),
+            wait_for_shutdown_signal(execution_node, shutdown_requested),
             boost::asio::use_future);
         context_pool.start();
         SILK_INFO << "Silkworm is now running";
 
         // Wait for shutdown signal or an exception from tasks
-        run_future.get();
+        std::exception_ptr run_exception;
+        try {
+            run_future.get();
+        } catch (...) {
+            run_exception = std::current_exception();
+        }
+
+        execution_node.request_stop();
+        context_pool.stop();
+        context_pool.join();
+
+        if (signal_future.wait_for(seconds{0}) == std::future_status::ready) {
+            try {
+                signal_future.get();
+            } catch (const boost::system::system_error& ex) {
+                if (ex.code() != boost::system::errc::operation_canceled) {
+                    throw;
+                }
+            }
+        }
+
+        if (run_exception) {
+            try {
+                std::rethrow_exception(run_exception);
+            } catch (const boost::system::system_error& ex) {
+                if (!shutdown_requested.load(std::memory_order_relaxed) ||
+                    ex.code() != boost::system::errc::operation_canceled) {
+                    throw;
+                }
+            }
+        }
 
         // Graceful exit after user shutdown signal
         SILK_INFO << "Exiting Silkworm";

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -73,6 +73,7 @@ SnapshotSync::SnapshotSync(
 Task<void> SnapshotSync::run() {
     using namespace concurrency::awaitable_wait_for_all;
 
+    stop_requested_.store(false, std::memory_order_relaxed);
     [[maybe_unused]] auto _ = gsl::finally([this]() { this->is_stopping_latch_.count_down(); });
 
     if (!settings_.enabled) {
@@ -95,6 +96,11 @@ Task<void> SnapshotSync::run() {
         }
         throw;
     }
+}
+
+void SnapshotSync::request_stop() {
+    stop_requested_.store(true, std::memory_order_relaxed);
+    client_.stop();
 }
 
 Task<void> SnapshotSync::setup_and_run() {
@@ -137,7 +143,9 @@ Task<void> SnapshotSync::setup() {
 
     // Update chain and stage progresses in database according to available snapshots
     datastore::kvdb::RWTxnManaged rw_txn = data_store_.chaindata.access_rw().start_rw_tx();
-    update_database(rw_txn, blocks_repository().max_timestamp_available(), [this] { return is_stopping_latch_.try_wait(); });
+    update_database(rw_txn, blocks_repository().max_timestamp_available(), [this] {
+        return stop_requested_.load(std::memory_order_relaxed) || is_stopping_latch_.try_wait();
+    });
     rw_txn.commit_and_stop();
 
     if (!settings_.no_seeding) {

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -43,6 +43,7 @@ class SnapshotSync {
         datastore::StageScheduler& stage_scheduler);
 
     Task<void> run();
+    void request_stop();
 
     Task<void> download_snapshots();
     Task<void> wait_for_setup();
@@ -75,6 +76,7 @@ class SnapshotSync {
     db::Freezer snapshot_freezer_;
     datastore::SnapshotMerger snapshot_merger_;
 
+    std::atomic_bool stop_requested_{false};
     std::latch is_stopping_latch_;
     std::atomic_bool setup_done_;
     concurrency::AwaitableConditionVariable setup_done_cond_var_;

--- a/silkworm/execution/api/active_direct_service.hpp
+++ b/silkworm/execution/api/active_direct_service.hpp
@@ -97,9 +97,10 @@ class ActiveDirectService : public DirectService, public ActiveComponent {
 
     Task<BlockNum> block_progress() override;
 
+    bool stop() override;
+
   protected:
     void execution_loop() override;
-    bool stop() override;
 
   private:
     boost::asio::io_context& ioc_;

--- a/silkworm/execution/grpc/server/server.cpp
+++ b/silkworm/execution/grpc/server/server.cpp
@@ -107,4 +107,8 @@ Task<void> Server::async_run(std::optional<size_t> stack_size) {
     return p_impl_->async_run("exec-engine", stack_size);
 }
 
+void Server::shutdown() {
+    p_impl_->shutdown();
+}
+
 }  // namespace silkworm::execution::grpc::server

--- a/silkworm/execution/grpc/server/server.hpp
+++ b/silkworm/execution/grpc/server/server.hpp
@@ -24,6 +24,7 @@ class Server final {
     Server& operator=(const Server&) = delete;
 
     Task<void> async_run(std::optional<size_t> stack_size = {});
+    void shutdown();
 
   private:
     std::unique_ptr<ServerImpl> p_impl_;

--- a/silkworm/infra/concurrency/channel.hpp
+++ b/silkworm/infra/concurrency/channel.hpp
@@ -17,6 +17,11 @@
 
 namespace silkworm::concurrency {
 
+inline bool is_channel_stop_error(const boost::system::error_code& error) {
+    return error == boost::asio::experimental::error::channel_cancelled ||
+           error == boost::asio::experimental::error::channel_closed;
+}
+
 template <typename T>
 class Channel {
   public:
@@ -28,7 +33,7 @@ class Channel {
         try {
             co_await channel_.async_send(boost::system::error_code(), value, boost::asio::use_awaitable);
         } catch (const boost::system::system_error& ex) {
-            if (ex.code() == boost::asio::experimental::error::channel_cancelled) {
+            if (is_channel_stop_error(ex.code())) {
                 throw boost::system::system_error(make_error_code(boost::system::errc::operation_canceled));
             }
             throw;
@@ -43,7 +48,7 @@ class Channel {
         try {
             co_return (co_await channel_.async_receive(boost::asio::use_awaitable));
         } catch (const boost::system::system_error& ex) {
-            if (ex.code() == boost::asio::experimental::error::channel_cancelled) {
+            if (is_channel_stop_error(ex.code())) {
                 throw boost::system::system_error(make_error_code(boost::system::errc::operation_canceled));
             }
             throw;
@@ -53,7 +58,7 @@ class Channel {
     std::optional<T> try_receive() {
         std::optional<T> result;
         channel_.try_receive([&](const boost::system::error_code& error, T&& value) {
-            if (error == boost::asio::experimental::error::channel_cancelled) {
+            if (is_channel_stop_error(error)) {
                 throw boost::system::system_error(make_error_code(boost::system::errc::operation_canceled));
             }
             if (error) {

--- a/silkworm/infra/grpc/server/server.hpp
+++ b/silkworm/infra/grpc/server/server.hpp
@@ -114,7 +114,6 @@ class Server {
         // Order matters here: 1) shutdown the server (immediate deadline)
         if (server_) {
             server_->Shutdown(gpr_time_0(GPR_CLOCK_REALTIME));
-            server_->Wait();
         }
 
         SILK_TRACE << "Server::shutdown " << this << " stopping context pool";
@@ -122,6 +121,10 @@ class Server {
         // Order matters here: 2) shutdown and drain the queues
         if (context_pool_) {
             context_pool_->stop();
+        }
+
+        if (server_) {
+            server_->Wait();
         }
 
         SILK_TRACE << "Server::shutdown " << this << " END";

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -48,6 +48,7 @@ class NodeImpl final {
     Task<void> run();
     Task<void> run_tasks();
     Task<void> wait_for_setup();
+    void request_stop();
 
     BlockNum last_pre_validated_block() const { return chain_sync_.last_pre_validated_block(); }
 
@@ -212,7 +213,7 @@ NodeImpl::NodeImpl(
           /* use_preverified_hashes = */ true,
           make_sync_engine_rpc_settings(settings.rpcdaemon_settings, settings.log_settings.log_verbosity),
       },
-      resource_usage_log_{*settings_.node_settings.data_directory} {
+      resource_usage_log_{context_pool.any_executor(), *settings_.node_settings.data_directory} {
     backend_ = std::make_unique<EthereumBackEnd>(settings_.node_settings, data_store_.chaindata().access_ro(), std::get<0>(sentry_));
     backend_->set_node_name(settings_.node_settings.build_info.node_name);
     backend_kv_rpc_server_ = std::make_unique<BackEndKvServer>(settings_.server_settings, *backend_);
@@ -241,6 +242,21 @@ Task<void> NodeImpl::run() {
     }
 }
 
+void NodeImpl::request_stop() {
+    snapshot_sync_.request_stop();
+    chain_sync_.request_stop();
+    resource_usage_log_.stop();
+    execution_service_->stop();
+    execution_engine_.stop();
+    execution_server_.shutdown();
+    if (backend_kv_rpc_server_) {
+        backend_kv_rpc_server_->shutdown();
+    }
+    if (auto& sentry_server = std::get<1>(sentry_)) {
+        sentry_server->request_stop();
+    }
+}
+
 Task<void> NodeImpl::run_tasks() {
     using namespace concurrency::awaitable_wait_for_all;
 
@@ -256,7 +272,7 @@ Task<void> NodeImpl::run_tasks() {
 
 Task<void> NodeImpl::run_execution_service() {
     // Thread running block execution requires custom stack size because of deep EVM call stacks
-    return execution_service_->async_run("exec-engine", /* stack_size = */ kExecutionThreadStackSize);
+    co_await execution_service_->async_run("exec-engine", /* stack_size = */ kExecutionThreadStackSize);
 }
 
 Task<void> NodeImpl::run_execution_server() {
@@ -306,6 +322,10 @@ Task<void> Node::run() {
 
 Task<void> Node::wait_for_setup() {
     return p_impl_->wait_for_setup();
+}
+
+void Node::request_stop() {
+    p_impl_->request_stop();
 }
 
 }  // namespace silkworm::node

--- a/silkworm/node/node.hpp
+++ b/silkworm/node/node.hpp
@@ -29,6 +29,7 @@ class Node {
 
     Task<void> run();
     Task<void> wait_for_setup();
+    void request_stop();
 
   private:
     std::unique_ptr<NodeImpl> p_impl_;

--- a/silkworm/node/resource_usage.cpp
+++ b/silkworm/node/resource_usage.cpp
@@ -14,6 +14,7 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/mem_usage.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>
+#include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 
 namespace silkworm::node {
 
@@ -23,14 +24,20 @@ using std::chrono::steady_clock;
 static constexpr std::chrono::seconds kResourceUsageInterval{300s};
 
 Task<void> ResourceUsageLog::run() {
+    using namespace concurrency::awaitable_wait_for_one;
+
     auto executor = co_await boost::asio::this_coro::executor;
     boost::asio::steady_timer timer{executor};
 
     const auto start_time = steady_clock::now();
-    while (true) {
+    stop_requested_.store(false, std::memory_order_relaxed);
+    while (!stop_requested_.load(std::memory_order_relaxed)) {
         try {
             timer.expires_after(kResourceUsageInterval);
-            co_await timer.async_wait(boost::asio::use_awaitable);
+            co_await (timer.async_wait(boost::asio::use_awaitable) || stop_notifier_.wait());
+            if (stop_requested_.load(std::memory_order_relaxed)) {
+                co_return;
+            }
 
             log::Info("Resource usage", {"mem", human_size(os::get_mem_usage()),
                                          "chain", human_size(data_directory_.chaindata().size()),
@@ -42,6 +49,11 @@ Task<void> ResourceUsageLog::run() {
             }
         }
     }
+}
+
+void ResourceUsageLog::stop() {
+    stop_requested_.store(true, std::memory_order_relaxed);
+    stop_notifier_.notify();
 }
 
 }  // namespace silkworm::node

--- a/silkworm/node/resource_usage.hpp
+++ b/silkworm/node/resource_usage.hpp
@@ -3,21 +3,29 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <boost/asio/any_io_executor.hpp>
+
 #include <silkworm/infra/common/directories.hpp>
+#include <silkworm/infra/concurrency/event_notifier.hpp>
 
 namespace silkworm::node {
 
 //! Log for resource usage
 class ResourceUsageLog {
   public:
-    explicit ResourceUsageLog(const DataDirectory& data_directory)
-        : data_directory_(data_directory) {}
+    explicit ResourceUsageLog(const boost::asio::any_io_executor& executor, const DataDirectory& data_directory)
+        : stop_notifier_(executor), data_directory_(data_directory) {}
 
     Task<void> run();
+    void stop();
 
   private:
+    std::atomic_bool stop_requested_{false};
+    concurrency::EventNotifier stop_notifier_;
     const DataDirectory& data_directory_;
 };
 

--- a/silkworm/node/stagedsync/execution_engine.cpp
+++ b/silkworm/node/stagedsync/execution_engine.cpp
@@ -50,6 +50,12 @@ void ExecutionEngine::close() {
     context_pool_.reset();
 }
 
+bool ExecutionEngine::stop() {
+    const bool engine_stopped = Stoppable::stop();
+    const bool main_chain_stopped = main_chain_.stop();
+    return engine_stopped || main_chain_stopped;
+}
+
 BlockNum ExecutionEngine::block_progress() const {
     return block_progress_;  // main_chain_.get_block_progress() or forks block progress
 }

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -56,6 +56,7 @@ class ExecutionEngine : public execution::api::ExecutionEngine, public Stoppable
     // needed to circumvent mdbx threading model limitations
     void open() override;
     void close() override;
+    bool stop() override;
 
     // actions
     void insert_blocks(const std::vector<std::shared_ptr<Block>>& blocks) override;

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -88,10 +88,10 @@ std::optional<Hash> ExecutionPipeline::bad_block() {
 }
 
 bool ExecutionPipeline::stop() {
-    bool stopped{true};
+    bool stopped{Stoppable::stop()};
     for (const auto& [_, stage] : stages_) {
         if (!stage->is_stopping()) {
-            stopped &= stage->stop();
+            stopped = stage->stop() || stopped;
         }
     }
     return stopped;

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -129,6 +129,10 @@ void MainChain::abort() {
     tx_.abort();
 }
 
+bool MainChain::stop() {
+    return pipeline_.stop();
+}
+
 NodeSettings& MainChain::node_settings() {
     return node_settings_;
 }

--- a/silkworm/node/stagedsync/forks/main_chain.hpp
+++ b/silkworm/node/stagedsync/forks/main_chain.hpp
@@ -42,6 +42,7 @@ class MainChain {
     void open();  // needed to circumvent mdbx threading model limitations
     void close();
     void abort();
+    bool stop();
 
     // extension
     void insert_block(const Block&);

--- a/silkworm/sentry/discovery/disc_v4/discovery.cpp
+++ b/silkworm/sentry/discovery/disc_v4/discovery.cpp
@@ -70,6 +70,12 @@ class DiscoveryImpl : private MessageHandler {
         discover_more_needed_notifier_.notify();
     }
 
+    void stop() {
+        server_.stop();
+        discover_more_needed_notifier_.notify();
+        discovered_event_notifier_.notify();
+    }
+
   private:
     uint64_t local_enr_seq_num() const {
         return this->node_record_().seq_num;
@@ -248,6 +254,10 @@ Task<void> Discovery::run() {
 
 void Discovery::discover_more_needed() {
     p_impl_->discover_more_needed();
+}
+
+void Discovery::stop() {
+    p_impl_->stop();
 }
 
 }  // namespace silkworm::sentry::discovery::disc_v4

--- a/silkworm/sentry/discovery/disc_v4/discovery.hpp
+++ b/silkworm/sentry/discovery/disc_v4/discovery.hpp
@@ -34,6 +34,7 @@ class Discovery {
     Discovery& operator=(const Discovery&) = delete;
 
     Task<void> run();
+    void stop();
 
     void discover_more_needed();
 

--- a/silkworm/sentry/discovery/disc_v4/server.cpp
+++ b/silkworm/sentry/discovery/disc_v4/server.cpp
@@ -132,6 +132,14 @@ class ServerImpl {
         }
     }
 
+    void stop() {
+        boost::asio::dispatch(socket_.get_executor(), [this] {
+            boost::system::error_code error;
+            socket_.cancel(error);
+            socket_.close(error);
+        });
+    }
+
     template <class TMessage>
     Task<void> send_message(const TMessage& message, ip::udp::endpoint recipient) {
         return send_message(Message{TMessage::kId, message.rlp_encode()}, std::move(recipient));
@@ -189,6 +197,10 @@ void Server::setup() {
 
 Task<void> Server::run() {
     return p_impl_->run();
+}
+
+void Server::stop() {
+    p_impl_->stop();
 }
 
 Task<void> Server::send_ping(ping::PingMessage message, ip::udp::endpoint recipient) {

--- a/silkworm/sentry/discovery/disc_v4/server.hpp
+++ b/silkworm/sentry/discovery/disc_v4/server.hpp
@@ -33,6 +33,7 @@ class Server : public MessageSender {
 
     void setup();
     Task<void> run();
+    void stop();
 
     Task<void> send_ping(ping::PingMessage message, boost::asio::ip::udp::endpoint recipient) override;
     Task<void> send_pong(ping::PongMessage message, boost::asio::ip::udp::endpoint recipient) override;

--- a/silkworm/sentry/discovery/discovery.cpp
+++ b/silkworm/sentry/discovery/discovery.cpp
@@ -37,6 +37,7 @@ class DiscoveryImpl {
     DiscoveryImpl& operator=(const DiscoveryImpl&) = delete;
 
     Task<void> run();
+    void stop();
 
     Task<std::vector<Discovery::PeerCandidate>> request_peer_candidates(
         size_t max_count,
@@ -127,6 +128,10 @@ Task<void> DiscoveryImpl::run() {
     if (with_dynamic_discovery_) {
         co_await disc_v4_discovery_.run();
     }
+}
+
+void DiscoveryImpl::stop() {
+    disc_v4_discovery_.stop();
 }
 
 void DiscoveryImpl::setup_node_db() {
@@ -235,6 +240,10 @@ Task<void> Discovery::run() {
         }
         throw se;
     }
+}
+
+void Discovery::stop() {
+    p_impl_->stop();
 }
 
 Task<std::vector<Discovery::PeerCandidate>> Discovery::request_peer_candidates(

--- a/silkworm/sentry/discovery/discovery.hpp
+++ b/silkworm/sentry/discovery/discovery.hpp
@@ -41,6 +41,7 @@ class Discovery {
     Discovery& operator=(const Discovery&) = delete;
 
     Task<void> run();
+    void stop();
 
     struct PeerCandidate {
         EnodeUrl url;

--- a/silkworm/sentry/grpc/server/server.cpp
+++ b/silkworm/sentry/grpc/server/server.cpp
@@ -111,4 +111,8 @@ Task<void> Server::async_run() {
     return p_impl_->async_run("sentry-gsrv");
 }
 
+void Server::shutdown() {
+    p_impl_->shutdown();
+}
+
 }  // namespace silkworm::sentry::grpc::server

--- a/silkworm/sentry/grpc/server/server.hpp
+++ b/silkworm/sentry/grpc/server/server.hpp
@@ -25,6 +25,7 @@ class Server final {
     Server& operator=(const Server&) = delete;
 
     Task<void> async_run();
+    void shutdown();
 
   private:
     std::unique_ptr<ServerImpl> p_impl_;

--- a/silkworm/sentry/message_receiver.cpp
+++ b/silkworm/sentry/message_receiver.cpp
@@ -40,6 +40,13 @@ Task<void> MessageReceiver::run(std::shared_ptr<MessageReceiver> self, PeerManag
     }
 }
 
+void MessageReceiver::stop() {
+    message_calls_channel_.close();
+    for (auto& subscription : subscriptions_) {
+        subscription.messages_channel->close();
+    }
+}
+
 Task<void> MessageReceiver::handle_calls() {
     auto executor = co_await this_coro::executor;
 

--- a/silkworm/sentry/message_receiver.hpp
+++ b/silkworm/sentry/message_receiver.hpp
@@ -38,6 +38,7 @@ class MessageReceiver : public PeerManagerObserver {
     }
 
     static Task<void> run(std::shared_ptr<MessageReceiver> self, PeerManager& peer_manager);
+    void stop();
 
   private:
     Task<void> handle_calls();

--- a/silkworm/sentry/message_sender.hpp
+++ b/silkworm/sentry/message_sender.hpp
@@ -24,6 +24,7 @@ class MessageSender {
     }
 
     Task<void> run(PeerManager& peer_manager);
+    void stop() { send_message_channel_.close(); }
 
   private:
     concurrency::Channel<api::router::SendMessageCall> send_message_channel_;

--- a/silkworm/sentry/peer_discovery_feedback.hpp
+++ b/silkworm/sentry/peer_discovery_feedback.hpp
@@ -28,6 +28,7 @@ class PeerDiscoveryFeedback : public PeerManagerObserver {
         std::shared_ptr<PeerDiscoveryFeedback> self,
         PeerManager& peer_manager,
         discovery::Discovery& discovery);
+    void stop() { peer_disconnected_events_.close(); }
 
   private:
     // PeerManagerObserver

--- a/silkworm/sentry/peer_manager.cpp
+++ b/silkworm/sentry/peer_manager.cpp
@@ -152,6 +152,17 @@ void PeerManager::add_observer(std::weak_ptr<PeerManagerObserver> observer) {
     observers_.push_back(std::move(observer));
 }
 
+void PeerManager::stop() {
+    client_peer_channel_.close();
+    need_peers_notifier_.notify();
+    for (auto& peer : peers_) {
+        peer->disconnect(rlpx::DisconnectReason::kDisconnectRequested);
+    }
+    for (auto& peer : handshaking_peers_) {
+        peer->disconnect(rlpx::DisconnectReason::kDisconnectRequested);
+    }
+}
+
 std::list<std::shared_ptr<PeerManagerObserver>> PeerManager::observers() {
     std::scoped_lock lock(observers_mutex_);
     std::list<std::shared_ptr<PeerManagerObserver>> observers;

--- a/silkworm/sentry/peer_manager.hpp
+++ b/silkworm/sentry/peer_manager.hpp
@@ -60,6 +60,7 @@ class PeerManager {
     Task<void> enumerate_random_peers(size_t max_count, EnumeratePeersCallback callback);
 
     void add_observer(std::weak_ptr<PeerManagerObserver> observer);
+    void stop();
 
   private:
     Task<void> run_in_strand(concurrency::Channel<std::shared_ptr<rlpx::Peer>>& peer_channel);

--- a/silkworm/sentry/peer_manager_api.cpp
+++ b/silkworm/sentry/peer_manager_api.cpp
@@ -37,6 +37,18 @@ Task<void> PeerManagerApi::run(std::shared_ptr<PeerManagerApi> self) {
     co_await concurrency::spawn_task(self->strand_, std::move(run));
 }
 
+void PeerManagerApi::stop() {
+    peer_count_calls_channel_.close();
+    peers_calls_channel_.close();
+    peer_calls_channel_.close();
+    peer_penalize_calls_channel_.close();
+    peer_events_calls_channel_.close();
+    peer_events_channel_.close();
+    for (auto& subscription : events_subscriptions_) {
+        subscription.events_channel->close();
+    }
+}
+
 Task<void> PeerManagerApi::handle_peer_count_calls() {
     // loop until receive() throws a cancelled exception
     while (true) {

--- a/silkworm/sentry/peer_manager_api.hpp
+++ b/silkworm/sentry/peer_manager_api.hpp
@@ -44,6 +44,7 @@ class PeerManagerApi : public PeerManagerObserver {
           peer_events_channel_(executor, 1000) {}
 
     static Task<void> run(std::shared_ptr<PeerManagerApi> self);
+    void stop();
 
     template <typename T>
     using Channel = concurrency::Channel<T>;

--- a/silkworm/sentry/rlpx/server.cpp
+++ b/silkworm/sentry/rlpx/server.cpp
@@ -65,6 +65,11 @@ Task<void> Server::run(
         try {
             co_await acceptor.async_accept(stream.socket(), use_awaitable);
         } catch (const boost::system::system_error& ex) {
+            if (ex.code() == error::operation_aborted ||
+                ex.code() == boost::system::errc::operation_canceled) {
+                SILK_DEBUG_M("sentry") << "Sentry RLPx server accept cancelled";
+                throw;
+            }
             if (ex.code() == boost::system::errc::invalid_argument) {
                 SILK_ERROR_M("sentry") << "Sentry RLPx server got invalid_argument on accept port=" << port_;
                 continue;

--- a/silkworm/sentry/rlpx/server.hpp
+++ b/silkworm/sentry/rlpx/server.hpp
@@ -32,6 +32,7 @@ class Server final {
         EccKeyPair node_key,
         std::string client_id,
         std::function<std::unique_ptr<Protocol>()> protocol_factory);
+    void stop() { peer_channel_.close(); }
 
     const boost::asio::ip::address& ip() const { return ip_; }
     boost::asio::ip::tcp::endpoint listen_endpoint() const;

--- a/silkworm/sentry/sentry.cpp
+++ b/silkworm/sentry/sentry.cpp
@@ -49,6 +49,7 @@ class SentryImpl final {
     SentryImpl& operator=(const SentryImpl&) = delete;
 
     Task<void> run();
+    void request_stop();
 
     std::shared_ptr<api::Service> service() { return direct_service_; }
 
@@ -172,6 +173,18 @@ Task<void> SentryImpl::run() {
     }
 }
 
+void SentryImpl::request_stop() {
+    status_manager_.stop();
+    rlpx_server_.stop();
+    discovery_.stop();
+    peer_manager_.stop();
+    message_sender_.stop();
+    message_receiver_->stop();
+    peer_manager_api_->stop();
+    peer_discovery_feedback_->stop();
+    grpc_server_.shutdown();
+}
+
 void SentryImpl::setup_node_key() {
     DataDirectory data_dir{settings_.data_dir_path, true};
     NodeKey node_key = node_key_get_or_generate(settings_.node_key, data_dir);
@@ -214,11 +227,11 @@ std::function<std::unique_ptr<rlpx::Protocol>()> SentryImpl::protocol_factory() 
 }
 
 Task<void> SentryImpl::run_status_manager() {
-    return status_manager_.run();
+    co_await status_manager_.run();
 }
 
 Task<void> SentryImpl::run_server() {
-    return rlpx_server_.run(executor_pool_, node_key_.value(), client_id(), protocol_factory());
+    co_await rlpx_server_.run(executor_pool_, node_key_.value(), client_id(), protocol_factory());
 }
 
 std::unique_ptr<rlpx::Client> SentryImpl::make_client() {
@@ -235,12 +248,12 @@ std::function<std::unique_ptr<rlpx::Client>()> SentryImpl::client_factory() {
 }
 
 Task<void> SentryImpl::run_discovery() {
-    return discovery_.run();
+    co_await discovery_.run();
 }
 
 Task<void> SentryImpl::run_peer_manager() {
     try {
-        return peer_manager_.run(rlpx_server_, discovery_, make_protocol(), client_factory());
+        co_await peer_manager_.run(rlpx_server_, discovery_, make_protocol(), client_factory());
     } catch (const boost::system::system_error& se) {
         if (se.code() == boost::system::errc::operation_canceled) {
             SILK_DEBUG_M("sentry") << "run_peer_manager unexpected end [operation_canceled]";
@@ -253,7 +266,7 @@ Task<void> SentryImpl::run_peer_manager() {
 
 Task<void> SentryImpl::run_message_sender() {
     try {
-        return message_sender_.run(peer_manager_);
+        co_await message_sender_.run(peer_manager_);
     } catch (const boost::system::system_error& se) {
         if (se.code() == boost::system::errc::operation_canceled) {
             SILK_DEBUG_M("sentry") << "run_message_sender unexpected end [operation_canceled]";
@@ -266,7 +279,7 @@ Task<void> SentryImpl::run_message_sender() {
 
 Task<void> SentryImpl::run_message_receiver() {
     try {
-        return MessageReceiver::run(message_receiver_, peer_manager_);
+        co_await MessageReceiver::run(message_receiver_, peer_manager_);
     } catch (const boost::system::system_error& se) {
         if (se.code() == boost::system::errc::operation_canceled) {
             SILK_DEBUG_M("sentry") << "run_message_receiver unexpected end [operation_canceled]";
@@ -279,7 +292,7 @@ Task<void> SentryImpl::run_message_receiver() {
 
 Task<void> SentryImpl::run_peer_manager_api() {
     try {
-        return PeerManagerApi::run(peer_manager_api_);
+        co_await PeerManagerApi::run(peer_manager_api_);
     } catch (const boost::system::system_error& se) {
         if (se.code() == boost::system::errc::operation_canceled) {
             SILK_DEBUG_M("sentry") << "run_peer_manager_api unexpected end [operation_canceled]";
@@ -292,7 +305,7 @@ Task<void> SentryImpl::run_peer_manager_api() {
 
 Task<void> SentryImpl::run_peer_discovery_feedback() {
     try {
-        return PeerDiscoveryFeedback::run(peer_discovery_feedback_, peer_manager_, discovery_);
+        co_await PeerDiscoveryFeedback::run(peer_discovery_feedback_, peer_manager_, discovery_);
     } catch (const boost::system::system_error& se) {
         if (se.code() == boost::system::errc::operation_canceled) {
             SILK_DEBUG_M("sentry") << "run_peer_discovery_feedback unexpected end [operation_canceled]";
@@ -386,6 +399,10 @@ Sentry::~Sentry() {
 
 Task<void> Sentry::run() {
     return p_impl_->run();
+}
+
+void Sentry::request_stop() {
+    p_impl_->request_stop();
 }
 
 Task<std::shared_ptr<api::Service>> Sentry::service() {

--- a/silkworm/sentry/sentry.hpp
+++ b/silkworm/sentry/sentry.hpp
@@ -28,6 +28,7 @@ class Sentry final : public api::SentryClient {
     Sentry& operator=(const Sentry&) = delete;
 
     Task<void> run();
+    void request_stop();
 
     Task<std::shared_ptr<api::Service>> service() override;
     bool is_ready() override;

--- a/silkworm/sentry/status_manager.hpp
+++ b/silkworm/sentry/status_manager.hpp
@@ -23,6 +23,7 @@ class StatusManager {
     Task<void> wait_for_status();
 
     Task<void> run();
+    void stop() { status_channel_.close(); }
 
     concurrency::Channel<eth::StatusData>& status_channel() {
         return status_channel_;

--- a/silkworm/sync/chain_sync.hpp
+++ b/silkworm/sync/chain_sync.hpp
@@ -20,6 +20,7 @@ class ChainSync {
     ChainSync& operator=(const ChainSync&) = delete;
 
     virtual Task<void> async_run() = 0;
+    virtual void request_stop() { block_exchange_.stop_downloading(); }
 
   protected:
     IBlockExchange& block_exchange_;

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -59,7 +59,15 @@ BlockNum Sync::last_pre_validated_block() const {
 
 Task<void> Sync::async_run() {
     using namespace concurrency::awaitable_wait_for_all;
-    return (run_tasks() && start_engine_rpc_server());
+    co_await (run_tasks() && start_engine_rpc_server());
+}
+
+void Sync::request_stop() {
+    block_exchange_.stop_downloading();
+    block_exchange_.stop();
+    if (chain_sync_) {
+        chain_sync_->request_stop();
+    }
 }
 
 Task<void> Sync::run_tasks() {
@@ -68,22 +76,23 @@ Task<void> Sync::run_tasks() {
 }
 
 Task<void> Sync::start_sync_sentry_client() {
-    return sync_sentry_client_.async_run();
+    co_await sync_sentry_client_.async_run();
 }
 
 Task<void> Sync::start_block_exchange() {
-    return block_exchange_.async_run("block-exchg");
+    co_await block_exchange_.async_run("block-exchg");
 }
 
 Task<void> Sync::start_chain_sync() {
     if (!engine_rpc_server_) {
-        return chain_sync_->async_run();
+        co_await chain_sync_->async_run();
+        co_return;
     }
 
     // The ChainSync async loop *must* run onto the Engine RPC server unique execution context
     // This is *strictly* required by the current design assumptions in PoSSync
     auto& ioc = engine_rpc_server_->context_pool().next_ioc();
-    return boost::asio::co_spawn(ioc, chain_sync_->async_run(), boost::asio::use_awaitable);
+    co_await boost::asio::co_spawn(ioc, chain_sync_->async_run(), boost::asio::use_awaitable);
 }
 
 Task<void> Sync::start_engine_rpc_server() {

--- a/silkworm/sync/sync.hpp
+++ b/silkworm/sync/sync.hpp
@@ -38,6 +38,7 @@ class Sync {
     Sync& operator=(const Sync&) = delete;
 
     Task<void> async_run();
+    void request_stop();
 
     BlockNum last_pre_validated_block() const;
 

--- a/silkworm/sync/sync_pos.cpp
+++ b/silkworm/sync/sync_pos.cpp
@@ -37,7 +37,13 @@ PoSSync::PoSSync(IBlockExchange& block_exchange, execution::api::Client& exec_cl
     : ChainSync(block_exchange, exec_client) {}
 
 Task<void> PoSSync::async_run() {
+    stop_requested_.store(false, std::memory_order_relaxed);
     co_await download_blocks();
+}
+
+void PoSSync::request_stop() {
+    stop_requested_.store(true, std::memory_order_relaxed);
+    block_exchange_.stop_downloading();
 }
 
 // Wait for blocks arrival from BlockExchange and insert them into ExecutionEngine
@@ -71,7 +77,7 @@ Task<void> PoSSync::download_blocks() {
 
     // main loop
     try {
-        while (true) {
+        while (!stop_requested_.load(std::memory_order_relaxed)) {
             Blocks blocks;
 
             // wait for a batch of blocks

--- a/silkworm/sync/sync_pos.hpp
+++ b/silkworm/sync/sync_pos.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <silkworm/infra/common/log.hpp>
@@ -22,6 +24,7 @@ class PoSSync : public ChainSync, public rpc::engine::ExecutionEngine {
     PoSSync(IBlockExchange&, execution::api::Client&);
 
     Task<void> async_run() override;
+    void request_stop() override;
 
     // public interface to download blocks
     Task<void> download_blocks(); /*[[long_running]]*/
@@ -38,6 +41,7 @@ class PoSSync : public ChainSync, public rpc::engine::ExecutionEngine {
     std::tuple<bool, Hash> has_valid_ancestor(const Hash& block_hash);
 
     size_t active_chain_validations_{0};
+    std::atomic_bool stop_requested_{false};
 };
 
 }  // namespace silkworm::chainsync

--- a/silkworm/sync/sync_pow.cpp
+++ b/silkworm/sync/sync_pow.cpp
@@ -23,6 +23,11 @@ Task<void> PoWSync::async_run() {
     return ActiveComponent::async_run("pow-sync-ex");
 }
 
+void PoWSync::request_stop() {
+    block_exchange_.stop_downloading();
+    stop();
+}
+
 BlockId PoWSync::resume() {  // find the point (head) where we left off
     BlockId head{};
 

--- a/silkworm/sync/sync_pow.hpp
+++ b/silkworm/sync/sync_pow.hpp
@@ -23,6 +23,7 @@ class PoWSync : public ChainSync, ActiveComponent {
     PoWSync(IBlockExchange&, execution::api::Client&);
 
     Task<void> async_run() override;
+    void request_stop() override;
 
     void execution_loop() final; /*[[long_running]]*/
 


### PR DESCRIPTION
## Summary
- run the node task and shutdown-signal waiter independently so SIGINT requests an orderly stop
- propagate request_stop through snapshot sync, chain sync, sentry, gRPC servers, resource usage logging, and staged execution
- treat expected channel/server cancellation paths as graceful shutdown instead of fatal errors

## Verification
- git diff --check
- built silkworm successfully on the integration branch before splitting this standalone PR branch

Opened as draft while we run a clean upstream-base build.